### PR TITLE
Benchmarks workflow

### DIFF
--- a/.codespell/ignore.txt
+++ b/.codespell/ignore.txt
@@ -13,3 +13,4 @@ falg
 bloc
 anull
 whitelist
+master

--- a/.codespell/requirements.txt
+++ b/.codespell/requirements.txt
@@ -1,0 +1,1 @@
+codespell

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -28,7 +28,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v17
         with:
           name: agda-synthetic-categories
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -71,7 +71,7 @@ jobs:
           external-data-json-path: './benchmark-cache/data.json'
 
       - name: Publish the profiling CSV as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: 'Typechecking profiling history'
           path: './benchmark-cache/data.csv'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,99 @@
+name: Benchmark
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  typecheck-benchmark:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v14
+        with:
+          name: agda-synthetic-categories
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Typecheck library with profiling
+        run: |
+          set -o pipefail
+          mkdir -p temp
+          nix-shell --run 'agda --version && make benchmark-typecheck' \
+            2> temp/memory-results.txt | tee temp/benchmark-results.txt
+
+      - name: Download previous typechecking profile
+        run: |
+          mkdir -p benchmark-cache
+          git fetch origin benchmark-data || true
+          if git show-ref --verify --quiet refs/remotes/origin/benchmark-data; then
+            git show origin/benchmark-data:data.json > benchmark-cache/data.json
+          else
+            cat > benchmark-cache/data.json <<EOF
+          {
+            "lastUpdate": null,
+            "repoUrl": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}",
+            "entries": {}
+          }
+          EOF
+          fi
+
+      - name: Process new profiling data
+        run: |
+          python3 scripts/typechecking_profile_parser.py \
+            temp/benchmark-results.txt temp/memory-results.txt \
+            temp/benchmark-results.json benchmark-cache/data.csv \
+            ${{ github.sha }}
+
+      - name: Merge JSON profiling data
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          tool: 'customSmallerIsBetter'
+          output-file-path: './temp/benchmark-results.json'
+          external-data-json-path: './benchmark-cache/data.json'
+
+      - name: Publish the profiling CSV as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'Typechecking profiling history'
+          path: './benchmark-cache/data.csv'
+
+      - name: Update benchmark-data branch
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          repo_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git clone --depth 1 --branch benchmark-data "${repo_url}" benchmark-data-branch || true
+          if [ ! -d benchmark-data-branch/.git ]; then
+            git init benchmark-data-branch
+            cd benchmark-data-branch
+            git checkout --orphan benchmark-data
+            git remote add origin "${repo_url}"
+          else
+            cd benchmark-data-branch
+          fi
+          cp ../benchmark-cache/data.json ./data.json
+          cp ../benchmark-cache/data.csv ./data.csv
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data.json data.csv
+          git commit -m "Update benchmark history for ${GITHUB_SHA}" || exit 0
+          git push origin benchmark-data

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,21 +79,39 @@ jobs:
       - name: Build
         run: nix-build
 
+      - name: Stage site artifact
+        if: >-
+          (github.event_name == 'workflow_dispatch' && github.ref_name == 'main') ||
+          (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main')
+        run: cp -LR result site-artifact
+
       - name: Prepare benchmark page data
+        if: >-
+          (github.event_name == 'workflow_dispatch' && github.ref_name == 'main') ||
+          (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main')
         run: |
-          mkdir -p result/benchmarks
+          mkdir -p site-artifact/benchmarks
           git fetch origin benchmark-data || true
           if git show-ref --verify --quiet refs/remotes/origin/benchmark-data; then
-            git show origin/benchmark-data:data.json > result/benchmarks/data.json
+            git show origin/benchmark-data:data.json > site-artifact/benchmarks/data.json
           fi
-          test -f result/benchmarks/data.json
-          printf 'window.BENCHMARK_DATA = ' > result/benchmarks/data.js
-          cat result/benchmarks/data.json >> result/benchmarks/data.js
+          test -f site-artifact/benchmarks/data.json
+          printf 'window.BENCHMARK_DATA = ' > site-artifact/benchmarks/data.js
+          cat site-artifact/benchmarks/data.json >> site-artifact/benchmarks/data.js
 
       - name: Upload site
         uses: actions/upload-pages-artifact@v5
+        if: >-
+          (github.event_name == 'workflow_dispatch' && github.ref_name == 'main') ||
+          (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main')
         with:
-          path: result/
+          path: site-artifact/
           retention-days: 1
 
   deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -37,7 +37,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v17
         with:
           name: agda-synthetic-categories
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
@@ -66,7 +66,7 @@ jobs:
         uses: cachix/install-nix-action@v31
 
       - name: Setup Cachix
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v17
         with:
           name: agda-synthetic-categories
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -91,7 +91,7 @@ jobs:
           cat result/benchmarks/data.json >> result/benchmarks/data.js
 
       - name: Upload site
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: result/
           retention-days: 1
@@ -120,4 +120,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,11 @@ on:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
+  workflow_run:
+    workflows:
+      - Benchmark
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,6 +22,7 @@ name: Build
 
 jobs:
   syntactic-check:
+    if: ${{ github.event_name != 'workflow_run' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -46,6 +52,7 @@ jobs:
         run: nix-shell --run "make check-forest-no-typecheck"
 
   build:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -53,6 +60,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -71,6 +79,17 @@ jobs:
       - name: Build
         run: nix-build
 
+      - name: Prepare benchmark page data
+        run: |
+          mkdir -p result/benchmarks
+          git fetch origin benchmark-data || true
+          if git show-ref --verify --quiet refs/remotes/origin/benchmark-data; then
+            git show origin/benchmark-data:data.json > result/benchmarks/data.json
+          fi
+          test -f result/benchmarks/data.json
+          printf 'window.BENCHMARK_DATA = ' > result/benchmarks/data.js
+          cat result/benchmarks/data.json >> result/benchmarks/data.js
+
       - name: Upload site
         uses: actions/upload-pages-artifact@v3
         with:
@@ -80,7 +99,11 @@ jobs:
   deploy:
     # Add a dependency to the build job
     needs: build
-    if: ${{ github.ref_name == 'main' }}
+    if: >-
+      (github.event_name == 'workflow_dispatch' && github.ref_name == 'main') ||
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main')
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           python-version: "3.x"
           cache: pip
-          cache-dependency-path: .github/workflows/codespell.yml
+          cache-dependency-path: .codespell/requirements.txt
 
       - name: Install codespell
-        run: python -m pip install --upgrade pip codespell
+        run: python -m pip install --upgrade pip -r .codespell/requirements.txt
 
       - name: Run codespell
         run: |

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,14 @@ DUP_DIR ?= ./trees/
 AGDA_FLAGS ?= --without-K --rewriting --guardedness --flat-split --postfix-projections --local-confluence-check --no-qualified-instances -WnoWithoutKFlagPrimEraseEquality
 EVERYTHING_INPUTS := $(shell find src -type f \( -name '*.agda' -o -name '*.lagda.tree' \) ! -name 'Everything.agda' | sort)
 
-.PHONY: help generate-everything prepare-agda-datadir sync-forest-src typecheck build-forest watch-agda check-port watch-forest server check-dup clean-agda clean-forester clean serve
+.PHONY: help generate-everything prepare-agda-datadir sync-forest-src typecheck benchmark-typecheck build-forest watch-agda check-port watch-forest server check-dup clean-agda clean-forester clean serve
 
 help:
 	@echo "Available targets:"
 	@echo "  make build-forest               # Generate Everything.agda + Agda/Forester trees/html"
 	@echo "  make sync-forest-src            # Copy source .lagda.tree files into trees/stt/autogen without highlighting and links"
 	@echo "  make typecheck                  # Generate Everything.agda and typecheck with agda"
+	@echo "  make benchmark-typecheck        # Clean typecheck with Agda profiling enabled"
 	@echo "  make watch-agda                 # Rebuild Agda output when src/ changes"
 	@echo "  make watch-forest [PORT=<port>] # Run forester watch server (default: 1313)"
 	@echo "  make server [PORT=<port>]       # Run watch-agda + watch-forest together (default: 1313)"
@@ -46,6 +47,15 @@ typecheck: $(EVERYTHING_FILE) prepare-agda-datadir
 	@mkdir -p "$(AGDA_DATADIR)" "$(AGDA_DATADIR)/lib"
 	@TIMEFORMAT='Typecheck elapsed: %3lR'; \
 	time Agda_datadir="./$(AGDA_DATADIR)" agda $(AGDA_FLAGS) -i src "$(EVERYTHING_FILE)"
+
+# Typecheck library from clean state, sequentially, and with profiling enabled
+benchmark-typecheck: $(EVERYTHING_FILE)
+	@chmod -R u+w "$(AGDA_DATADIR)" 2>/dev/null || true
+	@rm -rf "$(AGDA_DATADIR)"
+	@find . -type f \( -name '*.agdai' -o -name '*.agdai~' \) -delete
+	@$(MAKE) --no-print-directory prepare-agda-datadir
+	@mkdir -p "$(AGDA_DATADIR)" "$(AGDA_DATADIR)/lib"
+	@Agda_datadir="./$(AGDA_DATADIR)" agda $(AGDA_FLAGS) --profile=modules -i src "$(EVERYTHING_FILE)" +RTS -s -RTS
 
 sync-forest-src:
 	@mkdir -p "$(AUTOGEN_DIR)"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An agda development focussed on the development of ∞-category theory using sim
 type theory.
 Visit [the-forest](https://samtoth.github.io/agda-synthetic-categories) to browse
 the resource and find out more about the project.
+Benchmark history is published at
+[the benchmark page](https://samtoth.github.io/agda-synthetic-categories/benchmarks/).
 
 ## Development
 

--- a/assets/benchmarks/data.json
+++ b/assets/benchmarks/data.json
@@ -1,5 +1,5 @@
 {
   "lastUpdate": null,
-  "repoUrl": "https://github.com/samtoth/agda-synthetic-categories-2",
+  "repoUrl": "https://github.com/samtoth/agda-synthetic-categories",
   "entries": {}
 }

--- a/assets/benchmarks/data.json
+++ b/assets/benchmarks/data.json
@@ -1,0 +1,5 @@
+{
+  "lastUpdate": null,
+  "repoUrl": "https://github.com/samtoth/agda-synthetic-categories-2",
+  "entries": {}
+}

--- a/assets/benchmarks/index.html
+++ b/assets/benchmarks/index.html
@@ -1,0 +1,330 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes"
+    />
+    <style>
+      html {
+        font-family:
+          BlinkMacSystemFont,
+          -apple-system,
+          'Segoe UI',
+          Roboto,
+          Oxygen,
+          Ubuntu,
+          Cantarell,
+          'Fira Sans',
+          'Droid Sans',
+          'Helvetica Neue',
+          Helvetica,
+          Arial,
+          sans-serif;
+        -webkit-font-smoothing: antialiased;
+        background-color: #fff;
+        font-size: 16px;
+      }
+      body {
+        color: #4a4a4a;
+        margin: 8px;
+        font-size: 1em;
+        font-weight: 400;
+      }
+      header {
+        margin-bottom: 8px;
+        display: flex;
+        flex-direction: column;
+      }
+      main {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      a {
+        color: #3273dc;
+        cursor: pointer;
+        text-decoration: none;
+      }
+      a:hover {
+        color: #000;
+      }
+      button {
+        color: #fff;
+        background-color: #3298dc;
+        border-color: transparent;
+        cursor: pointer;
+        text-align: center;
+      }
+      button:hover {
+        background-color: #2793da;
+        flex: none;
+      }
+      .spacer {
+        flex: auto;
+      }
+      .small {
+        font-size: 0.75rem;
+      }
+      footer {
+        margin-top: 16px;
+        display: flex;
+        align-items: center;
+      }
+      .header-label {
+        margin-right: 4px;
+      }
+      .benchmark-set {
+        margin: 8px 0;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      .benchmark-title {
+        font-size: 3rem;
+        font-weight: 600;
+        word-break: break-word;
+        text-align: center;
+      }
+      .benchmark-graphs {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-around;
+        align-items: center;
+        flex-wrap: wrap;
+        width: 100%;
+      }
+      .benchmark-chart {
+        max-width: 1000px;
+      }
+    </style>
+    <title>Benchmarks</title>
+  </head>
+
+  <body>
+    <header id="header">
+      <div class="header-item">
+        <strong class="header-label">Last Update:</strong>
+        <span id="last-update"></span>
+      </div>
+      <div class="header-item">
+        <strong class="header-label">Repository:</strong>
+        <a id="repository-link" rel="noopener"></a>
+      </div>
+    </header>
+    <main id="main"></main>
+    <footer>
+      <button id="dl-button">Download data as JSON</button>
+      <div class="spacer"></div>
+      <div class="small">
+        Powered by
+        <a
+          rel="noopener"
+          href="https://github.com/marketplace/actions/continuous-benchmark"
+          >github-action-benchmark</a
+        >
+      </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js"></script>
+    <script src="data.js"></script>
+    <script id="main-script">
+      'use strict';
+      (function () {
+        // Colors from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
+        const toolColors = {
+          cargo: '#dea584',
+          go: '#00add8',
+          benchmarkjs: '#f1e05a',
+          benchmarkluau: '#000080',
+          pytest: '#3572a5',
+          googlecpp: '#f34b7d',
+          catch2: '#f34b7d',
+          julia: '#a270ba',
+          jmh: '#b07219',
+          benchmarkdotnet: '#178600',
+          customBiggerIsBetter: '#38ff38',
+          customSmallerIsBetter: '#ff3838',
+          _: '#333333',
+        };
+
+        function init() {
+          const data = window.BENCHMARK_DATA;
+
+          if (!data || !data.entries) {
+            throw new Error('Benchmark data is unavailable');
+          }
+
+          function collectBenchesPerTestCase(entries) {
+            const map = new Map();
+            for (const entry of entries) {
+              const { commit, date, tool, benches } = entry;
+              for (const bench of benches) {
+                const result = { commit, date, tool, bench };
+                const arr = map.get(bench.name);
+                if (arr === undefined) {
+                  map.set(bench.name, [result]);
+                } else {
+                  arr.push(result);
+                }
+              }
+            }
+            return map;
+          }
+
+          // Render header
+          document.getElementById('last-update').textContent = data.lastUpdate
+            ? new Date(data.lastUpdate).toString()
+            : 'No benchmark data yet';
+          const repoLink = document.getElementById('repository-link');
+          repoLink.href = data.repoUrl;
+          repoLink.textContent = data.repoUrl;
+
+          // Render footer
+          document.getElementById('dl-button').onclick = () => {
+            const dataUrl = 'data:,' + JSON.stringify(data, null, 2);
+            const a = document.createElement('a');
+            a.href = dataUrl;
+            a.download = 'benchmark_data.json';
+            a.click();
+          };
+
+          // Prepare data points for charts
+          return Object.keys(data.entries).map((name) => ({
+            name,
+            dataSet: collectBenchesPerTestCase(data.entries[name]),
+          }));
+        }
+
+        function renderAllChars(dataSets) {
+          function renderGraph(parent, name, dataset) {
+            const canvas = document.createElement('canvas');
+            canvas.className = 'benchmark-chart';
+            parent.appendChild(canvas);
+
+            const color = toolColors[dataset.length > 0 ? dataset[0].tool : '_'];
+            const data = {
+              labels: dataset.map((d) => d.commit.id.slice(0, 7)),
+              datasets: [
+                {
+                  label: name,
+                  data: dataset.map((d) => d.bench.value),
+                  borderColor: color,
+                  backgroundColor: color + '60', // Add alpha for #rrggbbaa
+                },
+              ],
+            };
+            const options = {
+              scales: {
+                xAxes: [
+                  {
+                    scaleLabel: {
+                      display: true,
+                      labelString: 'commit',
+                    },
+                  },
+                ],
+                yAxes: [
+                  {
+                    scaleLabel: {
+                      display: true,
+                      labelString: dataset.length > 0 ? dataset[0].bench.unit : '',
+                    },
+                    ticks: {
+                      beginAtZero: true,
+                    },
+                  },
+                ],
+              },
+              tooltips: {
+                callbacks: {
+                  afterTitle: (items) => {
+                    const { index } = items[0];
+                    const data = dataset[index];
+                    return (
+                      '\n' +
+                      data.commit.message +
+                      '\n\n' +
+                      data.commit.timestamp +
+                      '\n'
+                    );
+                  },
+                  label: (item) => {
+                    let label = item.value;
+                    const { range, unit } = dataset[item.index].bench;
+                    label += ' ' + unit;
+                    if (range) {
+                      label += ' (' + range + ')';
+                    }
+                    return label;
+                  },
+                  afterLabel: (item) => {
+                    const { extra } = dataset[item.index].bench;
+                    return extra ? '\n' + extra : '';
+                  },
+                },
+              },
+              onClick: (_mouseEvent, activeElems) => {
+                if (activeElems.length === 0) {
+                  return;
+                }
+                // XXX: Undocumented. How can we know the index?
+                const index = activeElems[0]._index;
+                const url = dataset[index].commit.url;
+                window.open(url, '_blank');
+              },
+            };
+
+            new Chart(canvas, {
+              type: 'line',
+              data,
+              options,
+            });
+          }
+
+          function renderBenchSet(name, benchSet, main) {
+            const setElem = document.createElement('div');
+            setElem.className = 'benchmark-set';
+            main.appendChild(setElem);
+
+            const nameElem = document.createElement('h1');
+            nameElem.className = 'benchmark-title';
+            nameElem.textContent = name;
+            setElem.appendChild(nameElem);
+
+            const graphsElem = document.createElement('div');
+            graphsElem.className = 'benchmark-graphs';
+            setElem.appendChild(graphsElem);
+
+            for (const [benchName, benches] of benchSet.entries()) {
+              renderGraph(graphsElem, benchName, benches);
+            }
+          }
+
+          const main = document.getElementById('main');
+          for (const { name, dataSet } of dataSets) {
+            renderBenchSet(name, dataSet, main);
+          }
+        }
+
+        try {
+          const benchmarkSets = init();
+          const main = document.getElementById('main');
+          if (benchmarkSets.length === 0) {
+            const emptyElem = document.createElement('p');
+            emptyElem.textContent = 'No benchmark data yet.';
+            main.appendChild(emptyElem);
+          } else {
+            renderAllChars(benchmarkSets);
+          }
+        } catch (_error) {
+          const main = document.getElementById('main');
+          const emptyElem = document.createElement('p');
+          emptyElem.textContent = 'Benchmark data is currently unavailable.';
+          main.appendChild(emptyElem);
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/default.nix
+++ b/default.nix
@@ -55,5 +55,11 @@ in
       mkdir -p $out
       cp -Lrvf output/agda-synthetic-categories/* "$out"/
       cp -Lrvf output/html "$out"/
+      mkdir -p "$out/benchmarks"
+      cp -Lrvf assets/benchmarks/. "$out/benchmarks"/
+      if [ -f "$out/benchmarks/data.json" ]; then
+        printf 'window.BENCHMARK_DATA = ' > "$out/benchmarks/data.js"
+        cat "$out/benchmarks/data.json" >> "$out/benchmarks/data.js"
+      fi
     '';
   }

--- a/scripts/typechecking_profile_parser.py
+++ b/scripts/typechecking_profile_parser.py
@@ -1,0 +1,148 @@
+import json
+import re
+import argparse
+import csv
+
+
+def parse_memory_profiling_data(filepath):
+    results = dict()
+
+    # Define patterns to match each line and their corresponding unit
+    patterns = {
+        'memory_allocated_in_heap': (r'(\d+(?:,\d+)*) bytes allocated in the heap', 'B'),
+        'memory_copied_during_GC': (r'(\d+(?:,\d+)*) bytes copied during GC', 'B'),
+        'maximum_residency': (r'(\d+(?:,\d+)*) bytes maximum residency', 'B'),
+        'memory_maximum_slop': (r'(\d+(?:,\d+)*) bytes maximum slop', 'B'),
+        'total_memory_in_use': (r'(\d+) MiB total memory in use', 'MiB')
+    }
+
+    with open(filepath, 'r') as file:
+        for line in file:
+            for key, (pattern, unit) in patterns.items():
+                match = re.search(pattern, line)
+                if match:
+                    value = int(match.group(1).replace(',', ''))
+                    if key == 'memory_maximum_slop':  # Convert maximum slo to KiB and truncate
+                        value //= 1024
+                        unit = 'KiB'
+                    elif unit == 'B':  # Convert bytes to MiB and truncate
+                        value //= 1024 * 1024
+                        unit = 'MiB'
+                    results[key] = {'value': value, 'unit': unit}
+
+    return results
+
+
+def parse_benchmark_results(input_path):
+    benchmarks = dict()
+    with open(input_path, 'r') as file:
+        for line in file:
+            # Match lines that end with "ms" indicating a timing result
+            match = re.fullmatch(r'^\s*(\S+)\s+(\d+(?:,\d+)*)ms\s*$', line)
+            if match:
+                name = match.group(1).strip()
+                # Correctly parse and combine the number groups to handle commas in numbers
+                milliseconds = int(match.group(2).replace(',', ''))
+                benchmarks[name] = {'value': milliseconds, 'unit': 'ms'}
+    return benchmarks
+
+
+def subdict(original_dict, keys_to_extract):
+    if keys_to_extract is None:
+        return original_dict
+    else:
+        return {key: original_dict[key] for key in keys_to_extract if key in original_dict}
+
+
+def convert_dict_to_list(data, keys_to_extract=None):
+    return [{'name': name, **details} for name, details in subdict(data, keys_to_extract).items()]
+
+
+def save_github_action_benchmark_json(output_path, benchmarks, memory_stats, benchmark_keys, memory_keys):
+    with open(output_path, 'w') as file:
+        json.dump(convert_dict_to_list(benchmarks, benchmark_keys) +
+                  convert_dict_to_list(memory_stats, memory_keys), file, indent=2)
+
+
+def read_existing_csv_to_dict(csv_path, commit_hash):
+    # Initialize a dictionary to hold the CSV data
+    data_dict = {}
+    fieldnames = ['name', 'unit', commit_hash]
+
+    try:
+        # Attempt to open the file, which will fail if the file doesn't exist
+        with open(csv_path, mode='r', newline='') as csvfile:
+            reader = csv.DictReader(csvfile)
+            # Update fieldnames with those found in the existing CSV, plus the new commit hash if necessary
+            fieldnames = reader.fieldnames + \
+                [commit_hash] if commit_hash not in reader.fieldnames else reader.fieldnames
+            for row in reader:
+                data_dict[row['name']] = row
+    except FileNotFoundError:
+        # File doesn't exist, proceed without modifying data_dict or fieldnames
+        pass
+
+    return data_dict, fieldnames
+
+
+def update_csv_data(data_dict, benchmarks, memory_stats, commit_hash):
+    # Combine benchmarks and memory stats for easier processing
+    combined_data = {**memory_stats, **benchmarks}
+
+    # Update the data_dict with new or updated values
+    for name, details in combined_data.items():
+        if name not in data_dict:
+            data_dict[name] = {'name': name, 'unit': details['unit']}
+        data_dict[name][commit_hash] = int(details['value'])
+
+
+def write_csv_from_dict(csv_path, data_dict, fieldnames, commit_hash):
+    def custom_sort(item):
+        # Sort all items that do not have unit "ms" first, then sort based on whether the name is capitalized, and then based on worst newest benchmark
+        is_not_ms_unit = item['unit'] != 'ms'
+
+        if is_not_ms_unit:
+            # If the unit is not `ms`, preserve order
+            return (False, False, 0)
+        else:
+            # If the unit is `ms`, sort based on capitalization, then on newest benchmark
+            return (True, item['name'][0].islower(), 0 if commit_hash not in item.keys() else -item[commit_hash])
+
+    with open(csv_path, mode='w', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        # Sort the data based on the custom sort function before writing
+        sorted_data = sorted(data_dict.values(), key=custom_sort)
+        for row in sorted_data:
+            writer.writerow(row)
+
+
+def save_as_csv(benchmarks, memory_stats, csv_path, commit_hash):
+    data_dict, fieldnames = read_existing_csv_to_dict(csv_path, commit_hash)
+    update_csv_data(data_dict, benchmarks, memory_stats, commit_hash)
+    write_csv_from_dict(csv_path, data_dict, fieldnames, commit_hash)
+
+
+if __name__ == '__main__':
+    # Set up argument parsing
+    parser = argparse.ArgumentParser(
+        description='Convert benchmark results to JSON format.')
+    parser.add_argument(
+        'input_times_path', help='Path to the input file containing typechecking times.')
+    parser.add_argument(
+        'input_memory_path', help='Path to the input file containing memory statistics.')
+    parser.add_argument('output_json_path',
+                        help='Path to the output JSON file.')
+    parser.add_argument('csv_path', help='Path to the profiling CSV file.')
+    parser.add_argument('commit_hash', help='Commit hash for current commit.')
+
+    # Parse arguments from command line
+    args = parser.parse_args()
+
+    # Use the provided command-line arguments
+    benchmarks = parse_benchmark_results(args.input_times_path)
+    memory_stats = parse_memory_profiling_data(args.input_memory_path)
+
+    save_github_action_benchmark_json(args.output_json_path, benchmarks, memory_stats, [
+                                      'Total',], ['total_memory_in_use',])
+    save_as_csv(benchmarks, memory_stats, args.csv_path, args.commit_hash)

--- a/scripts/typechecking_profile_parser.py
+++ b/scripts/typechecking_profile_parser.py
@@ -37,7 +37,7 @@ def parse_benchmark_results(input_path):
     benchmarks = dict()
     with open(input_path, 'r') as file:
         for line in file:
-            # Match lines that end with "ms" indicating a timing result
+            # Match lines that end with `ms` indicating a timing result
             match = re.fullmatch(r'^\s*(\S+)\s+(\d+(?:,\d+)*)ms\s*$', line)
             if match:
                 name = match.group(1).strip()
@@ -65,7 +65,7 @@ def save_github_action_benchmark_json(output_path, benchmarks, memory_stats, ben
 
 
 def read_existing_csv_to_dict(csv_path, commit_hash):
-    # Initialize a dictionary to hold the CSV data
+    # Initialise a dictionary to hold the CSV data
     data_dict = {}
     fieldnames = ['name', 'unit', commit_hash]
 
@@ -98,14 +98,14 @@ def update_csv_data(data_dict, benchmarks, memory_stats, commit_hash):
 
 def write_csv_from_dict(csv_path, data_dict, fieldnames, commit_hash):
     def custom_sort(item):
-        # Sort all items that do not have unit "ms" first, then sort based on whether the name is capitalized, and then based on worst newest benchmark
+        # Sort all items that do not have unit `ms` first, then sort based on whether the name is capitalised, and then based on worst newest benchmark
         is_not_ms_unit = item['unit'] != 'ms'
 
         if is_not_ms_unit:
             # If the unit is not `ms`, preserve order
             return (False, False, 0)
         else:
-            # If the unit is `ms`, sort based on capitalization, then on newest benchmark
+            # If the unit is `ms`, sort based on capitalisation, then on newest benchmark
             return (True, item['name'][0].islower(), 0 if commit_hash not in item.keys() else -item[commit_hash])
 
     with open(csv_path, mode='w', newline='') as csvfile:

--- a/scripts/typechecking_profile_parser.py
+++ b/scripts/typechecking_profile_parser.py
@@ -43,7 +43,7 @@ def parse_benchmark_results(input_path):
                 name = match.group(1).strip()
                 # Correctly parse and combine the number groups to handle commas in numbers
                 milliseconds = int(match.group(2).replace(',', ''))
-                benchmarks[name] = {'value': milliseconds, 'unit': 'ms'}
+                benchmarks[name] = {'value': round(milliseconds / 1000, 2), 'unit': 's'}
     return benchmarks
 
 
@@ -93,20 +93,23 @@ def update_csv_data(data_dict, benchmarks, memory_stats, commit_hash):
     for name, details in combined_data.items():
         if name not in data_dict:
             data_dict[name] = {'name': name, 'unit': details['unit']}
-        data_dict[name][commit_hash] = int(details['value'])
+        if details['unit'] == 's':
+            data_dict[name][commit_hash] = round(float(details['value']), 2)
+        else:
+            data_dict[name][commit_hash] = int(details['value'])
 
 
 def write_csv_from_dict(csv_path, data_dict, fieldnames, commit_hash):
     def custom_sort(item):
-        # Sort all items that do not have unit `ms` first, then sort based on whether the name is capitalised, and then based on worst newest benchmark
-        is_not_ms_unit = item['unit'] != 'ms'
+        # Sort all items that do not have unit `s` first, then sort based on whether the name is capitalised, and then based on worst newest benchmark
+        is_not_seconds_unit = item['unit'] != 's'
 
-        if is_not_ms_unit:
-            # If the unit is not `ms`, preserve order
+        if is_not_seconds_unit:
+            # If the unit is not `s`, preserve order
             return (False, False, 0)
         else:
-            # If the unit is `ms`, sort based on capitalisation, then on newest benchmark
-            return (True, item['name'][0].islower(), 0 if commit_hash not in item.keys() else -item[commit_hash])
+            # If the unit is `s`, sort based on capitalisation, then on newest benchmark
+            return (True, item['name'][0].islower(), 0 if commit_hash not in item.keys() else -float(item[commit_hash]))
 
     with open(csv_path, mode='w', newline='') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)


### PR DESCRIPTION
Adds a benchmarking CI and a dedicated page for benchmarking <https://samtoth.github.io/agda-synthetic-categories/benchmarks/>, like this one: https://fredrik-bakke.github.io/agda-unimath/benchmarks/

The json/html/python files are taken verbatim from my agda-unimath fork, the workflow is adapted from the same fork, but it uses nix directly. 

I will have to run the workflow on the main branch to see that it works properly.