### PR TITLE
03 localisation and Nullification

### DIFF
--- a/src/Everything.agda
+++ b/src/Everything.agda
@@ -3,6 +3,8 @@ open import axioms.FreeAlgInj
 open import core.Arrow
 open import core.ArrowEquiv
 open import core.CanonicalPushouts
+open import core.CoSlice
+open import core.Codiagonal
 open import core.Join
 open import core.Lifts
 open import core.Orthogonal

--- a/src/Everything.agda
+++ b/src/Everything.agda
@@ -1,11 +1,11 @@
 module Everything where
+open import axioms.FreeAlgInj
 open import core.Arrow
 open import core.ArrowEquiv
 open import core.CanonicalPushouts
 open import core.Join
 open import core.Lifts
 open import core.Orthogonal
-open import core.PullbackPath
 open import core.PullbackPower
 open import core.Slice
 open import core.Spheres
@@ -46,7 +46,9 @@ open import foundations.FunextUnivalence
 open import foundations.Homotopy
 open import foundations.Identity
 open import foundations.Nat
+open import foundations.PathSplit
 open import foundations.PropMapEmbedding
+open import foundations.PullbackPath
 open import foundations.Pullbacks
 open import foundations.Pushout
 open import foundations.QuasiIsomorphism

--- a/src/Everything.agda
+++ b/src/Everything.agda
@@ -69,6 +69,7 @@ open import modalities.Flat.Flat
 open import modalities.HigherModality
 open import modalities.ModalMaps
 open import modalities.Subuniverses
+open import modalities.instances.Localisation
 open import modalities.instances.OpenModalities
 open import ergonomics.Builtins
 open import ergonomics.Extensionality

--- a/src/axioms/FreeAlgInj.lagda.tree
+++ b/src/axioms/FreeAlgInj.lagda.tree
@@ -1,0 +1,276 @@
+\date{2025-06-17}
+\title{The Free Algabraicly Injective HIT}
+\taxon{module}
+\meta{module}{\startverb axioms.FreeAlgInj \stopverb}
+\author{samueltoth}
+\import{stt-macros}
+
+%```agda
+\agda{
+{-# OPTIONS --allow-unsolved-metas #-}
+module axioms.FreeAlgInj where
+
+open import ufAxioms
+open import foundations.Prelude
+open import core.Arrow
+open import core.Lifts
+open import core.PullbackPower
+}
+%```
+
+\subtree[stt-0060]{
+\taxon{remark}
+
+\p{The condition of [orthogonality](stt-0048) says that lifting
+problems as above have unique solutions. Algabraic injectivity
+is a weakening of this to only require that a chosen solution.}
+}
+
+\subtree[stt-005L]{
+\taxon{definition}
+\title{Weak orthogonators of maps}
+
+\p{[Orthogonal maps](stt-004A) require uniqueness of
+lifting solution. When this uniqueness requirement is lifted
+we can speak of the type of weak-orthogonators for a pair of
+maps, which give a chosen lift for each lifting problem.
+When this type is merely inhabited we say that a pair of maps
+are weakly orthogonal.}
+
+%```agda
+\agda{
+weak-orthogonator : ∀ {𝓤 𝓥 𝓦 𝓛} {A : Type 𝓤} {B : Type 𝓥}
+                          {C : Type 𝓦} {D : Type 𝓛}
+                        → (f : A → B)
+                        → (g : C → D)
+                        → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓛)
+weak-orthogonator f g = ∀ (H : Arrow-map f g) → Lift H
+}
+%```
+}
+
+
+\subtree[stt-005N]{
+\taxon{theorem}
+\title{Weakly orthogonal maps give a section of the pullback power}
+
+\p{A map #{f} is weakly orthogonal to #{g} iff the [pullback power](stt-004D)
+ #{f \pitchfork g} has a section.}
+
+%```agda
+\agda{
+sec-pb-power←weak-orthogonator
+  : ∀ {𝓤 𝓥 𝓦 𝓛} {A : Type 𝓤} {B : Type 𝓥}
+      {C : Type 𝓦} {D : Type 𝓛}
+      {f : A → B} {g : C → D}
+    → weak-orthogonator f g
+    → section (pullback-power f g)
+sec-pb-power←weak-orthogonator {f = f} {g} lift
+  = section←fibres _ fib where
+  fib : ∀ (H : Arrow-map f g) → fibre (pullback-power f g) H
+  fib H =  _≃_.bwd (pb-power-fibre≃lifts _ _ _) (lift H)
+
+sec-pb-power≃weak-orthogonator
+  : ∀ {𝓤 𝓥 𝓦 𝓛} {A : Type 𝓤} {B : Type 𝓥}
+      {C : Type 𝓦} {D : Type 𝓛}
+      {f : A → B} {g : C → D}
+    → weak-orthogonator f g
+    ≃ section (pullback-power f g)
+sec-pb-power≃weak-orthogonator {f = f}{g}
+  = Π (Arrow-map f g) Lift
+      ≃⟨ precomp-Π-≃ (λ c → pb-power-fibre≃lifts _ _ c e⁻¹) ⟩
+    Π (Arrow-map f g) (fibre (pullback-power f g))
+      ≃⟨ section≃fibres _ ⟩
+    section (pullback-power f g) ≃∎
+}
+%```
+}
+
+\subtree[stt-005O]{
+\title{Weak orthogonators for types}
+\taxon{definition}
+
+\p{A weak orthogonator for a type mirrors the definitions
+for the stronger notion of [orthogonality at types](stt-004O).
+We require not that the precomposition by #{f} is an equivalence,
+but instead talk about the \em{type} of sections to postcomposition by #{f}.
+}
+
+\p{A weak orthogonator for type #{X} with respect to a map #{f : A \to B}
+is a section of #{X^f : (B \to X) \to (A \to X)}.}
+
+%```agda
+\agda{
+weak-type-orthogonator
+  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+      (f : A → B) (X : Type 𝓦)
+    → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦)
+weak-type-orthogonator f X = section (postcomp X f)
+}
+%```
+}
+
+\subtree[stt-005P]{
+\taxon{theorem}
+
+\p{Mirroring the [corresponding theorem](stt-004Q) for orthogonality,
+we can say that the type of weak type orthogonators for #{X} against #{f}
+is equivalent to the type of weak orthoginators for the map #{! : A \to 1}
+against #{f}.}
+
+
+%```agda
+\agda{
+weak-type-orthogonator-!
+  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+      {f : A → B} {X : Type 𝓦}
+    → weak-type-orthogonator f X
+    ≃ weak-orthogonator f (! {A = X})
+weak-type-orthogonator-! = {!!}
+}
+%```
+}
+
+
+\subtree[stt-005J]{
+\taxon{definition}
+\title{Algabraicly injective types}
+
+\p{Given a family of maps #{f_i : A_i \to B_i}, we say that a type
+#{X} is \em{algabraicly} #{f\rm{-injective}} if for any family of maps
+#{a_i : A_i \to X}, there is a chosen extension of #{a} along #{f_i}, that
+is, the following diagram commutes for all #{i}: }
+
+\quiver{
+\begin{tikzcd}
+	{A_i} && X \\
+	\\
+	{B_i}
+	\arrow["{a_i}", from=1-1, to=1-3]
+	\arrow["{f_i}"', from=1-1, to=3-1]
+	\arrow[dashed, from=3-1, to=1-3]
+\end{tikzcd}
+}
+
+\p{We observe that this definition is equivalent to asking for
+a chosen [weak orthogonator](stt-005O) for #{X} against each #{f_i}.}
+
+%```agda
+\agda{
+algabraic-injector
+  : ∀ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘}
+      {A : I → Type 𝓤} {B : I → Type 𝓥}
+      (f : (i : I) → A i → B i)
+      (X : Type 𝓦)
+     → Type (𝓘 ⊔ 𝓤 ⊔ 𝓥 ⊔ 𝓦)
+algabraic-injector f X = ∀ i → weak-type-orthogonator (f i) X
+}
+%```
+}
+
+\subtree[stt-005I]{
+\taxon{definition}
+\title{Free algabraicly-injective types}
+\citek{rijkeMod2020}
+
+\p{Given a family of types #{f_i : A_i \to B_i} and a type #{X}, we can
+define the free algabraicly #{f\rm{-injective}} type on #{X}, called
+#{\mathcal{J}_{f}(X)} with the following
+higher inductive type:}
+
+\ul{
+\li{#{\eta : X \to \mathcal{J}_{f}(X)}}
+\li{#{\rm{ext}_i : (A_i \to \mathcal{J}_{f}(X)) \to (B_i \to \mathcal{J}_{f}(X))}}
+\li{#{\rm{isext}_i : \Pi_{(g : A_i \to \mathcal{J}_{f}(X))} \Pi_{(a : A_i)}
+                     \rm{ext}_i(g,f(a)) = g(a)}}
+}
+
+\p{In plain agda we have to define higher inductive types via
+postulates.}
+
+%```agda
+\agda{
+module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
+         {B : I → Type 𝓥} where
+  postulate
+    Free-inj : (f : ∀ i → A i → B i) → Type 𝓦 → Type 𝓦
+
+  module Free-inj {f : ∀ i → A i → B i} {X : Type 𝓦} where
+    postulate
+      inc   : X → Free-inj f X
+      ext : ∀ {i} → (g : A i → Free-inj f X)
+                       → B i → Free-inj f X
+      is-ext : ∀ {i} → (g : A i → Free-inj f X)
+                          (a : A i) → ext g (f i a) ＝ g a
+
+      ind : ∀ {𝓜} (P : Free-inj f X → Type 𝓜)
+              (N : (x : X) → P (inc x))
+              (R : ∀ {i} (g : A i → Free-inj f X)
+                   → ((a : A i) → P (g a))
+                   → ∀ (b : B i) → P (ext g b))
+              (S : ∀ {i} (g : A i → Free-inj f X)
+                    (h : (a : A i) → P (g a))
+                    (a : A i)
+                   → tr P (is-ext g a) (R g h (f i a)) ＝ h a)
+            → (x : Free-inj f X) → P x
+
+      ind-inc : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
+                  {N : (x : X) → P (inc x)}
+                  {R : ∀ {i} (g : A i → Free-inj f X)
+                       → ((a : A i) → P (g a))
+                       → ∀ (b : B i) → P (ext g b)}
+                  {S : ∀ {i} (g : A i → Free-inj f X)
+                         (h : (a : A i) → P (g a))
+                         (a : A i)
+                       → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
+                 → ∀ x → ind P N R S (inc x) ＝ N x
+
+      ind-ext : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
+                  {N : (x : X) → P (inc x)}
+                  {R : ∀ {i} (g : A i → Free-inj f X)
+                       → ((a : A i) → P (g a))
+                       → ∀ (b : B i) → P (ext g b)}
+                  {S : ∀ {i} (g : A i → Free-inj f X)
+                         (h : (a : A i) → P (g a))
+                         (a : A i)
+                       → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
+                 → ∀ {i} (g : A i → Free-inj f X)
+                     (h : (a : A i) → P (g a))
+                   → (b : B i) → ind P N R S (ext g b) ＝ R g h b
+
+      -- TODO: Formulate path beta rule for is-ext
+      -- ind-is-ext : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
+      --             {N : (x : X) → P (inc x)}
+      --             {R : ∀ {i} (g : A i → Free-inj f X)
+      --                  → ((a : A i) → P (g a))
+      --                  → ∀ (b : B i) → P (ext g b)}
+      --             {S : ∀ {i} (g : A i → Free-inj f X)
+      --                    (h : (a : A i) → P (g a))
+      --                    (a : A i)
+      --                  → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
+      --            → ∀ {i} (g : A i → Free-inj f X)
+
+    {-# REWRITE ind-inc #-}
+}
+%```
+}
+
+\subtree[stt-005W]{
+\date{2025-06-18}
+\title{Free algabraicly-injective types are algabraicly-injective}
+\taxon{theorem}
+
+%```agda
+\agda{
+module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
+         {B : I → Type 𝓥} where
+  injector-Free-inj
+    : ∀ {f : (i : I) → A i → B i}
+        {X : Type 𝓦}
+      → algabraic-injector f (Free-inj f X)
+  injector-Free-inj i .fst = Free-inj.ext
+  injector-Free-inj i .snd α
+    = funext→ (Free-inj.is-ext α)
+}
+%```
+}

--- a/src/axioms/FreeAlgInj.lagda.tree
+++ b/src/axioms/FreeAlgInj.lagda.tree
@@ -253,7 +253,23 @@ module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
                          (h : (a : A i) → P (g a))
                    → (b : B i) → ind P N R S (ext g b) ＝ R g h b
 
-    {-# REWRITE ind-inc #-}
+    ind-ext-base : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
+                  {N : (x : X) → P (inc x)}
+                  {R : ∀ {i} (g : A i → Free-inj f X)
+                         (h : (a : A i) → P (g a))
+                       → ∀ (b : B i) → P (ext g b)}
+                  {S : ∀ {i} (g : A i → Free-inj f X)
+                         (h : (a : A i) → P (g a))
+                         (a : A i)
+                       → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
+                  → ∀ {i} (g : A i → Free-inj f X)
+                  → (b : B i)
+                  → ind P N R S (ext g b)
+                      ＝
+                     R g (ind P N R S ∘ g) b
+    ind-ext-base g = ind-ext g _
+
+    {-# REWRITE ind-inc ind-ext-base #-}
     postulate
       ind-is-ext : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
                   {N : (x : X) → P (inc x)}
@@ -268,10 +284,16 @@ module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
                       (a : A i)
                  → apᵈ (ind P N R S) (is-ext g a)
                     ＝
-                    ap (tr P (is-ext g a)) (ind-ext g (ind P N R S ∘ g) (f i a))
-                    ∙ S g (ind P N R S ∘ g) a
+                   S g (ind P N R S ∘ g) a
+    {-# REWRITE ind-is-ext #-}
 }
 %```
+}
+
+\subtree[stt-0060]{
+\title{Understanding the recursion principal of the Free algebraic injective}
+
+\todo{TODO!}
 }
 
 \subtree[stt-005W]{

--- a/src/axioms/FreeAlgInj.lagda.tree
+++ b/src/axioms/FreeAlgInj.lagda.tree
@@ -59,8 +59,9 @@ weak-orthogonator f g = ∀ (H : Arrow-map f g) → Lift H
 \taxon{theorem}
 \title{Weakly orthogonal maps give a section of the pullback power}
 
-\p{A map #{f} is weakly orthogonal to #{g} iff the [pullback power](stt-004D)
- #{f \pitchfork g} has a section.}
+\p{The type of weak orthogonators for map #{g} with respect to #{f}
+is equivalent to type of sections of the [pullback power](stt-004D)
+ #{f \pitchfork g}.}
 
 %```agda
 \agda{
@@ -125,16 +126,6 @@ against #{f}.}
 
 \todo{Proof!}
 
-%```agda
-\agda{
--- weak-type-orthogonator-!
---   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
---       {f : A → B} {X : Type 𝓦}
---     → weak-type-orthogonator f X
---     ≃ weak-orthogonator f (! {A = X})
--- weak-type-orthogonator-! = {!!}
-}
-%```
 }
 
 
@@ -142,9 +133,9 @@ against #{f}.}
 \taxon{definition}
 \title{Algebraically injective types}
 
-\p{Given a family of maps #{f_i : A_i \to B_i}, we say that a type
-#{X} is \em{algebraically} #{f\rm{-injective}} if for any family of maps
-#{a_i : A_i \to X}, there is a chosen extension of #{a} along #{f_i}, that
+\p{Given a family of maps #{f_i : A_i \to B_i}, we say that the type
+of \em{algebraic} #{f\rm{-injectives}} for #{X} is, for any map
+#{a : A_i \to X}, a choice of extension for #{a} along #{f_i}. That
 is, the following diagram commutes for all #{i}: }
 
 \quiver{
@@ -290,12 +281,6 @@ module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
 %```
 }
 
-\subtree[stt-0060]{
-\title{Understanding the recursion principal of the Free algebraic injective}
-
-\todo{TODO!}
-}
-
 \subtree[stt-005W]{
 \date{2025-06-18}
 \title{Free algebraically-injective types are algebraically-injective}
@@ -374,27 +359,6 @@ words, given types #{X} and #{Y}, where #{X} is an algebraically
 injective type, the map #{- \circ \eta : (\mathcal{J}_{f}(X) \to Y) \to
 (X \to Y)} is an equivalence.}
 
-\todo{Proof: Todo}
+\todo{Proof}
 
-%```agda
-\agda{
-postcomp-alg-inj : ∀ {𝓘 𝓤 𝓥 𝓦 𝓜} {I : Type 𝓘}
-                     {A : I → Type 𝓤} {B : I → Type 𝓥}
-                     {f : (i : I) → A i → B i}
-                     (X : Type 𝓦) {Y : Type 𝓜}
-                     (Y-alg : Algebraic-injective f Y)
-                   → Σ[ α ∶ (Free-inj f X → Y) ]
-                       Algebraic-injective-map injector-Free-inj Y-alg α
-                   → (X → Y)
-postcomp-alg-inj X {Y} Y-alg = postcomp Y Free-inj.inc ∘ fst
-
--- alg-inj-map-factors : ∀ {𝓘 𝓤 𝓥 𝓦 𝓜} {I : Type 𝓘}
---                         {A : I → Type 𝓤} {B : I → Type 𝓥}
---                         {f : (i : I) → A i → B i}
---                         (X : Type 𝓦) {Y : Type 𝓜}
---                         (Y-alg : Algabraic-injective f Y)
---                       → is-equiv (postcomp-alg-inj {f = f} X Y-alg)
--- alg-inj-map-factors {f = f} X {Y} Y-alg = {!!}
-}
-%```
 }

--- a/src/axioms/FreeAlgInj.lagda.tree
+++ b/src/axioms/FreeAlgInj.lagda.tree
@@ -1,5 +1,5 @@
 \date{2025-06-17}
-\title{The Free Algabraicly Injective HIT}
+\title{The Free Algebraically Injective HIT}
 \taxon{module}
 \meta{module}{\startverb axioms.FreeAlgInj \stopverb}
 \author{samueltoth}
@@ -7,7 +7,6 @@
 
 %```agda
 \agda{
-{-# OPTIONS --allow-unsolved-metas #-}
 module axioms.FreeAlgInj where
 
 open import ufAxioms
@@ -18,24 +17,30 @@ open import core.PullbackPower
 }
 %```
 
-\subtree[stt-0060]{
-\taxon{remark}
-
-\p{The condition of [orthogonality](stt-0048) says that lifting
-problems as above have unique solutions. Algabraic injectivity
-is a weakening of this to only require that a chosen solution.}
-}
 
 \subtree[stt-005L]{
 \taxon{definition}
 \title{Weak orthogonators of maps}
 
+\quiver{
+\begin{tikzcd}
+	A && X \\
+	\\
+	B && Y
+	\arrow[from=1-1, to=1-3]
+	\arrow["f"', from=1-1, to=3-1]
+	\arrow["p", from=1-3, to=3-3]
+	\arrow[dashed, from=3-1, to=1-3]
+	\arrow[from=3-1, to=3-3]
+\end{tikzcd}
+}
+
 \p{[Orthogonal maps](stt-004A) require uniqueness of
-lifting solution. When this uniqueness requirement is lifted
-we can speak of the type of weak-orthogonators for a pair of
-maps, which give a chosen lift for each lifting problem.
-When this type is merely inhabited we say that a pair of maps
-are weakly orthogonal.}
+lifting solution to lifting problems as above. When this
+uniqueness requirement is lifted we can speak of the type
+of weak-orthogonators for a pair of maps, which give a chosen
+lift for each lifting problem. When this type is merely
+inhabited we say that a pair of maps are weakly orthogonal.}
 
 %```agda
 \agda{
@@ -118,15 +123,16 @@ we can say that the type of weak type orthogonators for #{X} against #{f}
 is equivalent to the type of weak orthoginators for the map #{! : A \to 1}
 against #{f}.}
 
+\todo{Proof!}
 
 %```agda
 \agda{
-weak-type-orthogonator-!
-  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
-      {f : A → B} {X : Type 𝓦}
-    → weak-type-orthogonator f X
-    ≃ weak-orthogonator f (! {A = X})
-weak-type-orthogonator-! = {!!}
+-- weak-type-orthogonator-!
+--   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+--       {f : A → B} {X : Type 𝓦}
+--     → weak-type-orthogonator f X
+--     ≃ weak-orthogonator f (! {A = X})
+-- weak-type-orthogonator-! = {!!}
 }
 %```
 }
@@ -134,10 +140,10 @@ weak-type-orthogonator-! = {!!}
 
 \subtree[stt-005J]{
 \taxon{definition}
-\title{Algabraicly injective types}
+\title{Algebraically injective types}
 
 \p{Given a family of maps #{f_i : A_i \to B_i}, we say that a type
-#{X} is \em{algabraicly} #{f\rm{-injective}} if for any family of maps
+#{X} is \em{algebraically} #{f\rm{-injective}} if for any family of maps
 #{a_i : A_i \to X}, there is a chosen extension of #{a} along #{f_i}, that
 is, the following diagram commutes for all #{i}: }
 
@@ -157,24 +163,33 @@ a chosen [weak orthogonator](stt-005O) for #{X} against each #{f_i}.}
 
 %```agda
 \agda{
-algabraic-injector
+Algebraic-injective
   : ∀ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘}
       {A : I → Type 𝓤} {B : I → Type 𝓥}
       (f : (i : I) → A i → B i)
       (X : Type 𝓦)
      → Type (𝓘 ⊔ 𝓤 ⊔ 𝓥 ⊔ 𝓦)
-algabraic-injector f X = ∀ i → weak-type-orthogonator (f i) X
+Algebraic-injective f X = ∀ i → weak-type-orthogonator (f i) X
+
+lift-alg-inj : ∀ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘}
+      {A : I → Type 𝓤} {B : I → Type 𝓥}
+      {f : (i : I) → A i → B i}
+      {X : Type 𝓦}
+     → Algebraic-injective f X
+     → (i : I) (p : A i → X)
+     → B i → X
+lift-alg-inj alg i = alg i .fst
 }
 %```
 }
 
 \subtree[stt-005I]{
 \taxon{definition}
-\title{Free algabraicly-injective types}
+\title{Free algebraically-injective types}
 \citek{rijkeMod2020}
 
 \p{Given a family of types #{f_i : A_i \to B_i} and a type #{X}, we can
-define the free algabraicly #{f\rm{-injective}} type on #{X}, called
+define the free algebraically #{f\rm{-injective}} type on #{X}, called
 #{\mathcal{J}_{f}(X)} with the following
 higher inductive type:}
 
@@ -206,7 +221,7 @@ module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
       ind : ∀ {𝓜} (P : Free-inj f X → Type 𝓜)
               (N : (x : X) → P (inc x))
               (R : ∀ {i} (g : A i → Free-inj f X)
-                   → ((a : A i) → P (g a))
+                         (h : (a : A i) → P (g a))
                    → ∀ (b : B i) → P (ext g b))
               (S : ∀ {i} (g : A i → Free-inj f X)
                     (h : (a : A i) → P (g a))
@@ -217,7 +232,7 @@ module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
       ind-inc : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
                   {N : (x : X) → P (inc x)}
                   {R : ∀ {i} (g : A i → Free-inj f X)
-                       → ((a : A i) → P (g a))
+                         (h : (a : A i) → P (g a))
                        → ∀ (b : B i) → P (ext g b)}
                   {S : ∀ {i} (g : A i → Free-inj f X)
                          (h : (a : A i) → P (g a))
@@ -228,36 +243,40 @@ module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
       ind-ext : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
                   {N : (x : X) → P (inc x)}
                   {R : ∀ {i} (g : A i → Free-inj f X)
-                       → ((a : A i) → P (g a))
+                         (h : (a : A i) → P (g a))
                        → ∀ (b : B i) → P (ext g b)}
                   {S : ∀ {i} (g : A i → Free-inj f X)
                          (h : (a : A i) → P (g a))
                          (a : A i)
                        → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
                  → ∀ {i} (g : A i → Free-inj f X)
-                     (h : (a : A i) → P (g a))
+                         (h : (a : A i) → P (g a))
                    → (b : B i) → ind P N R S (ext g b) ＝ R g h b
 
-      -- TODO: Formulate path beta rule for is-ext
-      -- ind-is-ext : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
-      --             {N : (x : X) → P (inc x)}
-      --             {R : ∀ {i} (g : A i → Free-inj f X)
-      --                  → ((a : A i) → P (g a))
-      --                  → ∀ (b : B i) → P (ext g b)}
-      --             {S : ∀ {i} (g : A i → Free-inj f X)
-      --                    (h : (a : A i) → P (g a))
-      --                    (a : A i)
-      --                  → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
-      --            → ∀ {i} (g : A i → Free-inj f X)
-
     {-# REWRITE ind-inc #-}
+    postulate
+      ind-is-ext : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
+                  {N : (x : X) → P (inc x)}
+                  {R : ∀ {i} (g : A i → Free-inj f X)
+                         (h : (a : A i) → P (g a))
+                       → ∀ (b : B i) → P (ext g b)}
+                  {S : ∀ {i} (g : A i → Free-inj f X)
+                         (h : (a : A i) → P (g a))
+                         (a : A i)
+                       → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
+                 → ∀ {i} (g : A i → Free-inj f X)
+                      (a : A i)
+                 → apᵈ (ind P N R S) (is-ext g a)
+                    ＝
+                    ap (tr P (is-ext g a)) (ind-ext g (ind P N R S ∘ g) (f i a))
+                    ∙ S g (ind P N R S ∘ g) a
 }
 %```
 }
 
 \subtree[stt-005W]{
 \date{2025-06-18}
-\title{Free algabraicly-injective types are algabraicly-injective}
+\title{Free algebraically-injective types are algebraically-injective}
 \taxon{theorem}
 
 %```agda
@@ -267,10 +286,93 @@ module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
   injector-Free-inj
     : ∀ {f : (i : I) → A i → B i}
         {X : Type 𝓦}
-      → algabraic-injector f (Free-inj f X)
+      → Algebraic-injective f (Free-inj f X)
   injector-Free-inj i .fst = Free-inj.ext
   injector-Free-inj i .snd α
     = funext→ (Free-inj.is-ext α)
+}
+%```
+}
+
+\subtree[stt-0068]{
+\title{Morphisms of algebraic injectives}
+\date{2025-06-21}
+
+\p{Given a pair of algebraic injectives #{(X,x)} and #{(Y,y)} over
+the same family of maps, #{f_i}, we define the type of morphisms
+of algebraic injectives: #{\Hom((X,x), (Y,y))} to be the
+type of maps which commute coherently with the given extensions.}
+
+\quiver{
+\begin{tikzcd}
+	& X \\
+	{A_i} && Y \\
+	\\
+	{B_i}
+	\arrow["\alpha", from=1-2, to=2-3]
+	\arrow["{p_x}", from=2-1, to=1-2]
+	\arrow["{\alpha p_x}"{description}, from=2-1, to=2-3]
+	\arrow["{f_i}"', from=2-1, to=4-1]
+	\arrow[dashed, from=4-1, to=1-2]
+	\arrow[dashed, from=4-1, to=2-3]
+\end{tikzcd}
+}
+
+%```agda
+\agda{
+record Algebraic-injective-map
+  {𝓘 𝓤 𝓥 𝓦 𝓜} {I : Type 𝓘}
+      {A : I → Type 𝓤} {B : I → Type 𝓥}
+      {f : (i : I) → A i → B i}
+      {X : Type 𝓦} (X-alg : Algebraic-injective f X)
+      {Y : Type 𝓜} (Y-alg : Algebraic-injective f Y)
+      (α : X → Y)
+    : Type (𝓘 ⊔ 𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓜) where
+  field
+    ext-comm : ∀ i p → (α ∘ lift-alg-inj X-alg i p)
+                         ~
+                      lift-alg-inj Y-alg i (α ∘ p)
+    ext-comm-coh : ∀ i → (precomp (A i) α ◂ X-alg i .snd)
+                           ~
+                          (λ a → funext→ (ext-comm i a ∘ f i))
+                            ~∙
+                            Y-alg i .snd ▸ precomp (A i) α
+}
+%```
+}
+
+\subtree[stt-0067]{
+\date{2025-06-21}
+\title{The universal property for free algebraic injectives}
+\taxon{theorem}
+
+\p{We show that any map into an algebraically injective type
+factors through the free algebraically injective type. In other
+words, given types #{X} and #{Y}, where #{X} is an algebraically
+injective type, the map #{- \circ \eta : (\mathcal{J}_{f}(X) \to Y) \to
+(X \to Y)} is an equivalence.}
+
+\todo{Proof: Todo}
+
+%```agda
+\agda{
+postcomp-alg-inj : ∀ {𝓘 𝓤 𝓥 𝓦 𝓜} {I : Type 𝓘}
+                     {A : I → Type 𝓤} {B : I → Type 𝓥}
+                     {f : (i : I) → A i → B i}
+                     (X : Type 𝓦) {Y : Type 𝓜}
+                     (Y-alg : Algebraic-injective f Y)
+                   → Σ[ α ∶ (Free-inj f X → Y) ]
+                       Algebraic-injective-map injector-Free-inj Y-alg α
+                   → (X → Y)
+postcomp-alg-inj X {Y} Y-alg = postcomp Y Free-inj.inc ∘ fst
+
+-- alg-inj-map-factors : ∀ {𝓘 𝓤 𝓥 𝓦 𝓜} {I : Type 𝓘}
+--                         {A : I → Type 𝓤} {B : I → Type 𝓥}
+--                         {f : (i : I) → A i → B i}
+--                         (X : Type 𝓦) {Y : Type 𝓜}
+--                         (Y-alg : Algabraic-injective f Y)
+--                       → is-equiv (postcomp-alg-inj {f = f} X Y-alg)
+-- alg-inj-map-factors {f = f} X {Y} Y-alg = {!!}
 }
 %```
 }

--- a/src/core/Arrow.lagda.tree
+++ b/src/core/Arrow.lagda.tree
@@ -15,7 +15,6 @@ open import ergonomics.Marker
 open import ergonomics.Extensionality
 open import core.Slice
 open import core.CanonicalPushouts
-open import core.PullbackPath
 }
 % ```
 

--- a/src/core/Arrow.lagda.tree
+++ b/src/core/Arrow.lagda.tree
@@ -28,6 +28,7 @@ open import core.CanonicalPushouts
 \agda{
 record Arrow : Typeω where
   constructor mk-arr
+  no-eta-equality
   field
     {𝓤 𝓥} : Level
     {dom} : Type 𝓤

--- a/src/core/ArrowEquiv.lagda.tree
+++ b/src/core/ArrowEquiv.lagda.tree
@@ -43,6 +43,28 @@ is-Arrow-equiv : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {X : 
                      → Arrow-map f g → Type _
 is-Arrow-equiv {f = f} {g} (mk-amap top bot comm)
   = is-equiv top × is-equiv bot
+
+
+Arrow⁻¹←Arrow-equiv : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {X : Type 𝓦}
+                       {Y : Type 𝓜} {f : A → B} {g : X → Y}
+                     → (F : Arrow-map f g)
+                     → is-Arrow-equiv F
+                     → Arrow-map g f
+Arrow⁻¹←Arrow-equiv {f = f}{g} (mk-amap top bot comm) (teq , beq)
+  = mk-amap top.bwd bot.bwd
+    (beq ◂eqv (   bot.ε ▸ g ▸ top
+               ~∙ (comm ~⁻¹)
+               ~∙ (bot ◂ f ◂ top.η ~⁻¹))
+               ▸eqv teq) where
+  module top = is-equiv teq
+  module bot = is-equiv beq
+
+Arrow⁻¹-is-equiv : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {X : Type 𝓦}
+                       {Y : Type 𝓜} {f : A → B} {g : X → Y}
+                     → (F : Arrow-map f g)
+                     → (eq : is-Arrow-equiv F)
+                     → is-Arrow-equiv (Arrow⁻¹←Arrow-equiv F eq)
+Arrow⁻¹-is-equiv F (teq , beq) = (is-equiv⁻¹ teq  , is-equiv⁻¹ beq)
 }
 %```
 }
@@ -75,6 +97,52 @@ is-equiv←Arrow-equiv⁻¹ : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Typ
                        → is-equiv g → is-equiv f
 is-equiv←Arrow-equiv⁻¹ {F = mk-amap top bot comm} (teq , beq) geq
   = 3-for-2~ (comm ~⁻¹) beq (is-equiv-∘ geq teq)
+}
+%```
+}
+
+\subtree[stt-0069]{
+\title{Arrow equivalences preserve sections}
+\taxon{theorem}
+
+\p{If there is an [arrow equivalence](stt-004R) from #{A \xrightarrow{f} B} to
+#{X \xrightarrow{g} Y}, then sections of #{f} are equivalent to sections of #{g}.
+}
+
+% TODO(sam): Look into why unification isn't working so well for arrow
+%            map
+
+%```agda
+\agda{
+section←Arrow-equiv : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {X : Type 𝓦}
+                       {Y : Type 𝓜} {f : A → B} {g : X → Y}
+                       {F : Arrow-map f g}
+                       → is-Arrow-equiv F
+                       → section f → section g
+section←Arrow-equiv {f = f} {g} {F = F} eq (secf , p) .fst
+  = top ∘ secf ∘ bot.bwd where
+  open Arrow-map F
+  module top = is-equiv (eq .fst)
+  module bot = is-equiv (eq .snd)
+section←Arrow-equiv {f = f} {g} {F} eq (secf , p) .snd
+  =  H ▸ top ▸ secf ▸ bot.bwd
+  ~∙ bot ◂ f ◂ top.η ▸ secf ▸ bot.bwd
+  ~∙ bot ◂ p ▸ bot.bwd
+  ~∙ bot.ε where
+  open Arrow-map F
+  module top = is-equiv (eq .fst)
+  module bot = is-equiv (eq .snd)
+  H : g ~ bot ∘ f ∘ top.bwd
+  H = comm ▸ top.bwd ~∙ g ◂ top.ε ~⁻¹
+
+section←Arrow-equiv⁻¹ : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {X : Type 𝓦}
+                       {Y : Type 𝓜} {f : A → B} {g : X → Y}
+                       {F : Arrow-map f g}
+                       → is-Arrow-equiv F
+                       → section g → section f
+section←Arrow-equiv⁻¹ {f = f}{g}{F} EF sec = section←Arrow-equiv {f = g}{f}
+                                               {Arrow⁻¹←Arrow-equiv F EF}
+                                               (Arrow⁻¹-is-equiv F EF) sec
 }
 %```
 }

--- a/src/core/CanonicalPushouts.lagda.tree
+++ b/src/core/CanonicalPushouts.lagda.tree
@@ -71,19 +71,3 @@ cogap = pushout-rec
 }
 % ```
 }
-
-\subtree[stt-005M]{
-  \taxon{definition}
-  \title{The codiagonal map}
-  \p{Given a map #{f : B \to C}, we can define the map #{\Nabla_f : B +^A B \to C}
-  called the codiagonal map.}
-
-%```agda
-\agda{
-∇ : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
-      (f : A → B)
-    → Pushout f f → B
-∇ f = pushout-rec (mk-cocone id id ~refl)
-}
-%```
-}

--- a/src/core/CanonicalPushouts.lagda.tree
+++ b/src/core/CanonicalPushouts.lagda.tree
@@ -71,3 +71,19 @@ cogap = pushout-rec
 }
 % ```
 }
+
+\subtree[stt-005M]{
+  \taxon{definition}
+  \title{The codiagonal map}
+  \p{Given a map #{f : B \to C}, we can define the map #{\Nabla_f : B +^A B \to C}
+  called the codiagonal map.}
+
+%```agda
+\agda{
+∇ : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+      (f : A → B)
+    → Pushout f f → B
+∇ f = pushout-rec (mk-cocone id id ~refl)
+}
+%```
+}

--- a/src/core/CoSlice.lagda.tree
+++ b/src/core/CoSlice.lagda.tree
@@ -1,0 +1,92 @@
+\date{2025-06-20}
+\title{Coslices of types}
+\taxon{module}
+\meta{module}{\startverb core.CoSlice \stopverb}
+\author{samueltoth}
+\import{stt-macros}
+
+%```agda
+\agda{
+module core.CoSlice where
+
+open import foundations.Prelude
+open import ufAxioms
+}
+%```
+
+\subtree[stt-0062]{
+\title{Coslices}
+\taxon{definition}
+
+\p{Fixing a type #{A}, there is a category
+#{\SS_{A/}} called the coslice category under #{A}.
+Maps in this category are commuting triangles:}
+
+%```agda
+\agda{
+Coslice-map : ∀ {𝓤} {A : Type 𝓤}
+                {𝓥} {X : Type 𝓥}
+                (p : A → X)
+                {𝓦} {Y : Type 𝓦}
+                (q : A → Y)
+               → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦)
+Coslice-map {X = X} p {Y = Y} q
+  = Σ[ f ∶ (X → Y) ] (f ∘ p ~ q)
+
+Coslice-id : ∀ {𝓤} {A : Type 𝓤}
+               {𝓥} {X : Type 𝓥}
+               (p : A → X)
+             → Coslice-map p p
+Coslice-id p = (id , ~refl)
+
+
+}
+%```
+}
+
+
+%```agda
+\agda{
+Coslice-equiv : ∀ {𝓤} {A : Type 𝓤}
+                {𝓥} {X : Type 𝓥}
+                {p : A → X}
+                {𝓦} {Y : Type 𝓦}
+                {q : A → Y}
+               → Coslice-map p q
+               → Type (𝓥 ⊔ 𝓦)
+Coslice-equiv (f , _) = is-equiv f
+
+sec←sec-Coslice-equiv
+  : ∀ {𝓤} {A : Type 𝓤}
+      {𝓥} {X : Type 𝓥}
+      {p : A → X}
+      {𝓦} {Y : Type 𝓦}
+      {q : A → Y}
+      (f : Coslice-map p q)
+    → Coslice-equiv f
+    → section p
+    → section q
+sec←sec-Coslice-equiv (f , H) feq (ps , sp)
+  = homotopy-section H ((ps ∘ f.bwd) , f ◂ sp ▸ f.bwd ~∙ f.ε) where
+  module f = is-equiv feq
+
+
+
+sec←sec-Coslice-equiv'
+  : ∀ {𝓤} {A : Type 𝓤}
+      {𝓥} {X : Type 𝓥}
+      {p : A → X}
+      {𝓦} {Y : Type 𝓦}
+      {q : A → Y}
+      (f : Coslice-map p q)
+    → Coslice-equiv f
+    → section q
+    → section p
+sec←sec-Coslice-equiv' (f , H) feq (ps , sp)
+  = homotopy-section (((f.η ▸ _ ~⁻¹) ~∙ f.bwd ◂ H) ~⁻¹ )
+                     ((ps ∘ f) , f.bwd ◂ sp ▸ f ~∙ f.η) where
+  module f = is-equiv feq
+
+
+}
+%```

--- a/src/core/CoSlice.lagda.tree
+++ b/src/core/CoSlice.lagda.tree
@@ -87,6 +87,17 @@ sec←sec-Coslice-equiv' (f , H) feq (ps , sp)
                      ((ps ∘ f) , f.bwd ◂ sp ▸ f ~∙ f.η) where
   module f = is-equiv feq
 
-
+equiv←Coslice-equiv
+  : ∀ {𝓤} {A : Type 𝓤}
+      {𝓥} {X : Type 𝓥}
+      {p : A → X}
+      {𝓦} {Y : Type 𝓦}
+      {q : A → Y}
+      (f : Coslice-map p q)
+    → Coslice-equiv f
+    → is-equiv p
+    → is-equiv q
+equiv←Coslice-equiv (f , comm) feq peq
+  = homotopy-is-equiv comm (is-equiv-∘ feq peq)
 }
 %```

--- a/src/core/CoSlice.lagda.tree
+++ b/src/core/CoSlice.lagda.tree
@@ -15,7 +15,7 @@ open import ufAxioms
 %```
 
 \subtree[stt-0062]{
-\title{Coslices}
+\title{Coslice maps}
 \taxon{definition}
 
 \p{Fixing a type #{A}, there is a category
@@ -38,12 +38,16 @@ Coslice-id : ∀ {𝓤} {A : Type 𝓤}
                (p : A → X)
              → Coslice-map p p
 Coslice-id p = (id , ~refl)
-
-
 }
 %```
 }
 
+\subtree[stt-0060]{
+\taxon{definition}
+\title{Equivalences of coslices}
+
+\p{A map of coslices is said to be an equivalence
+if it's underlying map of types in an equivalence.}
 
 %```agda
 \agda{
@@ -55,7 +59,16 @@ Coslice-equiv : ∀ {𝓤} {A : Type 𝓤}
                → Coslice-map p q
                → Type (𝓥 ⊔ 𝓦)
 Coslice-equiv (f , _) = is-equiv f
+}
+%```
+}
 
+\subtree[stt-006N]{
+\taxon{theorem}
+\title{Equivalences, sections and retracts are closed under coslice equivalence}
+
+%```agda
+\agda{
 sec←sec-Coslice-equiv
   : ∀ {𝓤} {A : Type 𝓤}
       {𝓥} {X : Type 𝓥}
@@ -101,3 +114,4 @@ equiv←Coslice-equiv (f , comm) feq peq
   = homotopy-is-equiv comm (is-equiv-∘ feq peq)
 }
 %```
+}

--- a/src/core/Codiagonal.lagda.tree
+++ b/src/core/Codiagonal.lagda.tree
@@ -1,0 +1,106 @@
+\date{2025-06-21}
+\title{(co)diagonal maps}
+\taxon{module}
+\meta{module}{\startverb core.Codiagonal \stopverb}
+\author{samueltoth}
+\import{stt-macros}
+
+%```agda
+\agda{
+module core.Codiagonal where
+
+open import foundations.Prelude
+open import ufAxioms
+open import core.CanonicalPushouts
+open import core.CoSlice
+}
+%```
+
+
+\subtree[stt-005M]{
+  \taxon{definition}
+  \title{The codiagonal map}
+  \p{Given a map #{f : B \to C}, we can define the map #{\nabla_f : B +^A B \to C}
+  called the codiagonal map.}
+
+%```agda
+\agda{
+∇ : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+      (f : A → B)
+    → Pushout f f → B
+∇ f = pushout-rec (mk-cocone id id ~refl)
+}
+%```
+}
+
+
+\subtree[stt-0064]{
+\title{Pullback of postcomposition is a cocone}
+
+%```agda
+\agda{
+Cocone←Pullback : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥}
+                    {C : Type 𝓦} {f : A → B} {g : A → C}
+                    {X : Type 𝓜}
+                  → Pullback (postcomp X f) (postcomp X g)
+                  → Cocone (mk-span A f g) X
+Cocone←Pullback (p , q , H) =  mk-cocone p q (happly H)
+
+Cocone←Pullback-is-equiv
+  : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥}
+      {C : Type 𝓦} {f : A → B} {g : A → C}
+      {X : Type 𝓜}
+    → is-equiv (Cocone←Pullback {f = f} {g} {X})
+Cocone←Pullback-is-equiv = is-equiv←qiso λ where
+  .fst (mk-cocone p q H) → (p , q , funext→ H)
+  .snd .fst (p , q , H) → ap (λ H → (p , q , H)) (funext.η _)
+  .snd .snd (mk-cocone p q H) → refl
+}
+%```
+}
+
+\subtree[stt-0063]{
+\title{Connection between diagonal and codiagonal}
+\taxon{theorem}
+\citet{2.11}{rijkeMod2020}
+
+\p{We can construct a map in the [coslice category](stt-0062)
+from postcomposition by the [codiagonal](stt-005M) of #{f : A \to B}
+to the [diagonal](stt-005X) of postcomposition by #{f}. This map
+is an equivalence.}
+
+\quiver{
+\begin{tikzcd}
+	&& {X^A} \\
+	\\
+	{B +^A B \to X} &&&& {X^B \times_{X^A} X^B}
+	\arrow["{-\circ \nabla_f}"', from=1-3, to=3-1]
+	\arrow["{\Delta_{-\circ f}}", from=1-3, to=3-5]
+	\arrow["\sim"', from=3-1, to=3-5]
+\end{tikzcd}
+}
+
+% TODO: This proof is horrible. Hopefully there is some kind
+%       of abstraction that is useful here. It would be bassically
+%       refl if path constructors computed tho....
+
+%```agda
+\agda{
+Δ←∇ : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+        (f : A → B) (X : Type 𝓦)
+      → Coslice-map (diagonal (postcomp X f)) (postcomp X (∇ f))
+Δ←∇ f X .fst = cogap ∘ Cocone←Pullback
+Δ←∇ f X .snd g = funext→ (pushout-ind _ (mk-coconeD ~refl ~refl
+    λ a → IdP-func←Square (glue a) refl refl
+      ( ∙-reflr _
+      ∙ pushout-rec-apβ a
+      ∙ sym ( ap-∘ g _ _
+            ∙ ap (ap g) (pushout-rec-apβ a)))))
+
+Δ←∇-is-equiv : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+                 {f : A → B} {X : Type 𝓦}
+               → Coslice-equiv (Δ←∇ f X)
+Δ←∇-is-equiv = is-equiv-∘ pushout-rec-is-equiv Cocone←Pullback-is-equiv
+}
+%```
+}

--- a/src/core/Codiagonal.lagda.tree
+++ b/src/core/Codiagonal.lagda.tree
@@ -80,10 +80,6 @@ is an equivalence.}
 \end{tikzcd}
 }
 
-% TODO: This proof is horrible. Hopefully there is some kind
-%       of abstraction that is useful here. It would be bassically
-%       refl if path constructors computed tho....
-
 %```agda
 \agda{
 Δ←∇ : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}

--- a/src/core/Orthogonal.lagda.tree
+++ b/src/core/Orthogonal.lagda.tree
@@ -156,7 +156,7 @@ orthogonal←postcomp-Π {f = f}{g} eqv F
 \taxon{theorem}
 \title{Orthogonality via composition}
 
-\p{A type #{A} is [orthogonal](stt-004N) to a map #{X \to Y} iff precomposition
+\p{A type #{A} is [orthogonal](stt-004N) to a map #{X \to Y} iff postcomposition
 by f is an equivalence.}
 
 \p{We postpone this proof until later, but for now in the formalisation we

--- a/src/core/PiSection.lagda.tree
+++ b/src/core/PiSection.lagda.tree
@@ -1,0 +1,55 @@
+\date{2025-06-26}
+\author{samueltoth}
+\title{Pi types as sections}
+\taxon{module}
+\meta{module}{\startverb core.PiSection \stopverb}
+\import{stt-macros}
+
+
+%```agda
+\agda{
+module core.PiSection where
+
+open import foundations.Prelude
+open import ufAxioms
+}
+%```
+
+
+\subtree[stt-006J]{
+\taxon{theorem}
+\title{Pi types are sections}
+
+\p{We show that the type #{\Pi_{(a : A)} B(a)} is equivalent to
+the type of sections of #{\pi : \Sigma_{(a : A)} B(a)}.}
+
+
+%```agda
+\agda{
+section←Π : ∀ {𝓤 𝓥} {A : Type 𝓤}
+              {B : A → Type 𝓥}
+            → Π _ B
+            → section (fst {B = B})
+section←Π {B = B} f = ((λ x → (x , f x)) , ~refl)
+
+
+section≃Π : ∀ {𝓤 𝓥} {A : Type 𝓤}
+              {B : A → Type 𝓥}
+            → section (fst {B = B})
+            ≃ Π _ B
+section≃Π {A = A} {B}
+  = section fst                                  ≃⟨ Σ-Π-swap≃ _ _ e⁻¹ ⟩
+    (∀ (a : A) → Σ[ x ∶ Σ A B ] (fst x ＝ a))    ≃⟨ Π-ap-≃ (λ a → Σ-assoc) ⟩
+    ((a : A) → Σ[ a' ∶ A ] ((B a') × (a' ＝ a))) ≃⟨ Π-ap-≃ (λ a
+                                                    → Σ-ap-≃ (λ a' → ×-swap)) ⟩
+    (((a : A) → Σ[ a' ∶ A ] ((a' ＝ a) × B a'))) ≃⟨ Π-ap-≃ (λ a → Σ-＝singl) ⟩
+    Π A B ≃∎
+
+Π←section : ∀ {𝓤 𝓥} {A : Type 𝓤}
+              {B : A → Type 𝓥}
+            → section (fst {B = B})
+            → Π _ B
+Π←section {B = B} (f , s) a = tr B (s a) (snd (f a))
+}
+%```
+}

--- a/src/core/Postwhisker.lagda.tree
+++ b/src/core/Postwhisker.lagda.tree
@@ -25,16 +25,16 @@ open import core.ArrowEquiv
 %```agda
 \agda{
 postwhisker : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
-                  {X : Type 𝓦} (f : A → B)
-                → ∀ (g h : B → X)
-                → g ~ h → g ∘ f ~ h ∘ f
+                {X : Type 𝓦} (f : A → B)
+                (g h : B → X)
+              → g ~ h → g ∘ f ~ h ∘ f
 postwhisker f g h = _▸ f
 
 prewhisker : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
-                  (X : Type 𝓦) (f : A → B)
-                → ∀ {g h : X → A}
-                → g ~ h → f ∘ g ~ f ∘ h
-prewhisker X f = f ◂_
+               {X : Type 𝓦} (f : A → B)
+               (g h : X → A)
+             → g ~ h → f ∘ g ~ f ∘ h
+prewhisker f g h = f ◂_
 }
 %```
 }

--- a/src/core/Postwhisker.lagda.tree
+++ b/src/core/Postwhisker.lagda.tree
@@ -1,0 +1,104 @@
+\title{(Pre)Postwhiskering}
+\date{2025-06-26}
+\author{samueltoth}
+\taxon{module}
+\meta{module}{\startverb core.Postwhisker \stopverb}
+\import{stt-macros}
+
+%```agda
+\agda{
+module core.Postwhisker where
+
+open import foundations.Prelude
+open import ufAxioms
+open import core.Arrow
+open import core.ArrowEquiv
+}
+%```
+
+
+\subtree[stt-006G]{
+\title{Postwhiskering a homotopy}
+\taxon{definition}
+
+
+%```agda
+\agda{
+postwhisker : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+                  {X : Type 𝓦} (f : A → B)
+                → ∀ (g h : B → X)
+                → g ~ h → g ∘ f ~ h ∘ f
+postwhisker f g h = _▸ f
+
+prewhisker : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+                  (X : Type 𝓦) (f : A → B)
+                → ∀ {g h : X → A}
+                → g ~ h → f ∘ g ~ f ∘ h
+prewhisker X f = f ◂_
+}
+%```
+}
+
+
+\subtree[stt-006I]{
+\title{Funext for Postwhsikering}
+\taxon{theorem}
+
+\p{Let #{f : A \to B}, and #{g,h : B \to C}, then
+postwhiskering by #{f} is an equivalence iff #{\rm{ap}_{- \circ f}^{g,h}} is.}
+
+%```agda
+\agda{
+postwhisker←ap-compose : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+            {C : Type 𝓦}
+           (f : A → B)
+           (g h : B → C)
+         → Arrow-map
+             (ap (postcomp C f) {g} {h})
+             (postwhisker f g h)
+postwhisker←ap-compose _ _ _ .Arrow-map.top = happly
+postwhisker←ap-compose _ _ _ .Arrow-map.bot = happly
+postwhisker←ap-compose _ _ _ .Arrow-map.comm refl = refl
+
+postwhisker-funext : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+                    {C : Type 𝓦}
+                    {f : A → B}
+                    {g h : B → C}
+                  → is-Arrow-equiv (postwhisker←ap-compose f g h)
+postwhisker-funext .fst = global-funext
+postwhisker-funext .snd = global-funext
+
+
+postwhisker-is-equiv←ap-compose
+  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+      {C : Type 𝓦}
+      {f : A → B}
+      {g h : B → C}
+    → is-equiv (ap (postcomp C f) {g} {h})
+    → is-equiv (postwhisker f g h)
+postwhisker-is-equiv←ap-compose e
+  = is-equiv←Arrow-equiv {F = postwhisker←ap-compose _ _ _}
+                         postwhisker-funext
+                         e
+
+}
+%```
+}
+
+\subtree[stt-006H]{
+\title{Postwhiskering by an equiavalence is an equivalence}
+\taxon{corollary}
+
+%```agda
+\agda{
+postwhisker-equiv-is-equiv
+  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+      {f : A → B} → is-equiv f
+    → ∀ {C : Type 𝓦} {g h : B → C}
+      → is-equiv (postwhisker f g h)
+postwhisker-equiv-is-equiv e
+  = postwhisker-is-equiv←ap-compose
+     (is-embedding←is-equiv (postcomp-equiv e))
+}
+%```
+}

--- a/src/foundations/CanonicalPullbacks.lagda.tree
+++ b/src/foundations/CanonicalPullbacks.lagda.tree
@@ -93,7 +93,7 @@ repeatedly applying the universal property of sigma types:}
   (Q \to \Sigma_{(x : B)}\Sigma_{(y : C)}(f(x) = g(y)))
     &\simeq \Sigma_{(i : Q \to B)}((q : Q) \to (\Sigma_{(y : C)}(f(i(q)) = g(y)))) \\
     &\simeq \Sigma_{(i : Q \to B)}\Sigma_{(j : Q \to C)}((q : Q) \to f(i(q)) = g(j(q))) \\
-    &\simeq \textrm{Cone}_S(Q) 
+    &\simeq \textrm{Cone}_S(Q)
 \end{align*}
 }
 
@@ -213,4 +213,21 @@ module _ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
 }
 % ```
 }
+}
+
+\subtree[stt-005X]{
+\title{The diagonal map}
+\taxon{definition}
+
+\p{Given a map #{f : A \to B}, we can form a map #{\Delta_f : A \to A \times_B A}
+called the \em{diagonal map} of #{f}.}
+
+%```agda
+\agda{
+diagonal : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+             (f : A → B)
+           → A → Pullback f f
+diagonal f a = a , a , refl
+}
+%```
 }

--- a/src/foundations/CanonicalPullbacks.lagda.tree
+++ b/src/foundations/CanonicalPullbacks.lagda.tree
@@ -1,10 +1,8 @@
 \date{2025-04-22}
-
 \title{Canonical pullbacks}
 \author{samueltoth}
 \taxon{module}
 \meta{module}{\startverb foundations.CanonicalPullbacks \stopverb}
-
 \import{stt-macros}
 
 % ```agda
@@ -127,7 +125,7 @@ module WithFunExt (FE : FE.FunExt-global) where
 
 \proof{
 \p{We need to show that for any #{Q}, #{\textrm{gap}(D) : D \toeq B \times_A C} is an
-equivalence iff 
+equivalence iff
 #{\textrm{cone-map}(D) : (Q \to D) \to Cone_S(Q)} is.
 We know that #{- \circ \textrm{gap}(D) : (Q \to D) \to (Q \to B \times_A C)} is an equivalence
 iff the gap map is, so we use then use the fact canonical pullbacks are pullbacks and
@@ -177,7 +175,7 @@ iff the gap map is, so we use then use the fact canonical pullbacks are pullback
 \p{Given a cospan, #{A \xrightarrow{f} C \xleftarrow{g} B}, we can classify the fibres of maps #{\pi_1 : A \times_C B \to A} and #{\pi_2 : A \times_C B \to B}:}
 
 ##{ \textrm{fib}_{\pi_1}(a) \simeq \textrm{fib}_{g}(f(a)) \\
-    \textrm{fib}_{\pi_2}(b) \simeq \textrm{fib}_{f}(g(a)) 
+    \textrm{fib}_{\pi_2}(b) \simeq \textrm{fib}_{f}(g(a))
 }
 
 \proof{
@@ -230,7 +228,7 @@ called the \em{diagonal map} of #{f}.}
 diagonal : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
              (f : A → B)
            → A → Pullback f f
-diagonal f a = a , a , refl
+diagonal f a = (a , a , refl)
 }
 %```
 }

--- a/src/foundations/CanonicalPullbacks.lagda.tree
+++ b/src/foundations/CanonicalPullbacks.lagda.tree
@@ -15,6 +15,7 @@ open import foundations.Universes
 open import foundations.Span
 open import foundations.Functions
 open import foundations.Identity
+open import foundations.Singleton
 open import foundations.Homotopy
 open import foundations.QuasiIsomorphism
 open import foundations.CoherentIsomorphism
@@ -26,6 +27,8 @@ open import foundations.EquivProp
 open import foundations.EquivHomotopy
 open import foundations.FibrewiseEquiv
 open import foundations.IdentityEquiv
+open import foundations.EquivSingleton
+open import foundations.Embedding
 import foundations.FunExt as FE
 import foundations.CompositionEquiv as CE
 }
@@ -228,6 +231,29 @@ diagonal : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
              (f : A → B)
            → A → Pullback f f
 diagonal f a = a , a , refl
+}
+%```
+}
+
+\subtree[stt-006B]{
+\date{2025-06-23}
+\title{Diagonal equivalence}
+\taxon{theorem}
+
+\p{The diagonal of map #{f} is an equivalence iff #{f} is.}
+
+%```agda
+\agda{
+diagonal-is-equiv : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+                      {f : A → B}
+                    → is-equiv f
+                    → is-equiv (diagonal f)
+diagonal-is-equiv {f = f} feq
+  = is-equiv⁻¹ (singleton-fst-is-equiv λ x
+        → is-single←equiv-to-single
+            (Σ-ap-≃ λ a
+              → mk≃ (ap f) (is-embedding←is-equiv feq))
+            Sing-is-singleton)
 }
 %```
 }

--- a/src/foundations/CoherentIsomorphism.lagda.tree
+++ b/src/foundations/CoherentIsomorphism.lagda.tree
@@ -233,6 +233,34 @@ equiv←qiso (mk-iso fwd fwd-iso) = mk≃ fwd (is-equiv←qiso fwd-iso)
 }
 }
 
+
+
+\subtree[stt-005T]{
+\date{2025-06-19}
+\title{Assuming the codomain to construct an equivalence}
+\taxon{theorem}
+  \p{To show that a function is an equialence,
+  it suffices show that it is an equivalence assuming a point
+  in the codomain.}
+
+%```agda
+\agda{
+is-equiv←is-equiv-if-cod
+  : ∀ {𝓤 𝓥} {A : Type 𝓤}
+      {B : Type 𝓥}
+      {f : A → B}
+     → (B → is-equiv f)
+     → is-equiv f
+is-equiv←is-equiv-if-cod {f = f} feqb
+  = is-equiv←qiso
+      ( (λ b → bwd (feqb b) b)
+      , (λ a → η (feqb (f a)) a)
+      , λ b → ε (feqb b) b ) where open is-equiv
+}
+%```
+}
+
+
 \subtree[stt-001T]{
 \title{Equivalences form an #{\infty}-groupoid over types}
 

--- a/src/foundations/CompositionEquiv.lagda.tree
+++ b/src/foundations/CompositionEquiv.lagda.tree
@@ -40,6 +40,11 @@ open import foundations.EquivContrFibre
 \proof{
 % ```agda
 \agda{
+
+precomp-ret : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} {C : Type 𝓦}
+             → retract f → retract (precomp C f)
+precomp-ret (g , r) = (g ∘_ , λ h → WithFunExtω.funext→ FE (r ▸ h))
+
 precomp-qinv : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} {C : Type 𝓦}
              → quasi-iso f → quasi-iso {B = C → B} (f ∘_)
 precomp-qinv {f = f} (g , ret , sec) = (g ∘_) , ret∘ , sec∘ where
@@ -49,9 +54,10 @@ precomp-qinv {f = f} (g , ret , sec) = (g ∘_) , ret∘ , sec∘ where
   ret∘ : retract-witness (_∘_ f) (g ∘_)
   ret∘ h = WithFunExtω.funext→ FE (ret ▸ h)
 
-precomp-equiv : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} {C : Type 𝓦}
+precomp-equiv : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+                  {f : A → B} {C : Type 𝓦}
                 → is-equiv f → is-equiv {B = C → B} (f ∘_)
-precomp-equiv eq = is-equiv←qiso (precomp-qinv (qiso←is-equiv eq))                
+precomp-equiv eq = is-equiv←qiso (precomp-qinv (qiso←is-equiv eq))
 
 precomp-≃ : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} (e : A ≃ B) {X : Type 𝓦}
                 → (X → A) ≃ (X → B)
@@ -70,12 +76,17 @@ precomp-Π-qinv {f = f} eq = (λ g c → eq .fst (g c)) , ret , sec where
    sec g = WithFunExtω.funext→ FE (λ c → eq .snd .snd (g c))
 
 precomp-Π-equiv : ∀ {𝓤 𝓥 𝓦} {C : Type 𝓦}
-                         {A : C → Type 𝓤} {B : C → Type 𝓥}
-                         {f : ∀ {c} → A c → B c}
-                       → (∀ {q} → is-equiv (f {q}))
-                       → is-equiv {A = ∀ c → A c} {B = ∀ c → B c} (λ g a → f {a} (g a))
+                    {A : C → Type 𝓤} {B : C → Type 𝓥}
+                    {f : ∀ {c} → A c → B c}
+                  → (∀ {q} → is-equiv (f {q}))
+                  → is-equiv {A = ∀ c → A c} {B = ∀ c → B c} (λ g a → f {a} (g a))
 precomp-Π-equiv eq = is-equiv←qiso (precomp-Π-qinv (qiso←is-equiv eq))
 
+precomp-Π-≃ : ∀ {𝓤 𝓥 𝓦} {C : Type 𝓦}
+                {A : C → Type 𝓤} {B : C → Type 𝓥}
+              → (∀ c → A c ≃ B c)
+              → Π C A ≃ Π C B
+precomp-Π-≃ peq = mk≃ _ (precomp-Π-equiv λ {a} → peq a ._≃_.has-is-eqv)
 
 postcomp-qinv : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} {C : Type 𝓦}
              → quasi-iso f → quasi-iso {B = A → C} (_∘ f)

--- a/src/foundations/Coproducts.lagda.tree
+++ b/src/foundations/Coproducts.lagda.tree
@@ -17,6 +17,7 @@ open import foundations.Universes
 % ```
 
 \subtree[stt-002Y]{
+\title{Coproduct types}
 \taxon{definition}
 \meta{defines}{\startverb ["_⊎_"] \stopverb}
 
@@ -29,3 +30,4 @@ data _⊎_ {𝓤 𝓥} (A : Type 𝓤) (B : Type 𝓥) : Type (𝓤 ⊔ 𝓥) wh
 % ```
 
 }
+

--- a/src/foundations/Embedding.lagda.tree
+++ b/src/foundations/Embedding.lagda.tree
@@ -43,8 +43,17 @@ unap : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
 unap emb = is-equiv.bwd emb
 
 _◂emb_  : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
-          → is-embedding f → ∀ {𝓦} {C : Type 𝓦} {g h : C → A} → f ∘ g ~ f ∘ h → g ~ h
+          → is-embedding f → ∀ {𝓦} {C : Type 𝓦} {g h : C → A}
+          → f ∘ g ~ f ∘ h → g ~ h
 (fe ◂emb h) a = unap fe (h a)
+
+embedding≃ : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+               {f : A → B}
+             → is-embedding f
+             → ∀ x y
+             → (f x ＝ f y)
+             ≃ (x ＝ y)
+embedding≃ emb _ _ = mk≃ (unap emb) (is-equiv⁻¹ emb)
 }
 % ```
 }
@@ -59,6 +68,25 @@ _◂emb_  : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
 is-embedding←is-equiv : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
                         → is-equiv f → is-embedding f
 is-embedding←is-equiv {B = B} {f = f} eq {x} {y} = ap-equiv←equiv eq
+
+unap-equiv : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
+       → is-equiv f → ∀ {x y} → f x ＝ f y → x ＝ y
+unap-equiv eq = unap (is-embedding←is-equiv eq)
+
+infixr 32 _◂eqv_
+infixl 33 _▸eqv_
+
+_◂eqv_  : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
+          → is-equiv f → ∀ {𝓦} {C : Type 𝓦} {g h : C → A}
+          → f ∘ g ~ f ∘ h → g ~ h
+fe ◂eqv h = is-embedding←is-equiv fe ◂emb h
+
+_▸eqv_ : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
+          → ∀ {𝓦} {C : Type 𝓦} {g h : B → C}
+          → g ∘ f ~ h ∘ f → is-equiv f →  g ~ h
+(_▸eqv_) {g = g} {h} H fe
+  = (g ◂ ε ~⁻¹) ~∙ H ▸ bwd ~∙ h ◂ ε where open is-equiv fe
+
 }
 % ```
 }
@@ -83,7 +111,7 @@ is-embedding←is-equiv {B = B} {f = f} eq {x} {y} = ap-equiv←equiv eq
 --     = fibre-path→
 --       ( sym (glinv _) ∙ ap g p ∙ glinv _
 --       , ∙-reflr _ ∙ {!!})
-    
+
 --   iso : quasi-iso (ap f)
 --   iso .fst p = sym (glinv _) ∙ ap g p ∙ glinv _
 --   iso .snd .fst refl = ∙-sym' (glinv _)

--- a/src/foundations/Embedding.lagda.tree
+++ b/src/foundations/Embedding.lagda.tree
@@ -59,7 +59,7 @@ embedding≃ emb _ _ = mk≃ (unap emb) (is-equiv⁻¹ emb)
 }
 
 
-\subtree{
+\subtree[stt-006D]{
 \taxon{theorem}
 \title{Equivalences are embeddings}
 

--- a/src/foundations/EquivHomotopy.lagda.tree
+++ b/src/foundations/EquivHomotopy.lagda.tree
@@ -12,6 +12,7 @@ module foundations.EquivHomotopy where
 open import foundations.Universes
 open import foundations.QuasiIsomorphism
 open import foundations.CoherentIsomorphism
+open import foundations.FunctionInverses
 open import foundations.Sigma
 open import foundations.Homotopy
 }
@@ -22,6 +23,20 @@ open import foundations.Homotopy
 
 % ```agda
 \agda{
+homotopy-section : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+                     {f g : A → B}
+                   → (f ~ g)
+                   → section f
+                   → section g
+homotopy-section H (h , sec) = (h , (H ~⁻¹) ▸ h ~∙ sec)
+
+homotopy-retract : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+                     {f g : A → B}
+                   → (f ~ g)
+                   → retract f
+                   → retract g
+homotopy-retract H (h , ret) = (h , h ◂ (H ~⁻¹) ~∙ ret)
+
 homotopy-qiso : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
               → {f g : A → B}
               → (f ~ g)

--- a/src/foundations/EquivOfSingleton.lagda.tree
+++ b/src/foundations/EquivOfSingleton.lagda.tree
@@ -56,7 +56,6 @@ is-equiv←single-to-prop : ∀ {𝓤 𝓥} {A : Type 𝓤} (a-sngl : is-singlet
 is-equiv←single-to-prop sa sb f
   = is-equiv←qiso ( ret .fst , ret .snd , λ _ → sb _ _) where
     ret = retract←singleton-dom sa f
-
 }
 % ```
 }

--- a/src/foundations/EquivOfSingleton.lagda.tree
+++ b/src/foundations/EquivOfSingleton.lagda.tree
@@ -56,6 +56,7 @@ is-equiv←single-to-prop : ∀ {𝓤 𝓥} {A : Type 𝓤} (a-sngl : is-singlet
 is-equiv←single-to-prop sa sb f
   = is-equiv←qiso ( ret .fst , ret .snd , λ _ → sb _ _) where
     ret = retract←singleton-dom sa f
+
 }
 % ```
 }

--- a/src/foundations/Functions.lagda.tree
+++ b/src/foundations/Functions.lagda.tree
@@ -112,6 +112,13 @@ ap-const : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {x y : A} {b}
            → (p : x ＝ y) → ap (λ _ → b) p ＝ refl {_}{B}
 ap-const refl = refl
 
+tr-const : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {x y : A}
+           → (p : x ＝ y)
+           → {b : B}
+           → tr (λ _ → B) p b ＝ b
+tr-const refl = refl
+
+
 ap-id : ∀ {𝓤} {A : Type 𝓤} {x y : A} (p : x ＝ y) → ap id p ＝ p
 ap-id refl = refl
 

--- a/src/foundations/Functions.lagda.tree
+++ b/src/foundations/Functions.lagda.tree
@@ -29,6 +29,9 @@ id a = a
 ev : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : A → Type 𝓥} → (a : A) → Π A B → B a
 ev a f = f a
 
+const : ∀ {𝓤 𝓥} (A : Type 𝓤) (B : Type 𝓥) → A → B → A
+const _ _ a _ = a
+
 infixr 40 _∘_
 _∘_ : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : A → Type 𝓥} {C : {a : A} → B a → Type 𝓦}
       → (f : {a : A} → (b : B a) → C b) → (g : (a : A) → B a) → (a : A) → C (g a)

--- a/src/foundations/Identity.lagda.tree
+++ b/src/foundations/Identity.lagda.tree
@@ -125,6 +125,7 @@ trans refl q = q
 
 _∙_ = trans
 infixr 20 _∙_
+{-# DISPLAY trans = _∙_ #-}
 
 -∙_ : ∀ {𝓤} {A : Type 𝓤} {x y z : A} → y ＝ z → (x ＝ y) ＝ (x ＝ z)
 -∙ p = ap (_ ＝_) p

--- a/src/foundations/Identity.lagda.tree
+++ b/src/foundations/Identity.lagda.tree
@@ -201,6 +201,13 @@ tr-transpose : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥} → ∀ {a 
                → (x : P a) → (y : P b)
                → tr P p x ＝ y → x ＝ tr P (sym p) y
 tr-transpose refl x y p = p
+
+tr-refl : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥}
+          → ∀ {a} (p : a ＝ a)
+              (x : P a)
+            → p ＝ refl
+            → x ＝ tr P p x
+tr-refl p x refl = refl
 }
 % ```
 }

--- a/src/foundations/IdentitySystem.agda
+++ b/src/foundations/IdentitySystem.agda
@@ -129,20 +129,24 @@ is-identity-system←Sing-sing : ∀ {𝓤 𝓥} {A : Type 𝓤} {a₀}
                                 → (R₀ : R a₀)
                                 → is-singleton (Σ[ b ∶ A ] R b)
                                 → is-identity-system-at A a₀ (R , R₀)
-is-identity-system←Sing-sing R R₀ Sing-sing b
-  = is-equiv←qiso the-iso where
+is-identity-system←Sing-sing {a₀ = a₀} R R₀ Sing-sing b
+  = is-equiv←qiso (bwd , the-iso) where
     Sing-recentre : ∀ (p : Σ _ R) → (_ , R₀) ＝ p
     Sing-recentre p = is-prop←is-single Sing-sing _ _
 
     coh : ∀ {𝓤 𝓥} {A : Type 𝓤} {R : A → Type 𝓥} {x y : Σ A R} (p : x ＝ y) →  ap R (Σ-path-fst p) ＝ ap (λ a → R (fst a)) p
     coh refl = refl
 
-    the-iso : quasi-iso (idtoppred (R , R₀) b)
-    the-iso .fst rb = Σ-path-fst (Sing-recentre (_ , rb))
-    the-iso .snd .fst refl = ap Σ-path-fst (is-prop←is-single
-                                            (Singleton-Id Sing-sing _ _)
-                                             _ _)
-    the-iso .snd .snd rb =    happly (ap coe (coh (Sing-recentre (_ , rb)))) R₀ ∙ Σ-path-snd (Sing-recentre (_ , rb))
+    bwd : R b → a₀ ＝ b
+    bwd rb = Σ-path-fst (Sing-recentre (_ , rb))
+
+    abstract
+      the-iso : retract-witness (idtoppred (R , R₀) b) bwd ×
+                section-witness (idtoppred (R , R₀) b) bwd
+      the-iso .fst refl = ap Σ-path-fst (is-prop←is-single
+                                              (Singleton-Id Sing-sing _ _)
+                                               _ _)
+      the-iso .snd rb =    happly (ap coe (coh (Sing-recentre (_ , rb)))) R₀ ∙ Σ-path-snd (Sing-recentre (_ , rb))
 
 
 -- TODO: Find special place for this
@@ -176,7 +180,7 @@ family-equiv←Sing-sing {B = B} {a₀} f H a = homotopy-is-equiv (family~idtopp
 
 ap-equiv←equiv : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} {x y : A} →
                is-equiv f → is-equiv (ap  f)
-ap-equiv←equiv {A = A} {f = f} {x} {y} h = family-equiv←Sing-sing (λ a → ap f) sing y where
+ap-equiv←equiv {A = A} {f = f} {x} {y} h = family-equiv←Sing-sing (λ a → ap f) sing y where abstract
   sing : is-singleton (Σ A (λ z → f x ＝ f z))
   sing = is-single←section-single (total-map (λ a → sym))
                                   ((λ (a , p) → (a , (sym p))) , λ x →  Σ-path→ (refl , sym-sym))

--- a/src/foundations/PathSplit.lagda.tree
+++ b/src/foundations/PathSplit.lagda.tree
@@ -1,0 +1,202 @@
+\date{2025-06-19}
+\title{Pathsplit maps}
+\taxon{module}
+\meta{module}{\startverb foundations.PathSplit \stopverb}
+\author{samueltoth}
+\import{stt-macros}
+
+%```agda
+\agda{
+module foundations.PathSplit where
+
+open import foundations.Universes
+open import foundations.Functions
+open import foundations.FunctionInverses
+open import foundations.Sigma
+open import foundations.Identity
+open import foundations.QuasiIsomorphism
+open import foundations.CoherentIsomorphism
+open import foundations.EquivOfSingleton
+open import foundations.EquivProp
+open import foundations.SingletonClosure
+open import foundations.Singleton
+open import foundations.Embedding
+open import foundations.EquivSingleton
+open import foundations.CanonicalPullbacks
+open import foundations.FibrewiseEquiv
+open import foundations.TheoremOfChoice
+open import foundations.CompositionEquiv
+open import foundations.CurryEquiv
+open import foundations.SigmaProperties
+open import foundations.IdentityEquiv
+open import foundations.PullbackPath
+
+open import foundations.FunExt as FE
+}
+%```
+
+\subtree[stt-005Q]{
+\title{Pathsplit maps}
+\taxon{definition}
+
+\p{A map #{f : A \to B} is \em{pathsplit} when there
+is a section of #{f} and for each #{x, y : A}, there
+is a section of #{\rm{ap}_f^{x,y}}.}
+
+%```agda
+\agda{
+is-pathsplit : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+                 (f : A → B) → Type (𝓤 ⊔ 𝓥)
+is-pathsplit f = section f × (∀ x y → section (ap f {x} {y}))
+}
+%```
+}
+
+\subtree[stt-005R]{
+\title{Pathsplit maps are equivalences}
+\taxon{theorem}
+
+\p{To show a [pathsplit](stt-005Q) map #{f : A \to B},
+is an equivalence, it surfices to give a retract of #{f}.
+We can show that #{fgf = f} where #{g} is the given section,
+and since #{\rm{ap}_f} has a section we derive that #{fg = id}.}
+
+%```agda
+\agda{
+is-equiv←is-pathsplit : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+                           {f : A → B}
+                         → is-pathsplit f
+                         → is-equiv f
+is-equiv←is-pathsplit {f = f} ((g , sec) , apsec)
+  = is-equiv←qiso λ where
+      .fst → g
+      .snd .fst a → apsec _ a .fst (sec (f a))
+      .snd .snd → sec
+}
+%```
+}
+
+\subtree[stt-005S]{
+\title{Being pathsplit is equivalent to being an equivalence}
+\taxon{theorem}
+
+\p{We want to show that the map defined in \ref{stt-005R} is an
+equivalence.}
+
+\proof{
+\p{To show the map is an equivalence, [it suffices](stt-005T)
+to assume the codomain is inhabited. Becuase [being an equivalence
+is a property](stt-001Y), we just need to show that the domain is a
+singleton. Then if the map is already an equivalence,
+[it's type of sections is a singleton](stt-000Q), and it is
+an embedding so the type of sections of #{\rm{ap}} is also a singleton.}
+}
+
+
+%```agda
+\agda{
+module PSWithFunExt (FE : FunExt-global) where
+  is-equiv≃is-pathsplit : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+                             {f : A → B}
+                           → is-pathsplit f
+                           ≃ is-equiv f
+  is-equiv≃is-pathsplit {f = f}
+    = mk≃ is-equiv←is-pathsplit (is-equiv←is-equiv-if-cod (λ
+        e → is-equiv←single-to-prop
+             (Singleton-Σ (section-is-single←qinv FE (qiso←is-equiv e))
+                          λ _ → Singleton-Π FE
+                           λ a → Singleton-Π FE
+                            λ b → section-is-single←qinv FE
+                                   (qiso←is-equiv (is-embedding←is-equiv e)))
+             (is-equiv-is-prop FE) _))
+}
+%```
+}
+
+\subtree[stt-005V]{
+\title{Begin pathsplit is a proposition}
+\taxon{corollary}
+
+\p{Any type equivalent to a proposition is a proposition,
+so from \ref{stt-005S} it follows being pathsplit is a proposition.}
+
+%```agda
+  \agda{
+  is-pathsplit-is-prop : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+                           {f : A → B}
+                         → is-prop (is-pathsplit f)
+  is-pathsplit-is-prop = is-prop←equiv-to-prop
+                             (is-equiv≃is-pathsplit e⁻¹)
+                             (is-equiv-is-prop FE)
+  }
+%```
+}
+
+\subtree[stt-005U]{
+\title{Pathsplitness via the diagonal}
+\taxon{theorem}
+\p{The type \code{is-pathsplit f} is equivalent to the type
+#{\rm{section}(f) \times \rm{section}(\Delta_f)}, where #{f}
+is the [diagonal map](stt-005X) associated to a pullback.}
+
+\proof{
+\p{We show #{\rm{section}(\Delta_f) \simeq \Pi_{(x,y : A)}\rm{section}(\rm{ap}_{x,y}(f))}
+by calculation:}
+
+##{
+\begin{align*}
+  \rm{section}(\Delta_f) &\simeq
+    \Sigma_{(g : A \times_B A \to A)} \Pi_{(x : A \times_B A)} (g(x), g(x), \refl) = x\\
+  &\simeq \Pi_{(x, y : A)} \Pi_{(p : x = y)} \Sigma_{a : A} (a , a , \refl) = (x, y, p) \\
+  &\simeq \Pi_{(x, y : A)} \Pi_{(p : x = y)} \Sigma_{a : A}
+    \Sigma_{(q : a ＝ x)} \Sigma_{(r : a = y)} (\rm{ap}_f(q) \cdot p = \rm{ap}_f(r)) \\
+  &\simeq \Pi_{(x, y : A)} \Pi_{(p : x = y)}
+          \Sigma_{(r : a = y)} (p = \rm{ap}_f(r)) \\
+  &\simeq \Pi_{(x, y: A)} \rm{section}(\rm{ap}_f)
+\end{align*}
+}
+}
+
+%```agda
+\agda{
+  is-pathsplit≃sec-diag
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+        {f : A → B}
+      → (section f × section (diagonal f)) ≃ is-pathsplit f
+  is-pathsplit≃sec-diag {A = A}{f = f} = Σ-ap-≃ λ a
+    → section (diagonal f) ≃⟨⟩
+      Σ[ g ∶ (Pullback f f → A)] (∀ pb → (g pb , g pb , refl) ＝ pb)
+
+         ≃⟨ Σ-Π-swap≃ _ (λ pb a → (a , a , refl) ＝ pb) e⁻¹  ⟩
+
+      ((x : Pullback f f) → Σ[ a ∶ A ] ((a , a , refl) ＝ x))
+
+          ≃⟨ precomp-Π-≃ FE(λ c → Σ-ap-≃ (λ _ → pullback-path _ _)) ⟩
+
+      (∀ (x : Pullback f f) → Σ[ a ∶ A ] pullback-Path (a , a , refl) x)
+
+         ≃⟨ curry≃ ⟩
+
+      (∀ x (y : Σ _ (λ v₁ → f x ＝ f v₁)) →
+        Σ[ a ∶ A ] pullback-Path (a , a , refl) (x , y))
+
+         ≃⟨ precomp-Π-≃ FE (λ c → curry≃) ⟩
+
+      (∀ x y (p : f x ＝ f y) →
+          Σ[ z ∶ A ] Σ[ P ∶ (z ＝ x)] Σ[ Q ∶ (z ＝ y)]
+            ((ap f P) ∙ p ＝ ap f Q))
+
+          ≃⟨ precomp-Π-≃ FE (λ _ → precomp-Π-≃ FE λ _
+              → precomp-Π-≃ FE λ c → Σ-＝singl) ⟩
+
+      ((x y : A) (p : f x ＝ f y) → (Σ[ Q ∶ (x ＝ y)] (p ＝ ap f Q)))
+
+        ≃⟨ precomp-Π-≃ FE (λ _ →
+             precomp-Π-≃ FE (λ _ →
+               Σ-Π-swap≃ _ _ ∙≃ Σ-ap-≃ (λ _ → precomp-Π-≃ FE (λ _ → sym≃)))) ⟩
+
+      (∀ x y → section (ap f)) ≃∎
+
+}
+%```
+}

--- a/src/foundations/PathSplit.lagda.tree
+++ b/src/foundations/PathSplit.lagda.tree
@@ -57,7 +57,7 @@ is-pathsplit f = section f × (∀ x y → section (ap f {x} {y}))
 \taxon{theorem}
 
 \p{To show a [pathsplit](stt-005Q) map #{f : A \to B},
-is an equivalence, it surfices to give a retract of #{f}.
+is an equivalence, it suffices to give a retract of #{f}.
 We can show that #{fgf = f} where #{g} is the given section,
 and since #{\rm{ap}_f} has a section we derive that #{fg = id}.}
 
@@ -142,7 +142,7 @@ so from \ref{stt-005S} it follows being pathsplit is a proposition.}
 \title{Pathsplitness via the diagonal}
 \taxon{theorem}
 \p{The type \code{is-pathsplit f} is equivalent to the type
-#{\rm{section}(f) \times \rm{section}(\Delta_f)}, where #{f}
+#{\rm{section}(f) \times \rm{section}(\Delta_f)}, where #{\Delta_f}
 is the [diagonal map](stt-005X) associated to a pullback.}
 
 \proof{

--- a/src/foundations/PathSplit.lagda.tree
+++ b/src/foundations/PathSplit.lagda.tree
@@ -109,6 +109,12 @@ module PSWithFunExt (FE : FunExt-global) where
                             λ b → section-is-single←qinv FE
                                    (qiso←is-equiv (is-embedding←is-equiv e)))
              (is-equiv-is-prop FE) _))
+
+  is-pathsplit←is-equiv : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+                            {f : A → B}
+                          → is-equiv f
+                          → is-pathsplit f
+  is-pathsplit←is-equiv = _≃_.bwd is-equiv≃is-pathsplit
 }
 %```
 }
@@ -205,6 +211,13 @@ by calculation:}
       → is-pathsplit f
   is-pathsplit←sec-diag sec secd = sec ,
     _≃_.fwd is-pathsplit≃sec-diag (sec , secd) .snd
+
+  sec-diag←is-pathsplit
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+        {f : A → B}
+      → is-pathsplit f
+      → section (diagonal f)
+  sec-diag←is-pathsplit = snd ∘ _≃_.bwd is-pathsplit≃sec-diag
 }
 %```
 }

--- a/src/foundations/PathSplit.lagda.tree
+++ b/src/foundations/PathSplit.lagda.tree
@@ -197,6 +197,14 @@ by calculation:}
 
       (∀ x y → section (ap f)) ≃∎
 
+  is-pathsplit←sec-diag
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+        {f : A → B}
+      → section f
+      → section (diagonal f)
+      → is-pathsplit f
+  is-pathsplit←sec-diag sec secd = sec ,
+    _≃_.fwd is-pathsplit≃sec-diag (sec , secd) .snd
 }
 %```
 }

--- a/src/foundations/Prelude.agda
+++ b/src/foundations/Prelude.agda
@@ -10,6 +10,7 @@ open import foundations.Unit public
 open import foundations.UnitUP public
 open import foundations.Empty public
 open import foundations.Nat public
+open import foundations.Coproducts public
 open import foundations.Identity public
 open import foundations.Singleton public
 open import foundations.Functions public
@@ -37,3 +38,5 @@ open import foundations.Span public hiding (Cocone-path→)
 open import foundations.3for2 public
 open import foundations.Pullbacks public
 open import foundations.CanonicalPullbacks public
+open import foundations.PullbackPath public
+open import foundations.PathSplit public

--- a/src/foundations/PropClosure.lagda.tree
+++ b/src/foundations/PropClosure.lagda.tree
@@ -22,6 +22,12 @@ open import foundations.FunExt
 %```
 
 
+\subtree[stt-006M]{
+\taxon{theorem}
+\title{Prop is closed under #{\Pi} and #{\Sigma}}
+
+\p{Prop is closed under #{\Sigma} and, under the assumption
+of [function extensionality](stt-0024), #{\Pi}.}
 
 %```agda
 \agda{
@@ -38,3 +44,4 @@ is-prop-Π : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : A → Type 𝓥}
 is-prop-Π FE pb x y = WithFunExtω.funext→ FE λ a → pb a (x a) (y a)
 }
 %```
+}

--- a/src/foundations/PropClosure.lagda.tree
+++ b/src/foundations/PropClosure.lagda.tree
@@ -1,0 +1,40 @@
+\date{2025-06-21}
+\title{Closure properties of propsitions}
+\taxon{module}
+\meta{module}{\startverb foundations.PropClosure \stopverb}
+\author{samueltoth}
+\import{stt-macros}
+
+%```agda
+\agda{
+module foundations.PropClosure where
+
+open import foundations.Universes
+open import foundations.Functions
+open import foundations.FunctionInverses
+open import foundations.Singleton
+open import foundations.Sigma
+open import foundations.SigmaPath
+open import foundations.Identity
+open import foundations.DependentIdentity
+open import foundations.FunExt
+}
+%```
+
+
+
+%```agda
+\agda{
+is-prop-Σ : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : A → Type 𝓥}
+            → is-prop A
+            → (∀ a → is-prop (B a))
+            → is-prop (Σ A B)
+is-prop-Σ {B = B} sa sb (a , x) (b , y) = Σ-path→ (sa a b  , sb b _ y)
+
+is-prop-Π : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : A → Type 𝓥}
+            → FunExtω 𝓥
+            → (∀ a → is-prop (B a))
+            → is-prop (Π A B)
+is-prop-Π FE pb x y = WithFunExtω.funext→ FE λ a → pb a (x a) (y a)
+}
+%```

--- a/src/foundations/PullbackPath.lagda.tree
+++ b/src/foundations/PullbackPath.lagda.tree
@@ -9,10 +9,17 @@
 
 % ```agda
 \agda{
-module core.PullbackPath where
+module foundations.PullbackPath where
 
-open import foundations.Prelude
-open import ergonomics.Extensionality
+open import foundations.Universes
+open import foundations.Identity
+open import foundations.Sigma
+open import foundations.SigmaPath
+open import foundations.CoherentIsomorphism
+open import foundations.IdentityEquiv
+open import foundations.FibrewiseEquiv
+open import foundations.SigmaProperties
+open import foundations.CanonicalPullbacks
 }
 % ```
 

--- a/src/foundations/Pullbacks.lagda.tree
+++ b/src/foundations/Pullbacks.lagda.tree
@@ -15,6 +15,9 @@ open import foundations.Span
 open import foundations.Functions
 open import foundations.Homotopy
 open import foundations.CoherentIsomorphism
+open import foundations.Sigma
+open import foundations.Identity
+open import foundations.Unit
 }
 % ```
 
@@ -76,3 +79,20 @@ is-pullbackω S C = ∀ {𝓠} (Q : Type 𝓠) → is-equiv (cone-map S C {Q})
 
 
 
+\subtree[stt-006K]{
+\date{2025-06-26}
+\title{Identity types are pullbacks}
+\taxon{example}
+
+%```agda
+\agda{
+Identity-pullback : ∀ {𝓤} {A : Type 𝓤} {x y : A}
+                    → is-pullbackω (mk-cospan _ (const A 𝟙 x) (const A 𝟙 y))
+                                   (mk-cone ! ! id)
+Identity-pullback Q = is-equiv←qiso λ where
+  .fst (mk-cone i j filler) q → filler q
+  .snd .fst a → refl
+  .snd .snd (mk-cone i j filler) → refl
+}
+%```
+}

--- a/src/foundations/SigmaProperties.lagda.tree
+++ b/src/foundations/SigmaProperties.lagda.tree
@@ -145,13 +145,19 @@ fibre-straighten P x = equiv←qiso lem where
   lem ._≅_.fwd-iso .snd .fst (_ , refl) = refl
   lem ._≅_.fwd-iso .snd .snd a = refl
 
+singleton-fst-is-equiv : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥}
+              → (∀ x → is-singleton (P x))
+              → is-equiv (fst {B = P})
+singleton-fst-is-equiv {P = P} sngl
+  = is-equiv←is-contr-map λ
+      b → is-single←equiv-to-single (fibre-straighten P b e⁻¹) (sngl b)
+
+
 Σ-singleton : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥}
               → (∀ x → is-singleton (P x))
               → Σ A P ≃ A
 Σ-singleton {P = P} sngl
-  = mk≃ fst
-        (is-equiv←is-contr-map
-          (λ b → is-single←equiv-to-single (fibre-straighten P b e⁻¹) (sngl b)))
+  = mk≃ fst (singleton-fst-is-equiv sngl)
 }
 % ```
 }

--- a/src/foundations/Square.lagda.tree
+++ b/src/foundations/Square.lagda.tree
@@ -79,16 +79,26 @@ IdP-func←Square : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
                   → IdP (ap (λ x → f x ＝ g x) p) q r
 IdP-func←Square refl p q r = sym (r ∙ ∙-reflr _)
 
+
+Square←brt＝l : ∀ {𝓤} {A : Type 𝓤}
+         → {a00 a01 a10 a11 : A}
+         → (ai0 : a00 ＝ a10)
+         → {ai1 : a01 ＝ a11}
+         → {a0i : a00 ＝ a01}
+         → {a1i : a10 ＝ a11}
+         → ai0 ∙ a1i ∙ sym ai1 ＝ a0i
+         → Square ai0 ai1 a0i a1i
+Square←brt＝l refl {refl} {refl} p = sym (∙-reflr _) ∙ p
+
 Square-drop-i : ∀ {𝓤} {A : Type 𝓤}
                 → {a b : A}
                 → (p : a ＝ b)
                 → Square p p refl refl
 Square-drop-i refl = refl
 
-         
 
 SquareP : ∀ {𝓤} {A B C D : Type 𝓤}
-          {ab : A ＝ B} {cd : C ＝ D} {ac : A ＝ C} {bd : B ＝ D} 
+          {ab : A ＝ B} {cd : C ＝ D} {ac : A ＝ C} {bd : B ＝ D}
           (S : Square ab cd ac bd)
           {s00 : A} {s10 : B} {s01 : C} {s11 : D}
           → (si0 : IdP ab s00 s10)

--- a/src/foundations/TheoremOfChoice.lagda.tree
+++ b/src/foundations/TheoremOfChoice.lagda.tree
@@ -31,7 +31,7 @@ open import foundations.Identity
 \agda{
 
 Σ-Π-swap : ∀ {𝓤 𝓥 𝓦} {X : Type 𝓤} (A : X → Type 𝓥) (P : (x : X) → A x → Type 𝓦)
-         → ((x : X) → Σ[ a ∶ A x ] P x a) → (Σ[ f ∶ ((x : X) → A x) ] ∀ (x : X) → P x (f x)) 
+         → ((x : X) → Σ[ a ∶ A x ] P x a) → (Σ[ f ∶ ((x : X) → A x) ] ∀ (x : X) → P x (f x))
 Σ-Π-swap _ _ f = (fst ∘ f , snd ∘ f)
 
 
@@ -44,8 +44,35 @@ open import foundations.Identity
   lem .snd .snd _ = refl
 
 Σ-Π-swap≃ : ∀ {𝓤 𝓥 𝓦} {X : Type 𝓤} (A : X → Type 𝓥) (P : (x : X) → A x → Type 𝓦)
-         → ((x : X) → Σ[ a ∶ A x ] P x a) ≃ (Σ[ f ∶ ((x : X) → A x) ] ∀ (x : X) → P x (f x)) 
+         → ((x : X) → Σ[ a ∶ A x ] P x a) ≃ (Σ[ f ∶ ((x : X) → A x) ] ∀ (x : X) → P x (f x))
 Σ-Π-swap≃ A P = mk≃ (Σ-Π-swap A P) Σ-Π-swap-is-equiv 
 
 }
 % ```
+
+
+\subtree[stt-0061]{
+\date{2025-06-19}
+\title{Sections from inhabited fibres}
+\taxon{corolary}
+
+\p{Suppose you have a map #{f : A \to B}, with #{\Pi_{b : B}\fibre{f}{B}},
+then #{f} has a section. In fact, these types are equivelent.}
+
+
+%```agda
+\agda{
+section←fibres : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+                 → (f : A → B)
+                 → ((b : B) → fibre f b)
+                 → section f
+section←fibres f = Σ-Π-swap _ _
+
+section≃fibres :  ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
+                 → (f : A → B)
+                 → ((b : B) → fibre f b)
+                 ≃ section f
+section≃fibres f = Σ-Π-swap≃ _ _
+}
+%```
+}

--- a/src/foundations/UnitUP.lagda.tree
+++ b/src/foundations/UnitUP.lagda.tree
@@ -37,6 +37,8 @@ unit-ev-is-equiv = is-equiv←qiso iso where
 unit-UP≃ : ∀ {𝓤} {A : Type 𝓤} → (𝟙 → A) ≃ A
 unit-UP≃ = mk≃ (ev tt) unit-ev-is-equiv
 
+unit-const-is-equiv : ∀ {𝓤} {A : Type 𝓤} → is-equiv (const A 𝟙)
+unit-const-is-equiv = is-equiv⁻¹ unit-ev-is-equiv
 }
 % ```
 

--- a/src/modalities/Subuniverses.lagda.tree
+++ b/src/modalities/Subuniverses.lagda.tree
@@ -11,6 +11,9 @@ module modalities.Subuniverses where
 
 open import foundations.Prelude
 open import ufAxioms
+open import modalities.HigherModality
+open import core.Postwhisker
+open import core.PiSection
 }
 % ```
 
@@ -31,7 +34,7 @@ SubU 𝓤 𝓥 = Subtype (Type 𝓤) 𝓥
 
 \subtree[stt-0040]{
 \title{Reflector}
-\taxon{defintion}
+\taxon{definition}
 \meta{defines}{\startverb ["Reflector", "Reflector.○", "Reflector.○∈S",
                            "Reflector.η-○", "Reflector.reflects", "mk-rfltor"] \stopverb}
 \p{Given a subuniverse #{S} of #{\UU}, we say that a type #{A : \UU} has a reflection
@@ -40,16 +43,35 @@ into a type in #{S} factors through #{\eta}.}
 
 % ```agda
 \agda{
-record Reflector {𝓤 𝓥} (S : SubU 𝓤 𝓥) (A : Type 𝓤) : Type (lsuc 𝓤 ⊔ 𝓥) where
+record is-reflector
+        {𝓤 𝓥} (S : SubU 𝓤 𝓥)
+        (A : Type 𝓤) (○A : Type 𝓤)
+        (η : A → ○A) : Type (lsuc 𝓤 ⊔ 𝓥) where
+  constructor mk-is-rfltor
+  field
+    ○∈S : ○A ∈ S
+    reflects : ∀ {C : Type 𝓤} → C ∈ S → is-equiv (postcomp C η)
+
+  ○-elim : ∀ {C : Type 𝓤} → C ∈ S → (A → C) → (○A → C)
+  ○-elim cs = is-equiv.bwd (reflects cs)
+
+  ○-elim-β : ∀ {C : Type 𝓤} (p : C ∈ S) (f : A → C)
+             → ○-elim p f ∘ η ~ f
+  ○-elim-β p f a = happly (is-equiv.ε (reflects p) f) a
+
+  module ∈S▸η {C : Type 𝓤} {g h} (C∈S : C ∈ S)
+    = is-equiv (postwhisker-is-equiv←ap-compose {A = A} {g = g}{h}
+                         (is-embedding←is-equiv (reflects C∈S)))
+
+record Reflector {𝓤 𝓥} (S : SubU 𝓤 𝓥)
+              (A : Type 𝓤) : Type (lsuc 𝓤 ⊔ 𝓥) where
   constructor mk-rfltor
   field
-    {○} : Type 𝓤
-    ○∈S : ○ ∈ S
-    ○-η : A → ○
-    reflects : ∀ {C : Type 𝓤} → C ∈ S → is-equiv (postcomp C ○-η)
+    ○ : Type 𝓤
+    η : A → ○
+    has-is-reflector : is-reflector S A ○ η
 
-  ○-elim : ∀ {C : Type 𝓤} → C ∈ S → (A → C) → (○ → C)
-  ○-elim cs = is-equiv.bwd (reflects cs)
+  open is-reflector has-is-reflector public
 }
 % ```
 }
@@ -67,16 +89,16 @@ is a theorem.}
 in-subU←η-is-equiv : ∀ {𝓤 𝓥} {S : SubU 𝓤 𝓥}
                        {A : Type 𝓤}
                      → (RA : Reflector S A)
-                     → is-equiv (RA .Reflector.○-η)
+                     → is-equiv (RA .Reflector.η)
                      → A ∈ S
 in-subU←η-is-equiv {S = S} RA eq
   = tr (_∈ S)
-       (ua (mk≃ ○-η eq e⁻¹))
+       (ua (mk≃ η eq e⁻¹))
        ○∈S where open Reflector RA
 }
 % ```
 
-\p{We can also show that for any type in #{S}, #{\eta_\circ} has a retract}
+\p{We can also show that a type is in #{S} iff #{\eta_\circ} has a retract}
 
 % ```agda
 \agda{
@@ -84,35 +106,89 @@ in-subU←η-is-equiv {S = S} RA eq
                        {A : Type 𝓤}
                        (RA : Reflector S A)
                        → A ∈ S
-                       → retract (RA .Reflector.○-η)
+                       → retract (RA .Reflector.η)
 η-has-retract←in-subU RA a∈S = (bwd id , happly (ε id)) where
   open Reflector RA
   open is-equiv (reflects a∈S)
+
+η-is-equiv←retract : ∀ {𝓤 𝓥} {S : SubU 𝓤 𝓥}
+                         {A : Type 𝓤}
+                         (RA : Reflector S A)
+                       → retract (RA .Reflector.η)
+                       → is-equiv (RA .Reflector.η)
+η-is-equiv←retract RA (f , ret)
+  = is-equiv←qiso
+      ( f
+      , ret
+      , ∈S▸η.bwd ○∈S (η ◂ ret)) where open Reflector RA
+
+in-subU←η-retract : ∀ {𝓤 𝓥} {S : SubU 𝓤 𝓥}
+                       {A : Type 𝓤}
+                       (RA : Reflector S A)
+                       → retract (RA .Reflector.η)
+                       → A ∈ S
+in-subU←η-retract RA ρ = in-subU←η-is-equiv RA (η-is-equiv←retract RA ρ)
 }
 % ```
-
 }
+
 
 \subtree[stt-0041]{
 \title{Reflective subuniverse}
 \taxon{definition}
-\meta{defines}{\startverb ["is-reflective", "mk-reflective", "is-reflective.has-reflectors"] \stopverb}
+\meta{defines}{\startverb ["Reflective", "mk-reflective", "is-reflective.has-reflectors"] \stopverb}
 \p{A subuniverse is reflective if it has all reflectors.}
 
 % ```agda
 \agda{
-record is-reflective {𝓤 𝓥} (S : SubU 𝓤 𝓥) : Type (lsuc 𝓤 ⊔ 𝓥) where
+record Reflective {𝓤 𝓥} (S : SubU 𝓤 𝓥) : Type (lsuc 𝓤 ⊔ 𝓥) where
   constructor mk-reflective
   field
-    has-reflectors : ∀ A → Reflector S A
+    ○ : Type 𝓤 → Type 𝓤
+    η : ∀ {A} → A → ○ A
+    has-is-reflector : ∀ {A} → is-reflector S A (○ A) η
 
-  module ○ {A} = Reflector (has-reflectors A)
-  open ○ public hiding (○)
+  module R {A} = is-reflector (has-is-reflector {A})
+  open R public
 
-  ○ : Type 𝓤 → Type 𝓤
-  ○ A = has-reflectors A .Reflector.○
+  module ▸η {A} {B} {g h}
+    = is-equiv (postwhisker-is-equiv←ap-compose {g = g}{h}
+                         (is-embedding←is-equiv (reflects {A = B} (○∈S {A}))))
+
+  reflector : ∀ (A : Type 𝓤) → Reflector S A
+  reflector A = mk-rfltor (○ A) η has-is-reflector
+
 }
 % ```
+}
+
+\subtree[stt-006L]{
+\date{2025-06-25}
+\title{Modal types are closed under Identity}
+\taxon{lemma}
+
+%```agda
+\agda{
+
+η＝-retract : ∀ {𝓤 𝓥} {A : Type 𝓤}
+                {x y : A}
+                {S : SubU 𝓤 𝓥}
+                (RS : Reflective S)
+              → A ∈ S
+              → retract (Reflective.η RS {x ＝ y})
+η＝-retract RS a = (∈S▸η.bwd a id , happly (∈S▸η.ε a id)) where open Reflective RS
+
+is-modal-＝ : ∀ {𝓤 𝓥} {A : Type 𝓤}
+                {x y : A}
+                {S : SubU 𝓤 𝓥}
+                (RS : Reflective S)
+              → A ∈ S
+              → (x ＝ y) ∈ S
+is-modal-＝ {A = A}{x}{y} RS a
+  = in-subU←η-retract (reflector (x ＝ y)) (η＝-retract RS a) where
+  open Reflective RS
+}
+%```
 }
 
 \subtree[stt-004U]{
@@ -130,6 +206,94 @@ is-Σ-closed : ∀ {𝓤 𝓥} (S : SubU 𝓤 𝓥) → Type _
 is-Σ-closed {𝓤} S = ∀ {A : Type 𝓤} {B : A → Type 𝓤}
                        → A ∈ S → (∀ a → B a ∈ S)
                        → (Σ[ a ∶ A ] B a) ∈ S
+}
+%```
+}
+
+
+
+\subtree[stt-006F]{
+\taxon{theorem}
+\date{2025-06-25}
+\title{Sigma closed reflective subuniverses are higher modalities}
+
+\p{Every #{\Sigma}-closed reflective subuniverse
+#{(S, \bigcirc, \eta)} gives rise to a higher modality}
+
+\proof{
+\p{We have the data of the modal operator and unit, as well as the fact that
+modal types are closed under Identity, so we just need to show that this data
+satisfies the modal induction principal for [higher modalities](stt-000G).}
+
+\p{Let #{P : \bigcirc A \to \UU} and #{f : \Pi_{(x : A)} \bigcirc P(\eta(x))},
+then to define a map #{\Pi_{(x : \bigcirc A)} \bigcirc P(x)}, [it suffices](stt-006J)
+to define a section of #{\pi : \Sigma_{(x : \bigcirc A)} \bigcirc P(x) \to \bigcirc
+A}.}
+
+\p{Because #{S} is closed under #{\Sigma} types, we can use the universal property
+of the reflector at #{A} to define a map
+#{\bar{f} : \bigcirc A \to \Sigma_{(x : \bigcirc A)} \bigcirc P(x)} just by it's action
+on #{\eta(x)} for #{x : A}. This map (denoted #{f}), is given by #{\eta(x) \mapsto (\eta(x), f(x))}.}
+
+\p{To show that #{\bar{f}} is indeed a section, we first note that
+the universal property of the reflector gives us #{\pi \bar{f} \eta \sim \eta}.
+Then because postcomposition by #{\eta} at a modal type is an equivalence,
+[so is postwhiskering](stt-006I) by #{\eta} (assuming funext), thus we can apply the
+inverse map to get a homotopy #{\pi \bar{f} \sim \id}.}
+}
+
+%```agda
+\agda{
+HigherModality←Σ-ref-SubU
+  : ∀ {𝓤 𝓥} {S : SubU 𝓤 𝓥} (Sref : Reflective S)
+      (SΣ : is-Σ-closed S)
+    → HigherModality 𝓤
+HigherModality←Σ-ref-SubU {𝓤} {S = S} rfl cls
+  = mod where
+  open HigherModality
+  module S = Reflective rfl
+
+  f'' : ∀ {A : Type 𝓤}
+          (P : S.○ A → Type 𝓤)
+        → (Π A (S.○ ∘ P ∘ S.η))
+        → A → Σ (S.○ A) (S.○ ∘ P)
+  f'' P f a = (S.η a , f a)
+
+  f' : ∀ {A : Type 𝓤}
+          (P : S.○ A → Type 𝓤)
+        → (Π A (S.○ ∘ P ∘ S.η))
+        → S.○ A → Σ (S.○ A) (S.○ ∘ P)
+  f' P f = S.○-elim (cls S.○∈S λ _ → S.○∈S)
+                 (f'' P f)
+  secη : ∀ {A : Type 𝓤}
+          {P : S.○ A → Type 𝓤}
+          {f : Π A (S.○ ∘ P ∘ S.η)}
+        → fst ∘ f' P f ∘ S.η ~ S.η
+  secη = fst ◂ S.○-elim-β _ _
+
+  sec : ∀ {A : Type 𝓤}
+          (P : S.○ A → Type 𝓤)
+        → (Π A (S.○ ∘ P ∘ S.η))
+        → section (fst {B = S.○ ∘ P})
+  sec {A} P f = (f' P f , S.▸η.bwd secη)
+
+  mod : HigherModality 𝓤
+  mod .○_ A = S.○ A
+  mod .○-η = S.η
+  mod .○-ind P f = Π←section (sec P f)
+  mod .○-β P f a
+    = tr (S.○ ∘ P) (S.▸η.bwd secη (S.η a)) (snd (f' P f (S.η a)))
+         ＝⟨ ap (λ p → tr (S.○ ∘ P) p (snd (f' P f (S.η a)))) (happly (S.▸η.ε secη) a) ⟩
+      tr (S.○ ∘ P) (ap fst (S.○-elim-β _ (f'' P f) a)) (snd (f' P f (S.η a)))
+         ＝⟨ ap (λ p → coe p (snd (f' P f (S.η a)))) (sym (ap-∘ (S.○ ∘ P) fst _)) ⟩
+      tr (S.○ ∘ P ∘ fst) (S.○-elim-β _ (f'' P f) a) (snd (f' P f (S.η a)))
+         ＝⟨ apᵈ snd (S.○-elim-β _ (f'' P f) a) ⟩
+      snd (f'' P f a)
+         ＝⟨⟩
+      f a ∎
+  mod .＝-○-is-○-modal = η-is-equiv←retract
+                          (S.reflector _)
+                          (η＝-retract rfl S.○∈S)
 }
 %```
 }

--- a/src/modalities/Subuniverses.lagda.tree
+++ b/src/modalities/Subuniverses.lagda.tree
@@ -39,7 +39,8 @@ SubU 𝓤 𝓥 = Subtype (Type 𝓤) 𝓥
                            "Reflector.η-○", "Reflector.reflects", "mk-rfltor"] \stopverb}
 \p{Given a subuniverse #{S} of #{\UU}, we say that a type #{A : \UU} has a reflection
 if there is a type #{○ A} in #{S} and a map #{\eta_○ : A \to \circ A} such that any map from #{A}
-into a type in #{S} factors through #{\eta}.}
+into a type in #{S} factors through #{\eta}. This final condition can be stated by
+asking postcomposition by #{\eta} to be an equivalence for all types in #{S}.}
 
 % ```agda
 \agda{
@@ -233,7 +234,7 @@ A}.}
 \p{Because #{S} is closed under #{\Sigma} types, we can use the universal property
 of the reflector at #{A} to define a map
 #{\bar{f} : \bigcirc A \to \Sigma_{(x : \bigcirc A)} \bigcirc P(x)} just by it's action
-on #{\eta(x)} for #{x : A}. This map (denoted #{f}), is given by #{\eta(x) \mapsto (\eta(x), f(x))}.}
+on #{\eta(x)} for #{x : A}. This map, is given by #{\eta(x) \mapsto (\eta(x), f(x))}.}
 
 \p{To show that #{\bar{f}} is indeed a section, we first note that
 the universal property of the reflector gives us #{\pi \bar{f} \eta \sim \eta}.

--- a/src/modalities/instances/Localisation.lagda.tree
+++ b/src/modalities/instances/Localisation.lagda.tree
@@ -229,6 +229,22 @@ module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
 }
 
 
+\subtree[stt-006C]{
+\date{2025-06-23}
+\taxon{theorem}
+\title{A partial universal property for Free Algebraic Injectives}
+
+\p{The Free Algebraic Injective type former is the left
+adjoint to the forgetfull functor from Algabraic injectives on #{\SS} to #{\SS}.
+So far, we have shied away from formalising this full universal property,
+but it is easier to formalise if we restrict to the category of #{f\rm{-local}}
+types.}
+
+\p{For an #{f\rm{-local}} type #{Y}, and any type #{X},
+   the map #{- \circ \eta : (\mathcal{J}_f(X) \to Y) \to (X \to Y)}
+   is an equivalence.
+   }
+
 %```agda
 \agda{
 postcomp-inj : ∀ {𝓘 𝓤 𝓥 𝓦 𝓜}
@@ -239,29 +255,73 @@ postcomp-inj : ∀ {𝓘 𝓤 𝓥 𝓦 𝓜}
                  → (Free-inj f X → Y)
                  → (X → Y)
 postcomp-inj X {Y} = postcomp Y Free-inj.inc
+}
+%```
+\proof{
 
-Local-reflects : ∀ {𝓘 𝓤 𝓥 𝓦 𝓜}
+\p{To prove this, we use [pathsplit](stt-005Q) as our notion of equivalence.
+   So we have to give a section to #{(- \circ \eta)} and to #{\rm{ap}_{- \circ \eta}^{g,h}} for any pair of maps #{g, h : \mathcal{J}_f(X) \to Y}.
+   }
+
+%```agda
+\agda{
+Free-inj-reflects : ∀ {𝓘 𝓤 𝓥 𝓦 𝓜}
                    {I : Type 𝓘} {A : I → Type 𝓤}
                    {B : I → Type 𝓥}
                  {f : (i : I) → A i → B i}
                  (X : Type 𝓦) {Y : Type 𝓜}
                → is-local f Y
                → is-equiv (postcomp-inj {f = f} X {Y})
-Local-reflects {I = I} {A}{B}{f} X {Y} Y-loc
+Free-inj-reflects {I = I} {A}{B}{f} X {Y} Y-loc
   = is-equiv←is-pathsplit ps where
   module Y {i} = is-equiv (Y-loc i)
+}
+%```
 
-  -- RHS (2.8) from RSS modalities
-  lem : (g h : Free-inj f X → Y)
-     (i : I)
-     (g' : A i → Free-inj _ X)
-     (q : g ∘ g' ~ h ∘ g') →
-     postcomp Y (f i) (g ∘ Free-inj.ext g') ~
-     postcomp Y (f i) (h ∘ Free-inj.ext g')
-  lem g h i g' K =      g ◂ (Free-inj.is-ext g')
-                     ~∙ K
-                     ~∙ (h ◂ Free-inj.is-ext g' ~⁻¹)
+\p{In the first case, the section of #{(- \circ \eta)} is relatively trivial
+to construct. To do so, we are given a map #{g : X \to Y} and need to construct
+one #{\mathcal{J}_f(X) \to Y}. We induct on the free algebraic injective:}
 
+\ol{
+\li{case \strong{inc}: We need a map #{X \to Y}, which is given by #{g}.
+     The map we are constructing needs to be a section of #{- \circ \eta},
+     but the computation rule says that #{\rm{ind}(g,..)(\eta(x)) = g(x)},
+     and thus our map is a section by definition.
+     }
+\li{case \strong{ext}: For all #{f' : A_i \to \mathcal{J}_f(X)} we need
+    a map #{(A_i \to Y) \to (B_i \to Y)} which is equal to #{f'} under
+    postcomposition by #{f}. This map is obtained by the fact that #{Y}
+    is #{f}-local.}
+}
+
+
+%```agda
+\agda{
+  sec-postcomp-inj : section (postcomp-inj X)
+  sec-postcomp-inj .fst g = Free-inj.ind
+                     (λ _ → Y)
+                     g
+                     (λ _ → Y.bwd)
+                     λ g' h a → tr-const (Free-inj.is-ext g' a)
+                                ∙ happly (Y.ε h) a
+  sec-postcomp-inj .snd h = refl
+}
+%```
+
+\p{Now we fix a pair of maps #{g, h : \mathcal{J}_f(X) \to Y}, and
+give a section to #{\rm{ap}_{- \circ  \eta}^{g,h} : g = h \to g\eta = h\eta}.}
+
+\p{Firstly we note generally that for any map #{f : A \to B},
+and maps #{g, h : B \to C}
+we can construct a map #{g \sim h \to gf \sim hf} by \em{postwhiskering} by
+#{f}. We can also construct an [equivalence of arrows](stt-004R) between
+this map and #{\rm{ap}_{- \circ f}} using function extensionality.}
+
+\p{Applying this observation to #{- \circ \eta}, [it suffices](stt-0069)
+then to give a section to the map by \em{postwhiskering} with #{\eta}.}
+
+%```agda
+\agda{
   postwhisker : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
                   (X : Type 𝓦) (f : A → B)
                 → ∀ {g h : B → X} → (g ~ h)
@@ -286,7 +346,15 @@ Local-reflects {I = I} {A}{B}{f} X {Y} Y-loc
                   → is-Arrow-equiv (amap f g h)
   amap-is-equiv .fst = global-funext
   amap-is-equiv .snd = global-funext
+}
+%```
 
+\p{Because every [equivalence is an embedding](stt-006D), we have that
+#{ap_{-\circ f_i}^{g,h}} is an equivalence, and so by the observation above
+#{- ▸ f : g \sim h \to gf_i \sim hf_i} is also an equivalence.}
+
+%```agda
+\agda{
   opaque
     Y▸-is-equiv : ∀ {i g h} → is-equiv (postwhisker Y (f i) {g} {h})
     Y▸-is-equiv {i} = is-equiv←Arrow-equiv {F = amap _ _ _}
@@ -295,6 +363,80 @@ Local-reflects {I = I} {A}{B}{f} X {Y} Y-loc
 
 
   module Y▸ {i g h} = is-equiv (Y▸-is-equiv {i} {g} {h})
+}
+%```
+
+\p{Now, we are ready to construct the section. Given #{H : g\eta \sim h\eta}
+we want to show for all #{x : \mathcal{J}_f(X)}, #{g(x) = h(x)}, which
+we do again by induction on #{x} with the motive #{x \mapsto g(x) = h(x)}.}
+
+\ol{
+\li{case \strong{inc}: We require #{g\eta \sim h\eta}, so as above, we can supply
+     the #{H} in the hypothesis. As above, the #{\beta} rule for HITs means, that
+     the map we are constructing will be a definitional section of postwhiskering
+     by #{\eta}.}
+\li{case \strong{ext}: Now, for any #{f' : A_i \to \mathcal{J}_f(X)},
+     we need to give a map #{f'' : gf' \sim hf' \to g\rm{ext}(f') \sim h\rm{ext}(f')},
+     such that for any #{(K : gf' \sim hf')}, #{f''(K)f_i =_{x ↦ g(x) = h(x)}^{\rm{is-ext}_{f'}} K}
+     (N.B. #{\rm{ext}(f') : B_i \to \mathcal{J}_f(X)})
+
+     \p{For the map in question, we take:
+       ##{(K : gf' \sim hf') \mapsto
+         (- ▸ f_f)^{-1}(g(\rm{is-ext}_{f'}) \cdot K \cdot h(\rm{is-ext}_{f'})^{-1})}
+      }
+
+      \p{Unfolding #{f''(K)f_i =_{x ↦ g(x) = h(x)}^{\rm{is-ext}_{f'}} K},
+         we find that we need to give a witness to the following square:
+         }
+
+      \quiver{
+        \begin{tikzcd}
+	{gf'} && {g\textrm{ext}_{f'}f_i} \\
+	\\
+	{hf'} && {h\textrm{ext}_{f'}f_i}
+	\arrow["{g(\textrm{is-ext}_{f'})^{-1}}", no head, from=1-1, to=1-3]
+	\arrow["{K}"', no head, from=1-1, to=3-1]
+	\arrow["{(- \blacktriangleright f')^{-1}(f''(K))f_i}", no head, from=1-3, to=3-3]
+	\arrow["{h(\textrm{is-ext}_{f'})}^{-1}"', no head, from=3-1, to=3-3]
+        \end{tikzcd}
+      }
+
+      \p{But now we have the postwhiskering applied to the inverse of postwhiskering
+         on the right hand side. Once this is eliminated, and #{f''} is unfolded,
+         we get:}
+
+      \quiver{
+        \begin{tikzcd}
+	{gf'} && {g\rm{ext}_{f'}f_i} && {gf'} \\
+	\\
+	{hf'} && {h\rm{ext}_{f'}f_i} && {hf'}
+	\arrow["{g(\textrm{is-ext}_{f'})^{-1}}", no head, from=1-1, to=1-3]
+	\arrow["K"', no head, from=1-1, to=3-1]
+	\arrow["{g(\textrm{is-ext}_{f'})}", no head, from=1-3, to=1-5]
+	\arrow[""{name=0, anchor=center, inner sep=0}, "{(- \blacktriangleright f')^{-1}(f''(K))f_i}"{description}, no head, from=1-3, to=3-3]
+	\arrow[""{name=1, anchor=center, inner sep=0}, "K", no head, from=1-5, to=3-5]
+	\arrow["{h(\textrm{is-ext}_{f'})^{-1}}"', no head, from=3-1, to=3-3]
+	\arrow["{h(\textrm{is-ext}_{f'})}"', no head, from=3-3, to=3-5]
+	\arrow["\epsilon"{pos=0.7}, shorten <=41pt, shorten >=14pt, Rightarrow, from=0, to=1]
+        \end{tikzcd}
+      }
+
+      \p{and this square clearly commutes.}
+     }
+}
+
+%```agda
+\agda{
+  -- RHS (2.8) from RSS modalities
+  lem : (g h : Free-inj f X → Y)
+     (i : I)
+     (g' : A i → Free-inj _ X)
+     (q : g ∘ g' ~ h ∘ g') →
+     postcomp Y (f i) (g ∘ Free-inj.ext g') ~
+     postcomp Y (f i) (h ∘ Free-inj.ext g')
+  lem g h i g' K =      g ◂ (Free-inj.is-ext g')
+                     ~∙ K
+                     ~∙ (h ◂ Free-inj.is-ext g' ~⁻¹)
 
   secAp : ∀ (g h : Free-inj f X → Y)
           → section (postwhisker Y Free-inj.inc {g} {h})
@@ -318,18 +460,12 @@ Local-reflects {I = I} {A}{B}{f} X {Y} Y-loc
   secAp g h .snd K = refl
 
   ps : is-pathsplit (postcomp-inj X)
-  -- The section for postcomp is easy
-  ps .fst .fst g = Free-inj.ind
-                     (λ _ → Y)
-                     g
-                     (λ _ → Y.bwd)
-                     λ g' h a → tr-const (Free-inj.is-ext g' a)
-                                ∙ happly (Y.ε h) a
-  ps .fst .snd h = refl
-  -- Proof for second part (section of ap) at page 2:34
+  ps .fst = sec-postcomp-inj
   ps .snd g h = section←Arrow-equiv⁻¹ {F = amap _ _ _} amap-is-equiv (secAp g h)
 }
 %```
+}
+}
 
 \subtree[stt-0065]{
 \date{2025-06-21}
@@ -359,7 +495,7 @@ Null∙-reflective a .is-reflective.has-reflectors A .Reflector.○∈S
 Null∙-reflective a .is-reflective.has-reflectors A .Reflector.○-η
   = Free-inj.inc
 Null∙-reflective a .is-reflective.has-reflectors A .Reflector.reflects
-  cnull = Local-reflects _ (is-local←is-null cnull)
+  cnull = Free-inj-reflects _ (is-local←is-null cnull)
 }
 %```
 }
@@ -386,6 +522,7 @@ is-local∇←is-local f {X} eq = equiv←Coslice-equiv
 
 \subtree[stt-0066]{
 \title{Localisation is a [reflective subuniverse](stt-0041)}
+\taxon{corollary}
 
 \p{Localisation at any family of maps forms a reflective subuniverse
 which is not in general #{\Sigma}-closed.}
@@ -407,8 +544,6 @@ module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
 
 
 
-  -- This is RSS lemma 2.7: Should extract to it's own tree probably
-
   Local-reflective
     : (f : (i : I) → A i → B i)
     → is-reflective (Local-SubU f)
@@ -416,7 +551,7 @@ module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
   Local-reflective f .has-reflectors A .○∈S = Loc-is-local
   Local-reflective f .has-reflectors A .○-η = Free-inj.inc
   Local-reflective f .has-reflectors A .reflects cloc
-    = Local-reflects _ λ where
+    = Free-inj-reflects _ λ where
       (left i) → cloc i
       (right i) → is-local∇←is-local (f i) (cloc i)
 }

--- a/src/modalities/instances/Localisation.lagda.tree
+++ b/src/modalities/instances/Localisation.lagda.tree
@@ -194,12 +194,12 @@ sec∇←is-local loc i = sec←sec-Coslice-equiv
 
 \p{Unlike in the case of [nullification](stt-005K), we cannot
 in general expect the family of functions against which we are
-localising to all have sections. As such the [Free algabraicly injective](stt-005I)
+localising to all have sections, and so the [Free algabraicly injective](stt-005I)
 type will not get us all the way to a localisation.}
 
 
-\p{As explained in \citet{2.14}{rijkeMod2020}, even though the free algabraicly
-#{f}-injective type is not a localisation, we can add some morphisms to the class
+\p{As explained in \citet{2.14}{rijkeMod2020}, even though
+we don't immediately get a localisation, we can add some morphisms to the class
 with which we localise against to make it so. By the observation in \ref{stt-005Z},
 we need to add all maps of the form #{\nabla_{f_i}} to #{f}.}
 
@@ -243,8 +243,8 @@ module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
 
 \p{The Free Algebraic Injective type former is the left
 adjoint to the forgetful functor from Algabraic injectives on #{\SS} to #{\SS}.
-So far, we have shied away from formalising this full universal property,
-but it is easier to formalise if we restrict to the category of #{f\rm{-local}}
+In this formalisaton we have shied away from formalising this full universal property,
+but we now formalise the (easier) restriction to the category of #{f\rm{-local}}
 types.}
 
 \p{For an #{f\rm{-local}} type #{Y}, and any type #{X},
@@ -318,16 +318,12 @@ one #{\mathcal{J}_f(X) \to Y}. We induct on the free algebraic injective:}
 \p{Now we fix a pair of maps #{g, h : \mathcal{J}_f(X) \to Y}, and
 give a section to #{\rm{ap}_{- \circ  \eta}^{g,h} : g = h \to g\eta = h\eta}.}
 
-\todo{Have refactored this to \ref{stt-006G}}
-
-\p{Firstly we note generally that for any map #{f : A \to B},
-and maps #{g, h : B \to C}
-we can construct a map #{g \sim h \to gf \sim hf} by \em{postwhiskering} by
-#{f}. We can also construct an [equivalence of arrows](stt-004R) between
-this map and #{\rm{ap}_{- \circ f}} using function extensionality.}
-
-\p{Applying this observation to #{- \circ \eta}, [it suffices](stt-0069)
-then to give a section to the map by \em{postwhiskering} with #{\eta}.}
+\p{[We can construct](stt-006I) an [equivalence of arrows](stt-004R) between
+[postwhiskering](stt-006G) by #{\eta} and #{\rm{ap}_{- \circ \eta}}
+using function extensionality. As a result, [it suffices](stt-0069)
+then to give a section to the map by \em{postwhiskering} with #{\eta}.
+By the same result, we note that because postcomposition by #{f_i} at #{Y}
+is an equivalence, then so is the postwhiskering by #{f_i} at maps #{B_i \to Y}}
 
 %```agda
 \agda{
@@ -401,7 +397,6 @@ we do again by induction on #{x} with the motive #{x \mapsto g(x) = h(x)}.}
 
 %```agda
 \agda{
-  -- RHS (2.8) from RSS modalities
   lem : (g h : Free-inj f X → Y)
      (i : I)
      (g' : A i → Free-inj _ X)
@@ -477,6 +472,22 @@ Null∙-reflective a .Reflective.has-is-reflector
 \taxon{theorem}
 \date{2025-06-25}
 \title{Nullfication is a #{\Sigma}-closed reflective subuniverse}
+
+
+\proof{
+\p{By calculation:}
+
+##{
+\begin{align}
+  \Sigma_{(x : X)} Y(x)  &\simeq \Sigma_{(x : X)} A_i \to Y(x) \\
+                         &\simeq \Sigma_{(x : A_i \to X)} \Pi_{(a : A_i)} Y(f(a))\\
+                         &\simeq A_i \to \Sigma_{(x : X)} Y(x)
+\end{align}
+}
+
+\p{Where (1) and (2) follow from the fact #{X} and each #{Y(x)} are #{A}-[null](stt-005G),
+and (3) is the [type theoretic theorem of choice](foundations.TheoremOfChoice).}
+}
 
 %```agda
 \agda{

--- a/src/modalities/instances/Localisation.lagda.tree
+++ b/src/modalities/instances/Localisation.lagda.tree
@@ -18,6 +18,7 @@ open import core.Codiagonal
 open import core.CoSlice
 open import core.Arrow
 open import core.ArrowEquiv
+open import core.Postwhisker
 open import ergonomics.notations.Orthogonality
 open import modalities.HigherModality
 open import modalities.Subuniverses
@@ -68,6 +69,12 @@ is-null-is-prop
   : ∀ {𝓘 𝓤 𝓥} {I : Type 𝓘} {A : I → Type 𝓤}
     → ∀ (X : Type 𝓥) → is-prop (is-null A X)
 is-null-is-prop X = is-prop-Π λ a → is-equiv-is-prop
+
+null≃ : ∀ {𝓘 𝓤 𝓥} {I : Type 𝓘} {A : I → Type 𝓤}
+          {X : Type 𝓥} (_ : is-null A X) i
+        → X
+        ≃ (A i → X)
+null≃ {A = A}{X} An i = mk≃ (const X (A i)) (An i)
 }
 %```
 }
@@ -235,7 +242,7 @@ module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
 \title{A partial universal property for Free Algebraic Injectives}
 
 \p{The Free Algebraic Injective type former is the left
-adjoint to the forgetfull functor from Algabraic injectives on #{\SS} to #{\SS}.
+adjoint to the forgetful functor from Algabraic injectives on #{\SS} to #{\SS}.
 So far, we have shied away from formalising this full universal property,
 but it is easier to formalise if we restrict to the category of #{f\rm{-local}}
 types.}
@@ -311,6 +318,8 @@ one #{\mathcal{J}_f(X) \to Y}. We induct on the free algebraic injective:}
 \p{Now we fix a pair of maps #{g, h : \mathcal{J}_f(X) \to Y}, and
 give a section to #{\rm{ap}_{- \circ  \eta}^{g,h} : g = h \to g\eta = h\eta}.}
 
+\todo{Have refactored this to \ref{stt-006G}}
+
 \p{Firstly we note generally that for any map #{f : A \to B},
 and maps #{g, h : B \to C}
 we can construct a map #{g \sim h \to gf \sim hf} by \em{postwhiskering} by
@@ -322,47 +331,12 @@ then to give a section to the map by \em{postwhiskering} with #{\eta}.}
 
 %```agda
 \agda{
-  postwhisker : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
-                  (X : Type 𝓦) (f : A → B)
-                → ∀ {g h : B → X} → (g ~ h)
-                → g ∘ f ~ h ∘ f
-  postwhisker X f = _▸ f
-
-  amap : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
-            {C : Type 𝓦}
-           (f : A → B)
-           (g h : B → C)
-         → Arrow-map
-              (ap (postcomp C f) {g} {h})
-              (postwhisker C f {g} {h})
-  amap _ _ _ .Arrow-map.top = happly
-  amap _ _ _ .Arrow-map.bot = happly
-  amap _ _ _ .Arrow-map.comm refl = refl
-
-  amap-is-equiv : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
-                    {C : Type 𝓦}
-                    {f : A → B}
-                    {g h : B → C}
-                  → is-Arrow-equiv (amap f g h)
-  amap-is-equiv .fst = global-funext
-  amap-is-equiv .snd = global-funext
-}
-%```
-
-\p{Because every [equivalence is an embedding](stt-006D), we have that
-#{ap_{-\circ f_i}^{g,h}} is an equivalence, and so by the observation above
-#{- ▸ f : g \sim h \to gf_i \sim hf_i} is also an equivalence.}
-
-%```agda
-\agda{
   opaque
-    Y▸-is-equiv : ∀ {i g h} → is-equiv (postwhisker Y (f i) {g} {h})
-    Y▸-is-equiv {i} = is-equiv←Arrow-equiv {F = amap _ _ _}
-                                   amap-is-equiv
-                               (is-embedding←is-equiv (Y-loc i))
+    Y▸-is-equiv : ∀ {i} {g h : B i → Y} → is-equiv (postwhisker (f i) g h)
+    Y▸-is-equiv {i} = postwhisker-is-equiv←ap-compose
+      (is-embedding←is-equiv (Y-loc i))
 
-
-  module Y▸ {i g h} = is-equiv (Y▸-is-equiv {i} {g} {h})
+  module Y▸ {i} {g h} = is-equiv (Y▸-is-equiv {i} {g} {h})
 }
 %```
 
@@ -439,7 +413,7 @@ we do again by induction on #{x} with the motive #{x \mapsto g(x) = h(x)}.}
                      ~∙ (h ◂ Free-inj.is-ext g' ~⁻¹)
 
   secAp : ∀ (g h : Free-inj f X → Y)
-          → section (postwhisker Y Free-inj.inc {g} {h})
+          → section (postwhisker Free-inj.inc g h)
   secAp g h .fst H
     = Free-inj.ind (λ z → g z ＝ h z)
         H
@@ -461,7 +435,8 @@ we do again by induction on #{x} with the motive #{x \mapsto g(x) = h(x)}.}
 
   ps : is-pathsplit (postcomp-inj X)
   ps .fst = sec-postcomp-inj
-  ps .snd g h = section←Arrow-equiv⁻¹ {F = amap _ _ _} amap-is-equiv (secAp g h)
+  ps .snd g h = section←Arrow-equiv⁻¹ {F = postwhisker←ap-compose _ _ _ }
+                                      postwhisker-funext(secAp g h)
 }
 %```
 }
@@ -487,18 +462,42 @@ Null∙-reflective
   : ∀ {𝓘 𝓤} {I : Type 𝓘}
       {A : I → Type 𝓤}
       (a∙ : ∀ i → A i)
-    → is-reflective (Null∙-SubU a∙)
-Null∙-reflective a .is-reflective.has-reflectors A .Reflector.○
-  = Null∙ _ a A
-Null∙-reflective a .is-reflective.has-reflectors A .Reflector.○∈S
-  = Null∙-is-null a
-Null∙-reflective a .is-reflective.has-reflectors A .Reflector.○-η
-  = Free-inj.inc
-Null∙-reflective a .is-reflective.has-reflectors A .Reflector.reflects
-  cnull = Free-inj-reflects _ (is-local←is-null cnull)
+    → Reflective (Null∙-SubU a∙)
+Null∙-reflective a .Reflective.○ = Null∙ _ a
+Null∙-reflective a .Reflective.η = Free-inj.inc
+Null∙-reflective a .Reflective.has-is-reflector
+  .is-reflector.○∈S = Null∙-is-null a
+Null∙-reflective a .Reflective.has-is-reflector
+  .is-reflector.reflects cnull = Free-inj-reflects _ (is-local←is-null cnull)
 }
 %```
 }
+
+\subtree[stt-006E]{
+\taxon{theorem}
+\date{2025-06-25}
+\title{Nullfication is a #{\Sigma}-closed reflective subuniverse}
+
+%```agda
+\agda{
+Null∙-Σ-closed : ∀ {𝓘 𝓤} {I : Type 𝓘}
+                   {A : I → Type 𝓤}
+                   (a : Π _ A)
+                 → is-Σ-closed (Null∙-SubU a)
+Null∙-Σ-closed {A = A} a∙ {A = X} {Y} Xnull Ynull i
+  = I ._≃_.has-is-eqv where
+  I : Σ X Y ≃ (A i → Σ X Y)
+  I = Σ X Y
+        ≃⟨ Σ-ap-≃ (λ x → null≃ (Ynull x) i) ⟩
+      Σ X (λ x → A i → Y x)
+        ≃⟨ Σ-ap-≃-fst {B = λ f → (a : A i) → Y (f a)} (null≃ Xnull i)  ⟩
+      Σ (A i → X) (λ f → (a : A i) → Y (f a))
+        ≃⟨ Σ-Π-swap≃ (λ _ → X) (λ _ → Y) e⁻¹ ⟩
+      (A i → Σ X Y) ≃∎
+}
+%```
+}
+
 
 \subtree[stt-006A]{
 \date{2025-06-23}
@@ -532,8 +531,8 @@ which is not in general #{\Sigma}-closed.}
 module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
          {A : I → Type 𝓤} {B : I → Type 𝓤}
          where
-  open is-reflective
-  open Reflector
+  open Reflective
+  open is-reflector
 
   Local-SubU
     : (f : (i : I) → A i → B i)
@@ -546,11 +545,11 @@ module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
 
   Local-reflective
     : (f : (i : I) → A i → B i)
-    → is-reflective (Local-SubU f)
-  Local-reflective f .has-reflectors A .Reflector.○ = Loc f A
-  Local-reflective f .has-reflectors A .○∈S = Loc-is-local
-  Local-reflective f .has-reflectors A .○-η = Free-inj.inc
-  Local-reflective f .has-reflectors A .reflects cloc
+    → Reflective (Local-SubU f)
+  Local-reflective f .○ = Loc f
+  Local-reflective f .η = Free-inj.inc
+  Local-reflective f .has-is-reflector .○∈S = Loc-is-local
+  Local-reflective f .has-is-reflector .reflects cloc
     = Free-inj-reflects _ λ where
       (left i) → cloc i
       (right i) → is-local∇←is-local (f i) (cloc i)

--- a/src/modalities/instances/Localisation.lagda.tree
+++ b/src/modalities/instances/Localisation.lagda.tree
@@ -10,8 +10,10 @@
 module modalities.instances.Localisation where
 
 open import ufAxioms
+open import axioms.FreeAlgInj
 open import foundations.Prelude
 open import core.Orthogonal
+open import core.CanonicalPushouts
 open import ergonomics.notations.Orthogonality
 open core.Orthogonal.notation
 }
@@ -79,4 +81,99 @@ is-null←is-local : ∀ {𝓘 𝓤 𝓥} {I : Type 𝓘} {A : I → Type 𝓤}
 is-null←is-local eq i = is-equiv-∘ (eq i) unit-const-is-equiv
 }
 %```
+}
+
+\subtree[stt-005K]{
+\title{Nullfication at an pointed family}
+\taxon{definition}
+
+\p{The nullification of a pointed type can be constructed
+using the [free algabraic injection](stt-005I)
+higher inductive type. By definition, the free
+algabraic injection already gives a section to
+the precomposition map. Because any map #{A \to 1}
+has a section, then the precomposition by this
+map already has a retract, and so the type is not just
+algabraicly #{A}-injective, but #{A}-null.}
+
+%```agda
+\agda{
+Null∙ : ∀ {𝓘 𝓤 𝓥} {I : Type 𝓘} (A : I → Type 𝓤)
+         (A∙ : Π _ A) (X : Type 𝓥)
+       → Type 𝓥
+Null∙ A _ X = Free-inj
+               (λ i → ! {A = A i})
+                X
+
+Null∙-is-null : ∀ {𝓘 𝓤 𝓥} {I : Type 𝓘}
+                 {A : I → Type 𝓤} {A∙ : Π _ A}
+                 {X : Type 𝓥}
+               → is-null A (Null∙ A A∙ X)
+Null∙-is-null {A∙ = a} = is-null←is-local I where
+  I : is-local (λ _ → !) _
+  I i = is-equiv←qiso λ where
+    .fst → injector-Free-inj i .fst
+    .snd .fst α → funext→ (λ _ → Free-inj.is-ext (α ∘ !) (a i))
+    .snd .snd → injector-Free-inj i .snd
+}
+%```
+}
+
+
+\subtree[stt-005Z]{
+\taxon{lemma}
+\title{Locality via sections of the codiagonal}
+\citet{rijkeMod2020}{2.13}
+
+\p{Given maps #{f_i : A_i \to B_i}, a type #{X} is #{f\rm{-local}}
+iff #{-\circ f_i} and #{-\circ \nabla_f_i} all have sections.}
+
+%```agda
+\agda{
+}
+%```
+}
+
+\subtree[stt-005Y]{
+\title{Localisation}
+\taxon{definition}
+
+\p{Unlike in the case of [nullification](stt-005K), we cannot
+in general expect the family of functions against which we are
+localising to all have sections. As such the [Free algabraicly injective](stt-005I)
+type will not get us all the way to a localisation.}
+
+
+\p{As explained in \citet{2.14}{rijkeMod2020}, even though the free algabraicly
+#{f}-injective type is not a localisation, we can add some morphisms to the class
+with which we localise against to make it so. By the observation in \ref{stt-005Z},
+we need to add all maps of the form #{\nabla_f_i} to #{f}.}
+
+%```agda
+\agda{
+
+module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
+         {A : I → Type 𝓤} {B : I → Type 𝓤}
+         where
+  private
+    A' : (f : ∀ i → A i → B i) → I ⊎ I → Type 𝓤
+    A' f (left i) = A i
+    A' f (right i) = Pushout (f i) (f i)
+
+    B' : (f : ∀ i → A i → B i) → I ⊎ I → Type 𝓤
+    B' f (left i)  = B i
+    B' f (right i) = B i
+
+    f' : (f : ∀ i → A i → B i) → (i : I ⊎ I) → A' f i → B' f i
+    f' f (left i) = f i
+    f' f (right i) = ∇ (f i)
+
+  Loc : (f : ∀ i → A i → B i) → Type 𝓦 → Type 𝓦
+  Loc f = Free-inj (f' f)
+
+  Loc-is-local : ∀ {X : Type 𝓦}
+                   {f : ∀ i → A i → B i}
+                 → is-local f (Loc f X)
+  Loc-is-local = {!is-local←sec-∇ !}
+}
 }

--- a/src/modalities/instances/Localisation.lagda.tree
+++ b/src/modalities/instances/Localisation.lagda.tree
@@ -1,0 +1,82 @@
+\date{2025-06-17}
+\title{Localisations}
+\taxon{module}
+\meta{module}{\startverb modalities.instances.Localisation \stopverb}
+\author{samueltoth}
+\import{stt-macros}
+
+%```agda
+\agda{
+module modalities.instances.Localisation where
+
+open import ufAxioms
+open import foundations.Prelude
+open import core.Orthogonal
+open import ergonomics.notations.Orthogonality
+open core.Orthogonal.notation
+}
+%```
+
+\subtree[stt-005F]{
+\taxon{definition}
+\title{Local types}
+
+\p{Given a family of maps #{f_i : A_i \to B_i}, we say that a type
+is #{f}-local if it is [orthogonal](stt-004O) to each map.}
+
+%```agda
+\agda{
+is-local : ∀ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤} {B : I → Type 𝓥}
+               → (f : (i : I) → A i → B i)
+               → Type 𝓦
+               → Type (𝓘 ⊔ 𝓤 ⊔ 𝓥 ⊔ 𝓦)
+is-local f A = ∀ i → orthogonal-type (f i) A
+}
+%```
+}
+
+
+\subtree[stt-005G]{
+\taxon{definition}
+\title{Null types}
+
+\p{Given a family of types #{A_i}, we say a type #{X} is #{A} null if
+it is right orthogonal to each #{A_i}. Or equivalently, if the
+obvious maps #{X \to (A_i \to X)} are equivalences for each #{i}.}
+
+%```agda
+\agda{
+is-null : ∀ {𝓘 𝓤 𝓥} {I : Type 𝓘} (A : I → Type 𝓤)
+            → Type 𝓥 → Type (𝓘 ⊔ 𝓤 ⊔ 𝓥)
+is-null A X = ∀ i → is-equiv (const X (A i))
+}
+%```
+}
+
+\subtree[stt-005H]{
+\taxon{theorem}
+\title{Null types are #{!\rm{-local}}}
+
+\p{A type is #{A_i}-null iff it is #{(! : A_i \to 1)\rm{-local}}.}
+
+\proof{
+\p{A type #{X} is #{!\rm{-local}} when the map #{- \circ\ ! : (1 \to X) \to (A_i \to X)}
+is an equivalence.}
+}
+
+%```agda
+\agda{
+is-local←is-null : ∀ {𝓘 𝓤 𝓥} {I : Type 𝓘} {A : I → Type 𝓤}
+                   → {X : Type 𝓥}
+                   → is-null A X
+                   → is-local (λ i → ! {A = A i}) X
+is-local←is-null eq i = 3-for-2' (is-equiv⁻¹ unit-ev-is-equiv) (eq i)
+
+is-null←is-local : ∀ {𝓘 𝓤 𝓥} {I : Type 𝓘} {A : I → Type 𝓤}
+                   → {X : Type 𝓥}
+                   → is-local (λ i → ! {A = A i}) X
+                   → is-null A X
+is-null←is-local eq i = is-equiv-∘ (eq i) unit-const-is-equiv
+}
+%```
+}

--- a/src/modalities/instances/Localisation.lagda.tree
+++ b/src/modalities/instances/Localisation.lagda.tree
@@ -17,6 +17,8 @@ open import core.CanonicalPushouts
 open import core.Codiagonal
 open import core.CoSlice
 open import ergonomics.notations.Orthogonality
+open import modalities.HigherModality
+open import modalities.Subuniverses
 open core.Orthogonal.notation
 }
 %```
@@ -35,6 +37,12 @@ is-local : ∀ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤} {B : 
                → Type 𝓦
                → Type (𝓘 ⊔ 𝓤 ⊔ 𝓥 ⊔ 𝓦)
 is-local f A = ∀ i → orthogonal-type (f i) A
+
+is-local-is-prop
+  : ∀ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤} {B : I → Type 𝓥}
+      {f : (i : I) → A i → B i}
+    → ∀ (A : Type 𝓦) → is-prop (is-local f A)
+is-local-is-prop A = is-prop-Π λ i → is-equiv-is-prop
 }
 %```
 }
@@ -148,6 +156,20 @@ is-local←sec←sec-∇ sec sec∇ i
           (Δ←∇ _ _)
           Δ←∇-is-equiv
           (sec∇ i)))
+
+
+sec∇←is-local
+  : ∀ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘}
+      {A : I → Type 𝓤} {B : I → Type 𝓥}
+      {f : (i : I) → A i → B i}
+      {X : Type 𝓦}
+    → is-local f X
+    → ∀ i → section (postcomp X (∇ (f i)))
+sec∇←is-local loc i = sec←sec-Coslice-equiv
+                        (Δ←∇ _ _)
+                        Δ←∇-is-equiv
+                        (sec-diag←is-pathsplit
+                          (is-pathsplit←is-equiv (loc i)))
 }
 %```
 }
@@ -196,4 +218,121 @@ module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
                    (λ i → injector-Free-inj (left i))
                    (λ i → injector-Free-inj (right i))
 }
+%```
+}
+
+\subtree[stt-0065]{
+\date{2025-06-21}
+\title{Nullification is a [higher modality](stt-000G)}
+\taxon{theorem}
+
+
+%```agda
+\agda{
+Null∙-HigherModality
+  : ∀ {𝓘 𝓤} {I : Type 𝓘}
+      {A : I → Type 𝓤}
+      (a∙ : ∀ i → A i)
+      𝓥
+    → HigherModality 𝓥
+Null∙-HigherModality a 𝓥 = hm where
+  open HigherModality
+
+  hm : HigherModality 𝓥
+  ○ hm = Null∙ _ a
+  hm .○-η = Free-inj.inc
+  hm .○-ind P f = {!!}
+  hm .○-β = {!!}
+  hm .＝-○-is-○-modal = {!!}
+}
+%```
+}
+
+
+\subtree[stt-0066]{
+\title{Localisation is a [reflective subuniverse](stt-0041)}
+
+\p{Localisation at any family of maps forms a reflective subuniverse
+which is not in general #{\Sigma}-closed.}
+
+%```agda
+\agda{
+module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
+         {A : I → Type 𝓤} {B : I → Type 𝓤}
+         where
+  open is-reflective
+  open Reflector
+
+  Local-SubU
+    : (f : (i : I) → A i → B i)
+      → SubU 𝓦 (𝓘 ⊔ 𝓤 ⊔ 𝓦)
+  Local-SubU f = mk-subtype
+                         {family = is-local f}
+                         is-local-is-prop
+
+  postcomp-inj : ∀ {𝓜}
+                   {f : (i : I) → A i → B i}
+                   (X : Type 𝓦) {Y : Type 𝓜}
+                 → (Free-inj f X → Y)
+                 → (X → Y)
+  postcomp-inj X {Y} = postcomp Y Free-inj.inc
+
+
+  -- This is RSS lemma 2.7: Should extract to it's own tree probably
+  Local-reflects : ∀ {𝓜}
+                   {f : (i : I) → A i → B i}
+                   (X : Type 𝓦) {Y : Type 𝓜}
+                 → is-local f Y
+                 → is-equiv (postcomp-inj {f = f} X {Y})
+  Local-reflects {_}{f} X {Y} Y-loc = is-equiv←is-pathsplit ps where
+    module Y {i} = is-equiv (Y-loc i)
+    module ∘Y {i g h} where
+      abstract
+        e : is-equiv (ap (postcomp Y (f i)) {g} {h})
+        e = (is-embedding←is-equiv (Y-loc i))
+      open is-equiv e public
+
+    -- RHS (2.8) from RSS modalities
+    lem : (g h : Free-inj f X → Y)
+       (p : postcomp-inj X g ＝ postcomp-inj X h) (i : I)
+       (g' : A i → Free-inj _ X)
+       (x : g ∘ g' ~ h ∘ g') →
+       postcomp Y (f i) (g ∘ Free-inj.ext g') ＝
+       postcomp Y (f i) (h ∘ Free-inj.ext g')
+    lem g h p i g' q = funext→ λ a → ap g (Free-inj.is-ext g' a)
+                                   ∙ q a
+                                   ∙ ap h (sym (Free-inj.is-ext g' a))
+
+    ps : is-pathsplit (postcomp-inj X)
+    -- The section for postcomp is easy
+    ps .fst .fst g = Free-inj.ind
+                       (λ _ → Y)
+                       g
+                       (λ _ → Y.bwd)
+                       λ g' h a → tr-const (Free-inj.is-ext g' a)
+                                  ∙ happly (Y.ε h) a
+    ps .fst .snd h = refl
+    -- Proof for second part (section of ap) at page 2:34
+    ps .snd g h .fst p
+      = funext→ (Free-inj.ind
+                  (λ z → g z ＝ h z)
+                  (happly p)
+                  (λ g' x → happly
+                    (∘Y.bwd (lem g h p _ g' x)))
+                  λ g' H a → IdP-func←Square {f = g} {h}
+                                              (Free-inj.is-ext g' a)
+                                              _
+                                              (H a)
+                                              {!!})
+    ps .snd g h .snd p = {!!}
+
+  Local-reflective
+    : (f : (i : I) → A i → B i)
+    → is-reflective (Local-SubU f)
+  Local-reflective f .has-reflectors A .Reflector.○ = Loc f A
+  Local-reflective f .has-reflectors A .○∈S = Loc-is-local
+  Local-reflective f .has-reflectors A .○-η = Free-inj.inc
+  Local-reflective f .has-reflectors A .reflects = {!!}
+}
+%```
 }

--- a/src/modalities/instances/Localisation.lagda.tree
+++ b/src/modalities/instances/Localisation.lagda.tree
@@ -16,6 +16,8 @@ open import core.Orthogonal
 open import core.CanonicalPushouts
 open import core.Codiagonal
 open import core.CoSlice
+open import core.Arrow
+open import core.ArrowEquiv
 open import ergonomics.notations.Orthogonality
 open import modalities.HigherModality
 open import modalities.Subuniverses
@@ -61,6 +63,11 @@ obvious maps #{X \to (A_i \to X)} are equivalences for each #{i}.}
 is-null : ∀ {𝓘 𝓤 𝓥} {I : Type 𝓘} (A : I → Type 𝓤)
             → Type 𝓥 → Type (𝓘 ⊔ 𝓤 ⊔ 𝓥)
 is-null A X = ∀ i → is-equiv (const X (A i))
+
+is-null-is-prop
+  : ∀ {𝓘 𝓤 𝓥} {I : Type 𝓘} {A : I → Type 𝓤}
+    → ∀ (X : Type 𝓥) → is-prop (is-null A X)
+is-null-is-prop X = is-prop-Π λ a → is-equiv-is-prop
 }
 %```
 }
@@ -116,10 +123,10 @@ Null∙ A _ X = Free-inj
                 X
 
 Null∙-is-null : ∀ {𝓘 𝓤 𝓥} {I : Type 𝓘}
-                 {A : I → Type 𝓤} {A∙ : Π _ A}
+                 {A : I → Type 𝓤} (A∙ : Π _ A)
                  {X : Type 𝓥}
                → is-null A (Null∙ A A∙ X)
-Null∙-is-null {A∙ = a} = is-null←is-local I where
+Null∙-is-null a = is-null←is-local I where
   I : is-local (λ _ → !) _
   I i = is-equiv←qiso λ where
     .fst → injector-Free-inj i .fst
@@ -221,33 +228,161 @@ module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
 %```
 }
 
+
+%```agda
+\agda{
+postcomp-inj : ∀ {𝓘 𝓤 𝓥 𝓦 𝓜}
+                   {I : Type 𝓘} {A : I → Type 𝓤}
+                   {B : I → Type 𝓥}
+                   {f : (i : I) → A i → B i}
+                   (X : Type 𝓦) {Y : Type 𝓜}
+                 → (Free-inj f X → Y)
+                 → (X → Y)
+postcomp-inj X {Y} = postcomp Y Free-inj.inc
+
+Local-reflects : ∀ {𝓘 𝓤 𝓥 𝓦 𝓜}
+                   {I : Type 𝓘} {A : I → Type 𝓤}
+                   {B : I → Type 𝓥}
+                 {f : (i : I) → A i → B i}
+                 (X : Type 𝓦) {Y : Type 𝓜}
+               → is-local f Y
+               → is-equiv (postcomp-inj {f = f} X {Y})
+Local-reflects {I = I} {A}{B}{f} X {Y} Y-loc
+  = is-equiv←is-pathsplit ps where
+  module Y {i} = is-equiv (Y-loc i)
+
+  -- RHS (2.8) from RSS modalities
+  lem : (g h : Free-inj f X → Y)
+     (i : I)
+     (g' : A i → Free-inj _ X)
+     (q : g ∘ g' ~ h ∘ g') →
+     postcomp Y (f i) (g ∘ Free-inj.ext g') ~
+     postcomp Y (f i) (h ∘ Free-inj.ext g')
+  lem g h i g' K =      g ◂ (Free-inj.is-ext g')
+                     ~∙ K
+                     ~∙ (h ◂ Free-inj.is-ext g' ~⁻¹)
+
+  postwhisker : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+                  (X : Type 𝓦) (f : A → B)
+                → ∀ {g h : B → X} → (g ~ h)
+                → g ∘ f ~ h ∘ f
+  postwhisker X f = _▸ f
+
+  amap : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+            {C : Type 𝓦}
+           (f : A → B)
+           (g h : B → C)
+         → Arrow-map
+              (ap (postcomp C f) {g} {h})
+              (postwhisker C f {g} {h})
+  amap _ _ _ .Arrow-map.top = happly
+  amap _ _ _ .Arrow-map.bot = happly
+  amap _ _ _ .Arrow-map.comm refl = refl
+
+  amap-is-equiv : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+                    {C : Type 𝓦}
+                    {f : A → B}
+                    {g h : B → C}
+                  → is-Arrow-equiv (amap f g h)
+  amap-is-equiv .fst = global-funext
+  amap-is-equiv .snd = global-funext
+
+  opaque
+    Y▸-is-equiv : ∀ {i g h} → is-equiv (postwhisker Y (f i) {g} {h})
+    Y▸-is-equiv {i} = is-equiv←Arrow-equiv {F = amap _ _ _}
+                                   amap-is-equiv
+                               (is-embedding←is-equiv (Y-loc i))
+
+
+  module Y▸ {i g h} = is-equiv (Y▸-is-equiv {i} {g} {h})
+
+  secAp : ∀ (g h : Free-inj f X → Y)
+          → section (postwhisker Y Free-inj.inc {g} {h})
+  secAp g h .fst H
+    = Free-inj.ind (λ z → g z ＝ h z)
+        H
+        (λ f' (K : g ∘ f' ~ h ∘ f')
+          → Y▸.bwd (lem g h _ f' K))
+        λ f' (K : g ∘ f' ~ h ∘ f') a
+          → IdP-func←Square
+             (Free-inj.is-ext f' a)
+             _
+             (K a)
+             (Square←brt＝l
+               (ap g (Free-inj.is-ext f' a))
+               {ap h (Free-inj.is-ext f' a)}
+               {Y▸.bwd {g = g ∘ Free-inj.ext f'}
+                       {h = h ∘ Free-inj.ext f'}
+                       (lem g h _ f' K) (f _ a)}
+               (sym (happly (Y▸.ε (lem g h _ f' K)) a)))
+  secAp g h .snd K = refl
+
+  ps : is-pathsplit (postcomp-inj X)
+  -- The section for postcomp is easy
+  ps .fst .fst g = Free-inj.ind
+                     (λ _ → Y)
+                     g
+                     (λ _ → Y.bwd)
+                     λ g' h a → tr-const (Free-inj.is-ext g' a)
+                                ∙ happly (Y.ε h) a
+  ps .fst .snd h = refl
+  -- Proof for second part (section of ap) at page 2:34
+  ps .snd g h = section←Arrow-equiv⁻¹ {F = amap _ _ _} amap-is-equiv (secAp g h)
+}
+%```
+
 \subtree[stt-0065]{
 \date{2025-06-21}
-\title{Nullification is a [higher modality](stt-000G)}
-\taxon{theorem}
+\title{Nullification is a [reflective subuniverse](stt-0041)}
+\taxon{corollary}
 
 
 %```agda
 \agda{
-Null∙-HigherModality
+Null∙-SubU
   : ∀ {𝓘 𝓤} {I : Type 𝓘}
       {A : I → Type 𝓤}
       (a∙ : ∀ i → A i)
-      𝓥
-    → HigherModality 𝓥
-Null∙-HigherModality a 𝓥 = hm where
-  open HigherModality
+    → SubU 𝓤 (𝓘 ⊔ 𝓤)
+Null∙-SubU {A = A} A∙ .Subtype.family = is-null A
+Null∙-SubU A∙ .Subtype.has-is-subtype = is-null-is-prop
 
-  hm : HigherModality 𝓥
-  ○ hm = Null∙ _ a
-  hm .○-η = Free-inj.inc
-  hm .○-ind P f = {!!}
-  hm .○-β = {!!}
-  hm .＝-○-is-○-modal = {!!}
+Null∙-reflective
+  : ∀ {𝓘 𝓤} {I : Type 𝓘}
+      {A : I → Type 𝓤}
+      (a∙ : ∀ i → A i)
+    → is-reflective (Null∙-SubU a∙)
+Null∙-reflective a .is-reflective.has-reflectors A .Reflector.○
+  = Null∙ _ a A
+Null∙-reflective a .is-reflective.has-reflectors A .Reflector.○∈S
+  = Null∙-is-null a
+Null∙-reflective a .is-reflective.has-reflectors A .Reflector.○-η
+  = Free-inj.inc
+Null∙-reflective a .is-reflective.has-reflectors A .Reflector.reflects
+  cnull = Local-reflects _ (is-local←is-null cnull)
 }
 %```
 }
 
+\subtree[stt-006A]{
+\date{2025-06-23}
+\taxon{lemma}
+\title{#{f} local maps are #{\nabla(f)} local}
+
+%```agda
+\agda{
+is-local∇←is-local : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
+                 (f : A → B)
+                 {X : Type 𝓦}
+               → is-equiv (postcomp X f)
+               → is-equiv (postcomp X (∇ f))
+is-local∇←is-local f {X} eq = equiv←Coslice-equiv
+                                (Δ←∇ f X)
+                                Δ←∇-is-equiv
+                                (diagonal-is-equiv eq)
+}
+%```
+}
 
 \subtree[stt-0066]{
 \title{Localisation is a [reflective subuniverse](stt-0041)}
@@ -270,61 +405,9 @@ module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
                          {family = is-local f}
                          is-local-is-prop
 
-  postcomp-inj : ∀ {𝓜}
-                   {f : (i : I) → A i → B i}
-                   (X : Type 𝓦) {Y : Type 𝓜}
-                 → (Free-inj f X → Y)
-                 → (X → Y)
-  postcomp-inj X {Y} = postcomp Y Free-inj.inc
 
 
   -- This is RSS lemma 2.7: Should extract to it's own tree probably
-  Local-reflects : ∀ {𝓜}
-                   {f : (i : I) → A i → B i}
-                   (X : Type 𝓦) {Y : Type 𝓜}
-                 → is-local f Y
-                 → is-equiv (postcomp-inj {f = f} X {Y})
-  Local-reflects {_}{f} X {Y} Y-loc = is-equiv←is-pathsplit ps where
-    module Y {i} = is-equiv (Y-loc i)
-    module ∘Y {i g h} where
-      abstract
-        e : is-equiv (ap (postcomp Y (f i)) {g} {h})
-        e = (is-embedding←is-equiv (Y-loc i))
-      open is-equiv e public
-
-    -- RHS (2.8) from RSS modalities
-    lem : (g h : Free-inj f X → Y)
-       (p : postcomp-inj X g ＝ postcomp-inj X h) (i : I)
-       (g' : A i → Free-inj _ X)
-       (x : g ∘ g' ~ h ∘ g') →
-       postcomp Y (f i) (g ∘ Free-inj.ext g') ＝
-       postcomp Y (f i) (h ∘ Free-inj.ext g')
-    lem g h p i g' q = funext→ λ a → ap g (Free-inj.is-ext g' a)
-                                   ∙ q a
-                                   ∙ ap h (sym (Free-inj.is-ext g' a))
-
-    ps : is-pathsplit (postcomp-inj X)
-    -- The section for postcomp is easy
-    ps .fst .fst g = Free-inj.ind
-                       (λ _ → Y)
-                       g
-                       (λ _ → Y.bwd)
-                       λ g' h a → tr-const (Free-inj.is-ext g' a)
-                                  ∙ happly (Y.ε h) a
-    ps .fst .snd h = refl
-    -- Proof for second part (section of ap) at page 2:34
-    ps .snd g h .fst p
-      = funext→ (Free-inj.ind
-                  (λ z → g z ＝ h z)
-                  (happly p)
-                  (λ g' x → happly
-                    (∘Y.bwd (lem g h p _ g' x)))
-                  λ g' H a → IdP-func←Square {f = g} {h}
-                                              (Free-inj.is-ext g' a)
-                                              _
-                                              (H a)
-                                              {!!})
-    ps .snd g h .snd p = {!!}
 
   Local-reflective
     : (f : (i : I) → A i → B i)
@@ -332,7 +415,10 @@ module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
   Local-reflective f .has-reflectors A .Reflector.○ = Loc f A
   Local-reflective f .has-reflectors A .○∈S = Loc-is-local
   Local-reflective f .has-reflectors A .○-η = Free-inj.inc
-  Local-reflective f .has-reflectors A .reflects = {!!}
+  Local-reflective f .has-reflectors A .reflects cloc
+    = Local-reflects _ λ where
+      (left i) → cloc i
+      (right i) → is-local∇←is-local (f i) (cloc i)
 }
 %```
 }

--- a/src/modalities/instances/Localisation.lagda.tree
+++ b/src/modalities/instances/Localisation.lagda.tree
@@ -108,7 +108,7 @@ is-null←is-local eq i = is-equiv-∘ (eq i) unit-const-is-equiv
 }
 
 \subtree[stt-005K]{
-\title{Nullfication at an pointed family}
+\title{Nullification at a pointed family}
 \taxon{definition}
 
 \p{The nullification of a pointed type can be constructed
@@ -471,7 +471,7 @@ Null∙-reflective a .Reflective.has-is-reflector
 \subtree[stt-006E]{
 \taxon{theorem}
 \date{2025-06-25}
-\title{Nullfication is a #{\Sigma}-closed reflective subuniverse}
+\title{Nullification is a #{\Sigma}-closed reflective subuniverse}
 
 
 \proof{

--- a/src/modalities/instances/Localisation.lagda.tree
+++ b/src/modalities/instances/Localisation.lagda.tree
@@ -14,6 +14,8 @@ open import axioms.FreeAlgInj
 open import foundations.Prelude
 open import core.Orthogonal
 open import core.CanonicalPushouts
+open import core.Codiagonal
+open import core.CoSlice
 open import ergonomics.notations.Orthogonality
 open core.Orthogonal.notation
 }
@@ -126,10 +128,26 @@ Null∙-is-null {A∙ = a} = is-null←is-local I where
 \citet{rijkeMod2020}{2.13}
 
 \p{Given maps #{f_i : A_i \to B_i}, a type #{X} is #{f\rm{-local}}
-iff #{-\circ f_i} and #{-\circ \nabla_f_i} all have sections.}
+iff #{-\circ f_i} and #{-\circ \nabla_{f_i}} all have sections.}
 
 %```agda
 \agda{
+is-local←sec←sec-∇
+  : ∀ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘}
+      {A : I → Type 𝓤} {B : I → Type 𝓥}
+      {f : (i : I) → A i → B i}
+      {X : Type 𝓦}
+    → (∀ i → section (postcomp X (f i)))
+    → (∀ i → section (postcomp X (∇ (f i))))
+    → is-local f X
+is-local←sec←sec-∇ sec sec∇ i
+  = is-equiv←is-pathsplit
+      (is-pathsplit←sec-diag
+        (sec i)
+        (sec←sec-Coslice-equiv'
+          (Δ←∇ _ _)
+          Δ←∇-is-equiv
+          (sec∇ i)))
 }
 %```
 }
@@ -147,7 +165,7 @@ type will not get us all the way to a localisation.}
 \p{As explained in \citet{2.14}{rijkeMod2020}, even though the free algabraicly
 #{f}-injective type is not a localisation, we can add some morphisms to the class
 with which we localise against to make it so. By the observation in \ref{stt-005Z},
-we need to add all maps of the form #{\nabla_f_i} to #{f}.}
+we need to add all maps of the form #{\nabla_{f_i}} to #{f}.}
 
 %```agda
 \agda{
@@ -174,6 +192,8 @@ module _ {𝓘 𝓤 𝓦 : Level} {I : Type 𝓘}
   Loc-is-local : ∀ {X : Type 𝓦}
                    {f : ∀ i → A i → B i}
                  → is-local f (Loc f X)
-  Loc-is-local = {!is-local←sec-∇ !}
+  Loc-is-local = is-local←sec←sec-∇
+                   (λ i → injector-Free-inj (left i))
+                   (λ i → injector-Free-inj (right i))
 }
 }

--- a/src/ufAxioms.agda
+++ b/src/ufAxioms.agda
@@ -22,6 +22,8 @@ open fe public
 
 import foundations.CanonicalPullbacks
 open foundations.CanonicalPullbacks.WithFunExt global-funext public
+import foundations.PathSplit
+open foundations.PathSplit.PSWithFunExt global-funext public
 open import foundations.EquivProp global-funext public
 open import foundations.EmptyUP global-funext public
 open import foundations.SingletonClosure public hiding (Singleton-Π)

--- a/src/ufAxioms.agda
+++ b/src/ufAxioms.agda
@@ -27,9 +27,14 @@ open foundations.PathSplit.PSWithFunExt global-funext public
 open import foundations.EquivProp global-funext public
 open import foundations.EmptyUP global-funext public
 open import foundations.SingletonClosure public hiding (Singleton-Π)
+open import foundations.PropClosure public hiding (is-prop-Π)
 open import foundations.CompositionEquiv global-funext public
 open import foundations.CompositionFibres global-funext public
 Singleton-Π = weak-funext
+is-prop-Π : ∀ {𝓤 𝓥 : Level} {A : Type 𝓤} {B : A → Type 𝓥}
+            → ((a : A) → is-prop (B a))
+            → is-prop (Π A B)
+is-prop-Π = foundations.PropClosure.is-prop-Π global-funext
 
 funext-redex : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : A → Type 𝓥}
                { f g : (a : A) → B a } → {p : f ~ g}

--- a/src/ufAxioms.agda
+++ b/src/ufAxioms.agda
@@ -105,7 +105,8 @@ module _ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦} where
   pushout-ind-apβ : ∀ {f : A → B} {g : A → C} {𝓠} {Q : Pushout f g → Type 𝓠}
                       {c : CoconeD (mk-span _ f g) pushout Q} →
                        ∀ x → apᵈ (pushout-ind Q c) (glue x) ＝ c .CoconeD.filler x
-  pushout-ind-apβ {c = c} x = primEraseEquality eq where postulate eq : apᵈ (pushout-ind _ c) (glue x) ＝ c .CoconeD.filler x
+  pushout-ind-apβ {c = c} x = primEraseEquality eq where
+    postulate eq : apᵈ (pushout-ind _ c) (glue x) ＝ c .CoconeD.filler x
 
   opaque
     pushout-rec : ∀ {f : A → B} {g : A → C} {𝓠} {Q : Type 𝓠}
@@ -122,11 +123,11 @@ module _ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦} where
     pushout-recβ2 : ∀ {f : A → B} {g : A → C} {𝓠} {Q : Type 𝓠}
                     → {c : Cocone (mk-span _ f g) Q}
                     → ∀ x → pushout-rec c (ι₂ x) ＝ c .Cocone.q x
-    pushout-recβ2 _ = refl 
+    pushout-recβ2 _ = refl
 
   {-# REWRITE pushout-recβ1 pushout-recβ2 #-}
 
-  opaque 
+  opaque
     unfolding pushout-rec
     pushout-rec-apβ : ∀ {f : A → B} {g : A → C} {𝓠} {Q : Type 𝓠}
                       {c : Cocone (mk-span _ f g)  Q} →

--- a/trees/index.tree
+++ b/trees/index.tree
@@ -1,5 +1,6 @@
 \title{An Agda Framework for Synthetic Mathematics}
 \date{2025}
+\author{samueltoth}
 
 \import{stt-macros}
 

--- a/trees/macros/agda-macros.tree
+++ b/trees/macros/agda-macros.tree
@@ -37,6 +37,7 @@
 \def\String[bod]{\spanclass{String}{\bod}}
 \def\CatchallClause[bod]{\spanclass{CatchallClause}{\bod}}
 \def\UnsolvedMeta[bod]{\spanclass{UnsolvedMeta}{\bod}}
+\def\UnsolvedConstraint[bod]{\spanclass{UnsolvedConstraint}{\bod}}
 \def\Deadcode[bod]{\spanclass{Deadcode}{\bod}}
 
 \def\lpar[a]{\startverb(\stopverb}

--- a/trees/macros/stt-macros.tree
+++ b/trees/macros/stt-macros.tree
@@ -20,6 +20,8 @@
 
 \def\hidden[x]{}
 
+\def\rm[x]{\textrm{\x}}
+  
 \def\tot[x]{{\startverb \~\stopverb{\x}}}
 
 \def\refl{\textrm{refl}}

--- a/trees/stt/stt-0036.tree
+++ b/trees/stt/stt-0036.tree
@@ -6,6 +6,7 @@
 \put\transclude/metadata{true}
 \put\transclude/expanded{false}
 
+\transclude{stt-006O}
 \transclude{stt-005E}
 \transclude{stt-004Y}
 \transclude{stt-003T}

--- a/trees/stt/stt-005E.tree
+++ b/trees/stt/stt-005E.tree
@@ -1,6 +1,7 @@
 \date{2025-06-13}
 \title{The Flat Modality}
 \author{samueltoth}
+\tag{changelog}
 \meta{external}{https://github.com/samtoth/agda-synthetic-categories/pull/20}
 \import{stt-macros}
 

--- a/trees/stt/stt-006O.tree
+++ b/trees/stt/stt-006O.tree
@@ -1,0 +1,30 @@
+\date{2025-06-26}
+\author{samueltoth}
+\meta{external}{https://github.com/samtoth/agda-synthetic-categories/pull/23}
+\title{Localisation}
+\tag{changelog}
+\import{stt-macros}
+
+\p{In this PR we continue with the programme of formalising
+[[rijkeMod2020]], in particular constructing localisations.}
+
+\ul{
+\li{Defined the notion of [pathsplit maps](stt-005Q) \ref{foundations.PathSplit}}
+  \li{Defined the notion of [weak orthogonators](stt-005L)
+      and [algabraic injectives](stt-005J), as well as a higher inductive
+      type corresponding to [free Algabraic Injectives](stt-005I).
+      \ref{axioms.FreeAlgInj}.}
+  \li{\ref{modalities.instances.Localisation}:
+  \ul{
+    \li{Defines [local](stt-005F) and [null](stt-005G) types.}
+    \li{Constructs [localisation](stt-005Y) and [nullification](stt-005K) via the free algabraic injectives}
+    \li{Proves a [universal property](stt-006C) for nullification/localisation}
+    \li{Shows that ([null](stt-006E))[localisation](stt-0066) gives rise to a
+    (#{\Sigma}-closed) reflective subuniverse}
+  }}
+  \li{Cleaned up the interface in \ref{modalities.Subuniverses}, and showed 
+  [#{\Sigma}-closed reflective subuniverses give rise to higher modalities](stt-006F)}
+}
+
+\p{We should now be ready to give some examples of localisation and nullification,
+most importantly we can finally define truncation at HLevels.}


### PR DESCRIPTION
# Localisation and Nullification 

Adds most of the machinery for localisation and nullification at families of maps.

 - The notion of weak orthogonators
 - Algabraic injectives
 - Free Algabraic Injectives
 - `is-null` and `is-local`
 - Pathsplit-ness and that it is equivalent to equivalence
 - Local and Null types via free algabraic injectives
 - Reflective subuniverses corresponding to nullification and localisation

Still todo:

 - [x] Clean and split up proof of reflectors for Free-alg-inj
 - [x] Show nullification is Sigma Closed
 - [x] Write changelog
 - [ ] ~~Look at maps of algabraic injectives (probably not in this PR)~~
 - [x] Show Higher Modality <- Sigma closed reflective SubU