### PR TITLE
Uploads an artifact in the build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,4 @@
 on:
-  push:
-    branches-ignore:
-      - main
-      - benchmark-data
   pull_request:
   workflow_dispatch:
     inputs:
@@ -73,3 +69,9 @@ jobs:
 
       - name: Build
         run: nix-build
+
+      - name: Upload site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: result/
+          retention-days: 1


### PR DESCRIPTION
Fixes a regression on PR preview made when adding benchmarking data.

This also make build no longer trigger on push by default - only pull request, this will avoid unnecessarily building twice when pull requests come from this repository.