### PR TITLE
add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*.tree linguist-language=Text
+*.tree linguist-language=Text linguist-detectable
 *.lagda.tree linguist-language=Agda

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.tree linguist-language=Text
+*.lagda.tree linguist-language=Agda


### PR DESCRIPTION
Makes it so literate agda files are reported as agda code in the repo, and trees are reported as text (since forester isn't supported by linguist).