### PR TITLE
Shorthand for iterated dependent sums on the same type

### DIFF
--- a/src/Core/Coequalisers.lagda.tree
+++ b/src/Core/Coequalisers.lagda.tree
@@ -129,11 +129,11 @@ cocone≃fork {B = B} {f} {g} {C}
       ≃⟨⟩
     (Σ[ p ∶ (B → C)] (p ∘ f ~ p ∘ g))
       ≃⟨ Σ-snd-≃ (λ _ → Σ-＝singl') e⁻¹ ⟩
-    (Σ[ p ∶ (B → C)] Σ[ q ∶ (B → C)] ((p ＝ q) × (p ∘ f ~ q ∘ g)))
+    (Σ[ p q ∶ (B → C)] ((p ＝ q) × (p ∘ f ~ q ∘ g)))
       ≃⟨ Σ-snd-≃ (λ p → Σ-snd-≃ (λ q → Σ-fst-≃ funext≃)) ⟩
-    (Σ[ p ∶ (B → C)] Σ[ q ∶ (B → C)] ((p ~ q) × (p ∘ f ~ q ∘ g)))
+    (Σ[ p q ∶ (B → C)] ((p ~ q) × (p ∘ f ~ q ∘ g)))
       ≃⟨ Σ-snd-≃ (λ p → Σ-snd-≃ (λ q → ⊎-UP≃ global-funext)) ⟩
-    (Σ[ p ∶ (B → C)] Σ[ q ∶ (B → C)] (p ∘ Coeq.l f g ~ q ∘ Coeq.r f g))
+    (Σ[ p q ∶ (B → C)] (p ∘ Coeq.l f g ~ q ∘ Coeq.r f g))
       ≃⟨ cocone-repr≃ e⁻¹ ⟩
     Cocone (Coeq.span f g) C ≃∎
 
@@ -273,11 +273,11 @@ cocone≃forkᵈ {B = B} {f} {g} {C}
       ≃⟨⟩
     (Σ[ p ∶ (Π B (C ∘ ι₂))] (p ∘ f ~[ (C ◂ (coeq f g .snd)) ] p ∘ g))
       ≃⟨ Σ-snd-≃ (λ p → Σ-＝singl') e⁻¹ ⟩
-    (Σ[ p ∶ (Π B (C ∘ ι₂))] Σ[ q ∶ Π B (C ∘ ι₂)] ((p ＝ q) × (p ∘ f ~[ C ◂ (coeq f g .snd) ] q ∘ g)))
+    (Σ[ p q ∶ (Π B (C ∘ ι₂))] ((p ＝ q) × (p ∘ f ~[ C ◂ (coeq f g .snd) ] q ∘ g)))
       ≃⟨ Σ-snd-≃ (λ p → Σ-snd-≃ (λ q → Σ-fst-≃ funext≃)) ⟩
-    (Σ[ p ∶ Π B (C ∘ ι₂)] Σ[ q ∶ Π B (C ∘ ι₂)] ((p ~ q) × (p ∘ f ~[ C ◂ (coeq f g .snd) ] q ∘ g)))
+    (Σ[ p q ∶ Π B (C ∘ ι₂)] ((p ~ q) × (p ∘ f ~[ C ◂ (coeq f g .snd) ] q ∘ g)))
       ≃⟨ Σ-snd-≃ (λ p → Σ-snd-≃ (λ q → ⊎-UP≃ global-funext)) ⟩
-    (Σ[ p ∶ Π B (C ∘ ι₂)] Σ[ q ∶ Π B (C ∘ ι₂)] (p ∘ Coeq.l f g ~[ (C ◂ ⊎-ind (~refl , coeq f g .snd)) ] q ∘ Coeq.r f g))
+    (Σ[ p q ∶ Π B (C ∘ ι₂)] (p ∘ Coeq.l f g ~[ (C ◂ ⊎-ind (~refl , coeq f g .snd)) ] q ∘ Coeq.r f g))
       ≃⟨ coconeD-repr≃ e⁻¹ ⟩
     Coconeᵈ (Coeq.span f g) _ C ≃∎
 

--- a/src/Core/Suspensions.lagda.tree
+++ b/src/Core/Suspensions.lagda.tree
@@ -82,7 +82,7 @@ merid = glue
 Susp-UP→
   : ∀ {𝓤 𝓥} {X : Type 𝓤}
       {Y : Type 𝓥}
-    → Σ[ x ∶ Y ] Σ[ y ∶ Y ] (X → x ＝ y)
+    → Σ[ x y ∶ Y ] (X → x ＝ y)
     → Susp X → Y
 Susp-UP→ (x , y , p) = pushout-rec (mk-cocone (λ _ → x) (λ _ → y) p)
 
@@ -98,13 +98,13 @@ Susp-UP-is-equiv = is-equiv←qinv (λ where
 Susp-UP≃
   : ∀ {𝓤 𝓥} {X : Type 𝓤}
       {Y : Type 𝓥}
-    → (Susp X → Y) ≃ (Σ[ x ∶ Y ] Σ[ y ∶ Y ] (X → x ＝ y))
+    → (Susp X → Y) ≃ (Σ[ x y ∶ Y ] (X → x ＝ y))
 Susp-UP≃ {X = X} {Y} = mk≃ _ (is-equiv⁻¹ Susp-UP-is-equiv)
   -- = (Susp X → Y) ≃⟨ mk≃ _ Pushout-has-up-pushout ⟩
   --   Cocone _ Y                                            ≃⟨ cocone-repr≃ ⟩
-  --   (Σ[ f ∶ (𝟙 → Y) ] Σ[ g ∶ (𝟙 → Y)] (X → f tt ＝ g tt)) ≃⟨ Σ-ap-≃-fst unit-UP≃ ⟩
+  --   (Σ[ f g ∶ (𝟙 → Y)] (X → f tt ＝ g tt)) ≃⟨ Σ-ap-≃-fst unit-UP≃ ⟩
   --   (Σ[ x ∶ Y ] Σ[ g ∶ (𝟙 → Y) ] (X → x ＝ g tt))          ≃⟨ Σ-ap-≃ (λ x → Σ-ap-≃-fst (unit-UP≃)) ⟩
-  --   Σ[ x ∶ Y ] Σ[ y ∶ Y ] (X → x ＝ y) ≃∎
+  --   Σ[ x y ∶ Y ] (X → x ＝ y) ≃∎
 }
 }
 

--- a/src/Foundations/Sigma.lagda.tree
+++ b/src/Foundations/Sigma.lagda.tree
@@ -38,6 +38,7 @@ snd: B = snd
 
 \subtree[stt-001B]{
 \taxon{Notation}
+\contributor{fredrikbakke}
 
 \p{
   In prose, we use a combination of the big sigma notation #{\Sigma_{x : A} B(x)}, as well as the nupurl style notation: #{(x : A) \times B(x)}. To mirror this in the agda development, we introduce the following syntax: }
@@ -47,6 +48,25 @@ syntax Σ A (λ x → B) = Σ[ x ∶ A ] B
 }
 
 \p{Additionally, given a family of types #{B : A \to \cal{U}}, we write #{\startverb \~{B} \stopverb} to signify the total space #{\Sigma_{a : A} B(a)}, and use #{\pi : \tot{B} \to A} to refer to the first projection.}
+
+\p{
+We also introduce Agda syntax for the shorthand style #{\Sigma_{x,y : A} B(x)} for
+multivariable dependent sums.
+}
+
+\agda{
+Σ₂ : ∀ {𝓤 𝓥} (A : Type 𝓤) (B : A → A → Type 𝓥) → Type (𝓤 ⊔ 𝓥)
+Σ₂ A B =  Σ A (λ x → Σ A (λ y → B x y))
+{-# INLINE Σ₂ #-}
+
+syntax Σ₂ A (λ x y → B) = Σ[ x y ∶ A ] B
+
+Σ₃ : ∀ {𝓤 𝓥} (A : Type 𝓤) (B : A → A → A → Type 𝓥) → Type (𝓤 ⊔ 𝓥)
+Σ₃ A B =  Σ A (λ x → Σ₂ A (B x))
+{-# INLINE Σ₂ #-}
+
+syntax Σ₃ A (λ x y z → B) = Σ[ x y z ∶ A ] B
+}
 }
 
 

--- a/src/Foundations/Sigma.lagda.tree
+++ b/src/Foundations/Sigma.lagda.tree
@@ -66,6 +66,12 @@ syntax Σ₂ A (λ x y → B) = Σ[ x y ∶ A ] B
 {-# INLINE Σ₂ #-}
 
 syntax Σ₃ A (λ x y z → B) = Σ[ x y z ∶ A ] B
+
+Σ₄ : ∀ {𝓤 𝓥} (A : Type 𝓤) (B : A → A → A → A → Type 𝓥) → Type (𝓤 ⊔ 𝓥)
+Σ₄ A B =  Σ A (λ x → Σ₃ A (B x))
+{-# INLINE Σ₂ #-}
+
+syntax Σ₄ A (λ x y z w → B) = Σ[ x y z w ∶ A ] B
 }
 }
 

--- a/src/Modalities/Instances/Truncation.lagda.tree
+++ b/src/Modalities/Instances/Truncation.lagda.tree
@@ -338,14 +338,14 @@ suc-is-null {X = X} {A} AXnull i = eqv where opaque
 
   module Ideq x y = _≃_ (Ideq {x} {y})
 
-  map1 : A → Σ[ a ∶ A ] Σ[ b ∶ A ] (X i → a ＝ b)
+  map1 : A → Σ[ a b ∶ A ] (X i → a ＝ b)
   map1 a = (a , a , ~refl)
 
-  map1-eqv : A ≃ (Σ[ a ∶ A ] Σ[ b ∶ A ] (X i → a ＝ b))
+  map1-eqv : A ≃ (Σ[ a b ∶ A ] (X i → a ＝ b))
   map1-eqv
     = A                                     ≃⟨ Σ-singleton (λ _ → Sing-is-singleton) e⁻¹ ⟩
       ((Σ[ a ∶ A ] Sing A a))               ≃⟨ Σ-snd-≃ (λ a → Σ-snd-≃ (λ b → Ideq)) ⟩
-      (Σ[ a ∶ A ] Σ[ b ∶ A ] (X i → a ＝ b)) ≃∎
+      (Σ[ a b ∶ A ] (X i → a ＝ b)) ≃∎
 
   map1-is-equiv : is-equiv map1
   map1-is-equiv = map1-eqv ._≃_.fwd-is-equiv

--- a/src/Synthetic/Categories/FullyFaithfulMaps.lagda.tree
+++ b/src/Synthetic/Categories/FullyFaithfulMaps.lagda.tree
@@ -154,7 +154,7 @@ module CompareFF {𝓤 𝓥 : Level} {A : Type 𝓤} {B : Type 𝓥} (f : A → 
 
   ΣΣHom←arr-map-∂Δ¹-incl
     : Arrow-map ∂Δ¹-incl f
-    → Σ[ x ∶ A ] Σ[ y ∶ A ] Hom B (f x) (f y)
+    → Σ[ x y ∶ A ] Hom B (f x) (f y)
   ΣΣHom←arr-map-∂Δ¹-incl F
     = ( F .Arrow-map.top ∂Δ¹-0
       , F .Arrow-map.top ∂Δ¹-1
@@ -164,7 +164,7 @@ module CompareFF {𝓤 𝓥 : Level} {A : Type 𝓤} {B : Type 𝓥} (f : A → 
           (F .Arrow-map.comm ∂Δ¹-1))
 
   arr-map-∂Δ¹-incl←ΣΣHom
-    : Σ[ x ∶ A ] Σ[ y ∶ A ] Hom B (f x) (f y)
+    : Σ[ x y ∶ A ] Hom B (f x) (f y)
     → Arrow-map ∂Δ¹-incl f
   arr-map-∂Δ¹-incl←ΣΣHom (x , y , h)
     = mk-amap (∂Δ¹-UP→ (x , y)) (ext .fst) ext-comm
@@ -192,9 +192,9 @@ module CompareFF {𝓤 𝓥 : Level} {A : Type 𝓤} {B : Type 𝓥} (f : A → 
 
   arr-map-∂Δ¹-incl≃ΣΣHom
     : Arrow-map ∂Δ¹-incl f
-    ≃ Σ[ x ∶ A ] Σ[ y ∶ A ] Hom B (f x) (f y)
+    ≃ Σ[ x y ∶ A ] Hom B (f x) (f y)
   arr-map-∂Δ¹-incl≃ΣΣHom = equiv←qequiv qeqv where
-    qeqv : Arrow-map ∂Δ¹-incl f ≊ (Σ[ x ∶ A ] Σ[ y ∶ A ] Hom B (f x) (f y))
+    qeqv : Arrow-map ∂Δ¹-incl f ≊ (Σ[ x y ∶ A ] Hom B (f x) (f y))
     qeqv ._≊_.fwd = ΣΣHom←arr-map-∂Δ¹-incl
     qeqv ._≊_.fwd-qinv .fst = arr-map-∂Δ¹-incl←ΣΣHom
     qeqv ._≊_.fwd-qinv .snd .fst F
@@ -221,8 +221,8 @@ module CompareFF {𝓤 𝓥 : Level} {A : Type 𝓤} {B : Type 𝓥} (f : A → 
     qeqv ._≊_.fwd-qinv .snd .snd (x , y , h) = sym (arr-map-∂Δ¹-incl←ΣΣHom-sec x y h)
 
   total-ap-hom
-    : Σ[ x ∶ A ] Σ[ y ∶ A ] Hom A x y
-    → Σ[ x ∶ A ] Σ[ y ∶ A ] Hom B (f x) (f y)
+    : Σ[ x y ∶ A ] Hom A x y
+    → Σ[ x y ∶ A ] Hom B (f x) (f y)
   total-ap-hom = total-map λ x → total-map λ y → ap-hom f {x} {y}
 
   total-ap-hom-square

--- a/src/Synthetic/Categories/Spaces.lagda.tree
+++ b/src/Synthetic/Categories/Spaces.lagda.tree
@@ -328,12 +328,12 @@ Cov-NT-is-equiv
     → (∀ x → is-equiv (α (∂Δ¹-incl x))) → ∀ i → is-equiv (α i)
 Cov-NT-is-equiv {𝓤} f g α epeq = is-equiv.bwd part1' epeq where
   @♭ Y : Type (lsuc (𝓤 ⊔ 𝓘))
-  Y = Σ[ F ∶ (Δ¹ → Space 𝓤) ] Σ[ G ∶ (Δ¹ → Space 𝓤)]
+  Y = Σ[ F G ∶ (Δ¹ → Space 𝓤)]
         Σ[ α' ∶ (∀ i → F i .Space.Carrier → G i .Space.Carrier) ]
           ∀ i → is-equiv (α' i)
 
   @♭ X : Type (lsuc (𝓤 ⊔ 𝓘))
-  X = Σ[ F ∶ (Δ¹ → Space 𝓤) ] Σ[ G ∶ (Δ¹ → Space 𝓤)]
+  X = Σ[ F G ∶ (Δ¹ → Space 𝓤)]
         Σ[ α' ∶ (∀ i → F i .Space.Carrier → G i .Space.Carrier) ]
           ∀ x → is-equiv (α' (∂Δ¹-incl x))
 
@@ -353,12 +353,12 @@ Cov-NT-is-equiv {𝓤} f g α epeq = is-equiv.bwd part1' epeq where
   open Space
 
   @♭ Y' : ∀ n → Type (lsuc (𝓘 ⊔ 𝓤))
-  Y' n = Σ[ F ∶ (Γ n → Space 𝓤) ] Σ[ G ∶ (Γ n → Space 𝓤)]
+  Y' n = Σ[ F G ∶ (Γ n → Space 𝓤)]
           Σ[ α' ∶ (∀ i → F i .Space.Carrier → G i .Space.Carrier) ]
             ∀ i → is-equiv (α' i)
 
   @♭ X' : ∀ n → Type (lsuc (𝓘 ⊔ 𝓤))
-  X' n = Σ[ F ∶ (Γ n → Space 𝓤) ] Σ[ G ∶ (Γ n → Space 𝓤)]
+  X' n = Σ[ F G ∶ (Γ n → Space 𝓤)]
           Σ[ α' ∶ (∀ i → F i .Space.Carrier → G i .Space.Carrier) ]
             ∀ i → is-equiv (α' (i .fst , ∂Δ¹-incl (i .snd)))
 
@@ -550,7 +550,7 @@ tr-𝓢-unique f {F = F} x p = ap fst (Space-π-is-covariant f x .central (F x ,
 
 dua→
   : ∀ {@♭ 𝓤} → (Δ¹ → Space 𝓤)
-    → Σ[ A ∶ Space 𝓤 ] Σ[ B ∶ Space 𝓤 ] (Space.Carrier A → Space.Carrier B)
+    → Σ[ A B ∶ Space 𝓤 ] (Space.Carrier A → Space.Carrier B)
 dua→ h = (h i0 , h i1 , tr-𝓢 h)
 }
 
@@ -591,20 +591,20 @@ the paths in #{\Sigma_{A\ B} A \to B} and #{\textrm{Gl}(A,B,f)}:}
 
 \agda{
   SpaceΣ-Path
-    : ∀ {@♭ 𝓤} (x y : (Σ[ A ∶ Space 𝓤 ] Σ[ B ∶ Space 𝓤 ] (Carrier A → Carrier B)))
+    : ∀ {@♭ 𝓤} (x y : (Σ[ A B ∶ Space 𝓤 ] (Carrier A → Carrier B)))
       → Type 𝓤
   SpaceΣ-Path (A , B , f) (X , Y , g)
     = Σ[ e ∶ A .Carrier ≃ X .Carrier ] Σ[ p ∶ B .Carrier ≃ Y .Carrier ]
         (p ._≃_.fwd ∘ f ~ g ∘ e ._≃_.fwd)
 
   SpaceΣ-Path-refl
-    : ∀ {@♭ 𝓤} (x : (Σ[ A ∶ Space 𝓤 ] Σ[ B ∶ Space 𝓤 ] (Carrier A → Carrier B)))
+    : ∀ {@♭ 𝓤} (x : (Σ[ A B ∶ Space 𝓤 ] (Carrier A → Carrier B)))
       → SpaceΣ-Path x x
   SpaceΣ-Path-refl x = (id≃ , id≃ , ~refl)
 
   opaque
     SpaceΣ-Path-is-torsorial
-      : ∀ {@♭ 𝓤} (x : (Σ[ A ∶ Space 𝓤 ] Σ[ B ∶ Space 𝓤 ] (Carrier A → Carrier B)))
+      : ∀ {@♭ 𝓤} (x : (Σ[ A B ∶ Space 𝓤 ] (Carrier A → Carrier B)))
         → is-singleton (Σ _ (SpaceΣ-Path x))
     SpaceΣ-Path-is-torsorial (A , B , f)
       = is-singleton-structure←parts
@@ -617,9 +617,7 @@ the paths in #{\Sigma_{A\ B} A \to B} and #{\textrm{Gl}(A,B,f)}:}
 
   instance
     SpaceΣ-IdS
-      : ∀ {@♭ 𝓤}
-        → Identity-system ((Σ[ A ∶ Space 𝓤 ] Σ[ B ∶ Space 𝓤 ] (Carrier A → Carrier B)))
-                          𝓤
+      : ∀ {@♭ 𝓤} → Identity-system ((Σ[ A B ∶ Space 𝓤 ] (Carrier A → Carrier B))) 𝓤
     SpaceΣ-IdS .Identity-system.IdS = SpaceΣ-Path
     SpaceΣ-IdS .Identity-system.IdS←Id {a = A} refl = SpaceΣ-Path-refl A
     SpaceΣ-IdS .Identity-system.IdS←Id-is-equiv x

--- a/src/Synthetic/Categories/Spaces.lagda.tree
+++ b/src/Synthetic/Categories/Spaces.lagda.tree
@@ -576,7 +576,7 @@ module DUA
       _ = B .Carrier-is-afib
 
   GlΣ
-    : ∀ {@♭ 𝓤} → (Σ[ A ∶ Space (𝓘 ⊔ 𝓤)] Σ[ B ∶ Space (𝓘 ⊔ 𝓤)] (Carrier A → Carrier B))
+    : ∀ {@♭ 𝓤} → (Σ[ A B ∶ Space (𝓘 ⊔ 𝓤)] (Carrier A → Carrier B))
       → (Δ¹ → Space (𝓘 ⊔ 𝓤))
   GlΣ {𝓤} x = Gl {𝓤} (x .fst) (x .snd .fst) (x .snd .snd)
 }

--- a/src/Synthetic/Hom.lagda.tree
+++ b/src/Synthetic/Hom.lagda.tree
@@ -74,7 +74,7 @@ Hom-over {A = A} {B} f x' y'
 0≤1 .Homᵈ.hom0 = refl
 0≤1 .Homᵈ.hom1 = refl
 
-total-hom : ∀ {𝓤} {A : Type 𝓤} → (I → A) ≃ (Σ[ x ∶ A ] Σ[ y ∶ A ] Hom A x y)
+total-hom : ∀ {𝓤} {A : Type 𝓤} → (I → A) ≃ (Σ[ x y ∶ A ] Hom A x y)
 total-hom {A = A} = equiv←qequiv
   (mk≊
     (λ f → (f i0 , f i1 , λhom f))
@@ -242,7 +242,7 @@ ap-hom-over F (mk-hom f hom0 refl) .Homᵈ.hom1 = refl
 ap-total-hom
   : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥}
     → (A → B)
-    → (Σ[ x ∶ A ] Σ[ y ∶ A ] Hom _ x y) → Σ[ x' ∶ B ] Σ[ y' ∶ B ] Hom _ x' y'
+    → (Σ[ x y ∶ A ] Hom _ x y) → Σ[ x' y' ∶ B ] Hom _ x' y'
 ap-total-hom F = map-Σ F (λ a → map-Σ F λ b → ap-hom F)
 
 ap-total-hom-is-equiv

--- a/src/Synthetic/Horns.lagda.tree
+++ b/src/Synthetic/Horns.lagda.tree
@@ -88,7 +88,7 @@ open Subtype
 Λ[2,1]-incl = cogap Λ[2,1]-Δ²-cocone
 
 [2,1]-hom : ∀ {𝓤} (C : Type 𝓤) → Type (𝓤 ⊔ 𝓘)
-[2,1]-hom C = Σ[ f ∶ (Δ¹ → C) ] Σ[ g ∶ (Δ¹ → C)] (f i1 ＝ g i0)
+[2,1]-hom C = Σ[ f g ∶ (Δ¹ → C)] (f i1 ＝ g i0)
 
 make-horn : ∀ {𝓤} {C : Type 𝓤} {x y z} → Hom C y z → Hom C x y → Λ[2,1] → C
 make-horn f g = pushout-rec (mk-cocone (g .Homᵈ.hom) (f .Homᵈ.hom)


### PR DESCRIPTION
Introduces the Agda shorthand `Σ[ x y ∶ A ] B` for `Σ A (λ x → Σ A (λ y → B x y))` and higher order variants.