### PR TITLE
chore: Fix weak orthogonator terminology

### DIFF
--- a/src/Axioms/FreeAlgebraicInjectives.lagda.tree
+++ b/src/Axioms/FreeAlgebraicInjectives.lagda.tree
@@ -16,7 +16,7 @@ open import Core.PullbackPowers
 
 \subtree[stt-005L]{
 \taxon{Definition}
-\title{Weak orthogonators of maps}
+\title{Lifting operations between maps}
 
 \quiver{
 \begin{tikzcd}
@@ -25,35 +25,41 @@ open import Core.PullbackPowers
 	B && Y
 	\arrow[from=1-1, to=1-3]
 	\arrow["f"', from=1-1, to=3-1]
-	\arrow["p", from=1-3, to=3-3]
+	\arrow["g", from=1-3, to=3-3]
 	\arrow[dashed, from=3-1, to=1-3]
 	\arrow[from=3-1, to=3-3]
 \end{tikzcd}
 }
 
-\p{[Orthogonal maps](stt-004A) require uniqueness of
+\p{
+[Orthogonal maps](stt-004A) require uniqueness of
 lifting solution to lifting problems as above. When this
 uniqueness requirement is lifted we can speak of the type
-of weak-orthogonators for a pair of maps, which give a chosen
-lift for each lifting problem. When this type is merely
-inhabited we say that a pair of maps are weakly orthogonal.}
+of \em{lifting operations} between a pair of maps, which give a chosen
+lift for each lifting problem. When this type is only merely
+inhabited we say that #{f} \em{merely lifts} against #{g}, and that
+#{f} has the \em{lifting property} with respect to #{g}.
+}
+
+\p{
+Due to dependency order, we cannot define the notion of lifting property in
+this module.
+}
 
 \agda{
-weak-orthogonator
-  : ∀ {𝓤 𝓥 𝓦 𝓛} {A : Type 𝓤} {B : Type 𝓥}
-      {C : Type 𝓦} {D : Type 𝓛}
-    → (f : A → B)
-    → (g : C → D)
-    → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓛)
-weak-orthogonator f g = ∀ (H : Arrow-map f g) → Lift H
+module _ {𝓤 𝓥 𝓦 𝓛} {A : Type 𝓤} {B : Type 𝓥}  {X : Type 𝓦} {Y : Type 𝓛} where
+
+  lifting-operation
+    : (f : A → B) (g : X → Y) → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓛)
+  lifting-operation f g = (H : Arrow-map f g) → Lift H
 }
 }
 
 \subtree[stt-005N]{
 \taxon{Theorem}
-\title{Weakly orthogonal maps give a section of the pullback power}
+\title{Lifting operations give a section of the pullback power}
 
-\p{The type of weak orthogonators for map #{g} with respect to #{f}
+\p{The type of lifting operations between #{f} and #{g}
 is equivalent to type of sections of the [pullback power](stt-004D)
  #{\pullpow{f}{g}}.}
 
@@ -62,7 +68,7 @@ sec-pb-power←weak-orthogonator
   : ∀ {𝓤 𝓥 𝓦 𝓛} {A : Type 𝓤} {B : Type 𝓥}
       {C : Type 𝓦} {D : Type 𝓛}
       {f : A → B} {g : C → D}
-    → weak-orthogonator f g
+    → lifting-operation f g
     → section (pullback-power f g)
 sec-pb-power←weak-orthogonator {f = f} {g} lift
   = section←fibres _ fib where
@@ -73,7 +79,7 @@ sec-pb-power≃weak-orthogonator
   : ∀ {𝓤 𝓥 𝓦 𝓛} {A : Type 𝓤} {B : Type 𝓥}
       {C : Type 𝓦} {D : Type 𝓛}
       {f : A → B} {g : C → D}
-    → weak-orthogonator f g
+    → lifting-operation f g
     ≃ section (pullback-power f g)
 sec-pb-power≃weak-orthogonator {f = f}{g}
   = Π (Arrow-map f g) Lift
@@ -85,34 +91,39 @@ sec-pb-power≃weak-orthogonator {f = f}{g}
 }
 
 \subtree[stt-005O]{
-\title{Weak orthogonators for types}
+\title{Lifting operations for types}
 \taxon{Definition}
 
-\p{A weak orthogonator for a type mirrors the definitions
+\p{
+A lifting operation for a type mirrors the definitions
 for the stronger notion of [orthogonality at types](stt-004O).
 We require not that the precomposition by #{f} is an equivalence,
 but instead talk about the \em{type} of sections to postcomposition by #{f}.
 }
 
-\p{A weak orthogonator for type #{X} with respect to a map #{f : A \to B}
-is a section of #{X^f : (B \to X) \to (A \to X)}.}
+\p{
+A \em{lifting operation} for the type #{X} with respect to a map #{f : A \to B}
+is a section of #{X^f : (B \to X) \to (A \to X)}.
+}
 
 \agda{
-weak-type-orthogonator
+lifting-operation-for-type
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
       (f : A → B) (X : Type 𝓦)
     → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦)
-weak-type-orthogonator f X = section (precomp X f)
+lifting-operation-for-type f X = section (precomp X f)
 }
 }
 
 \subtree[stt-005P]{
 \taxon{Theorem}
 
-\p{Mirroring the [corresponding theorem](stt-004Q) for orthogonality,
-we can say that the type of weak type orthogonators for #{X} against #{f}
-is equivalent to the type of weak orthoginators for the map #{! : A \to 1}
-against #{f}.}
+\p{
+Mirroring the [corresponding theorem](stt-004Q) for orthogonality,
+we can say that the type of lifting operations for the type #{X} against #{f}
+is equivalent to the type of lifting operations for the map #{! : A \to 1}
+against #{f}.
+}
 
 \todo{Proof!}
 }
@@ -121,10 +132,12 @@ against #{f}.}
 \taxon{Definition}
 \title{Algebraically injective types}
 
-\p{Given a family of maps #{f_i : A_i \to B_i}, we say that the type
+\p{
+Given a family of maps #{f_i : A_i \to B_i}, we say that the type
 of \em{algebraic} #{f\rm{-injectives}} for #{X} is, for any map
 #{a : A_i \to X}, a choice of extension for #{a} along #{f_i}. That
-is, the following diagram commutes for all #{i}: }
+is, the following diagram commutes for all #{i}:
+}
 
 \quiver{
 \begin{tikzcd}
@@ -138,7 +151,7 @@ is, the following diagram commutes for all #{i}: }
 }
 
 \p{We observe that this definition is equivalent to asking for
-a chosen [weak orthogonator](stt-005O) for #{X} against each #{f_i}.}
+a chosen [lifting operation](stt-005O) for #{X} against each #{f_i}.}
 
 \agda{
 Algebraic-injective
@@ -147,7 +160,7 @@ Algebraic-injective
       (f : (i : I) → A i → B i)
       (X : Type 𝓦)
     → Type (𝓘 ⊔ 𝓤 ⊔ 𝓥 ⊔ 𝓦)
-Algebraic-injective f X = ∀ i → weak-type-orthogonator (f i) X
+Algebraic-injective f X = ∀ i → lifting-operation-for-type (f i) X
 
 lift-alg-inj
   : ∀ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘}
@@ -166,10 +179,11 @@ lift-alg-inj alg i = alg i .fst
 \title{Free algebraically injective types}
 \citek{RSS2020}
 
-\p{Given a family of types #{f_i : A_i \to B_i} and a type #{X}, we can
+\p{
+Given a family of types #{f_i : A_i \to B_i} and a type #{X}, we can
 define the free algebraically #{f\rm{-injective}} type on #{X}, called
-#{\mathcal{J}_{f}(X)} with the following
-higher inductive type:}
+#{\mathcal{J}_{f}(X)} with the following higher inductive type:
+}
 
 \ul{
 \li{#{\eta : X \to \mathcal{J}_{f}(X)}}
@@ -178,96 +192,98 @@ higher inductive type:}
                      \rm{ext}_i(g,f(a)) = g(a)}}
 }
 
-\p{In plain agda we have to define higher inductive types via
-postulates.}
+\p{
+In plain agda we have to define higher inductive types via postulates.
+}
 
 \agda{
-module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
-         {B : I → Type 𝓥} where
-  postulate
-    Free-inj : (f : ∀ i → A i → B i) → Type 𝓦 → Type 𝓦
+module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤} {B : I → Type 𝓥} where
 
-  module Free-inj {f : ∀ i → A i → B i} {X : Type 𝓦} where
+  postulate
+    FreeInj : (f : (i : I) → A i → B i) → Type 𝓦 → Type 𝓦
+
+  module FreeInj {f : (i : I) → A i → B i} {X : Type 𝓦} where
+
     postulate
-      inc   : X → Free-inj f X
+      inc : X → FreeInj f X
       ext
-        : ∀ {i} → (g : A i → Free-inj f X)
-          → B i → Free-inj f X
-      is-ext : ∀ {i} → (g : A i → Free-inj f X)
-                          (a : A i) → ext g (f i a) ＝ g a
+        : {i : I} (g : A i → FreeInj f X) → B i → FreeInj f X
+      is-ext
+        : {i : I}
+          (g : A i → FreeInj f X)
+          (a : A i)
+        → ext g (f i a) ＝ g a
 
       ind
-        : ∀ {𝓜} (P : Free-inj f X → Type 𝓜)
+        : ∀ {𝓜} (P : FreeInj f X → Type 𝓜)
             (N : (x : X) → P (inc x))
-            (R : ∀ {i} (g : A i → Free-inj f X)
+            (R : {i : I} (g : A i → FreeInj f X)
                  (h : (a : A i) → P (g a))
-           → ∀ (b : B i) → P (ext g b))
-            (S : ∀ {i} (g : A i → Free-inj f X)
-            (h : (a : A i) → P (g a))
-            (a : A i)
-           → tr P (is-ext g a) (R g h (f i a)) ＝ h a)
-          → (x : Free-inj f X) → P x
+               → (b : B i) → P (ext g b))
+            (S : {i : I} (g : A i → FreeInj f X)
+                 (h : (a : A i) → P (g a))
+                 (a : A i)
+               → tr P (is-ext g a) (R g h (f i a)) ＝ h a)
+          → (x : FreeInj f X) → P x
 
       ind-inc
-        : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
+        : ∀ {𝓜} {P : FreeInj f X → Type 𝓜}
             {N : (x : X) → P (inc x)}
-            {R : ∀ {i} (g : A i → Free-inj f X)
-             (h : (a : A i) → P (g a))
-           → ∀ (b : B i) → P (ext g b)}
-            {S : ∀ {i} (g : A i → Free-inj f X)
-             (h : (a : A i) → P (g a))
-             (a : A i)
-           → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
-          → ∀ x → ind P N R S (inc x) ＝ N x
+            {R : {i : I} (g : A i → FreeInj f X)
+                 (h : (a : A i) → P (g a))
+               → (b : B i) → P (ext g b)}
+            {S : {i : I} (g : A i → FreeInj f X)
+                 (h : (a : A i) → P (g a))
+                 (a : A i)
+               → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
+          → (x : X) → ind P N R S (inc x) ＝ N x
 
       ind-ext
-        : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
+        : ∀ {𝓜} {P : FreeInj f X → Type 𝓜}
             {N : (x : X) → P (inc x)}
-            {R : ∀ {i} (g : A i → Free-inj f X)
-             (h : (a : A i) → P (g a))
-           → ∀ (b : B i) → P (ext g b)}
-            {S : ∀ {i} (g : A i → Free-inj f X)
-             (h : (a : A i) → P (g a))
-             (a : A i)
-           → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
-          → ∀ {i} (g : A i → Free-inj f X)
-             (h : (a : A i) → P (g a))
+            {R : {i : I} (g : A i → FreeInj f X)
+                 (h : (a : A i) → P (g a))
+               → (b : B i) → P (ext g b)}
+            {S : {i : I} (g : A i → FreeInj f X)
+                 (h : (a : A i) → P (g a))
+                 (a : A i)
+               → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
+          → {i : I} (g : A i → FreeInj f X)
+            (h : (a : A i) → P (g a))
           → (b : B i) → ind P N R S (ext g b) ＝ R g h b
 
     ind-ext-base
-      : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
+      : ∀ {𝓜} {P : FreeInj f X → Type 𝓜}
           {N : (x : X) → P (inc x)}
-          {R : ∀ {i} (g : A i → Free-inj f X)
-           (h : (a : A i) → P (g a))
-         → ∀ (b : B i) → P (ext g b)}
-          {S : ∀ {i} (g : A i → Free-inj f X)
-           (h : (a : A i) → P (g a))
-           (a : A i)
-         → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
-        → ∀ {i} (g : A i → Free-inj f X)
+          {R : {i : I} (g : A i → FreeInj f X)
+               (h : (a : A i) → P (g a))
+             → (b : B i) → P (ext g b)}
+          {S : {i : I} (g : A i → FreeInj f X)
+               (h : (a : A i) → P (g a))
+               (a : A i)
+             → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
+        → {i : I} (g : A i → FreeInj f X)
         → (b : B i)
         → ind P N R S (ext g b)
-        ＝
-        R g (ind P N R S ∘ g) b
+        ＝ R g (ind P N R S ∘ g) b
     ind-ext-base g = ind-ext g _
 
     {-# REWRITE ind-inc ind-ext-base #-}
+
     postulate
       ind-is-ext
-        : ∀ {𝓜} {P : Free-inj f X → Type 𝓜}
+        : ∀ {𝓜} {P : FreeInj f X → Type 𝓜}
             {N : (x : X) → P (inc x)}
-            {R : ∀ {i} (g : A i → Free-inj f X)
-                   (h : (a : A i) → P (g a))
-                 → ∀ (b : B i) → P (ext g b)}
-            {S : ∀ {i} (g : A i → Free-inj f X)
-                   (h : (a : A i) → P (g a))
-                   (a : A i)
-                 → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
-          → ∀ {i} (g : A i → Free-inj f X)
-            (a : A i)
+            {R : {i : I} (g : A i → FreeInj f X)
+                 (h : (a : A i) → P (g a))
+               → (b : B i) → P (ext g b)}
+            {S : {i : I} (g : A i → FreeInj f X)
+                 (h : (a : A i) → P (g a))
+                 (a : A i)
+               → tr P (is-ext g a) (R g h (f i a)) ＝ h a}
+          → {i : I} (g : A i → FreeInj f X) (a : A i)
           → apᶠ (ind P N R S) (is-ext g a)
-          ＝
-          S g (ind P N R S ∘ g) a
+          ＝ S g (ind P N R S ∘ g) a
 }
 }
 
@@ -277,15 +293,15 @@ module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
 \taxon{Theorem}
 
 \agda{
-module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
-         {B : I → Type 𝓥} where
-  injector-Free-inj
-    : ∀ {f : (i : I) → A i → B i}
-        {X : Type 𝓦}
-      → Algebraic-injective f (Free-inj f X)
-  injector-Free-inj i .fst = Free-inj.ext
-  injector-Free-inj i .snd α
-    = funext→ (Free-inj.is-ext α)
+module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤} {B : I → Type 𝓥} where
+
+  injector-FreeInj
+    : {f : (i : I) → A i → B i}
+      {X : Type 𝓦}
+    → Algebraic-injective f (FreeInj f X)
+  injector-FreeInj i .fst = FreeInj.ext
+  injector-FreeInj i .snd α
+    = funext→ (FreeInj.is-ext α)
 }
 }
 
@@ -293,10 +309,12 @@ module _ {𝓘 𝓤 𝓥 𝓦} {I : Type 𝓘} {A : I → Type 𝓤}
 \title{Morphisms of algebraic injectives}
 \date{2025-06-21}
 
-\p{Given a pair of algebraic injectives #{(X,x)} and #{(Y,y)} over
+\p{
+Given a pair of algebraic injectives #{(X,x)} and #{(Y,y)} over
 the same family of maps, #{f_i}, we define the type of morphisms
 of algebraic injectives: #{\Hom((X,x), (Y,y))} to be the
-type of maps which commute coherently with the given extensions.}
+type of maps which commute coherently with the given extensions.
+}
 
 \quiver{
 \begin{tikzcd}
@@ -315,22 +333,23 @@ type of maps which commute coherently with the given extensions.}
 
 \agda{
 record Algebraic-injective-map
-  {𝓘 𝓤 𝓥 𝓦 𝓜} {I : Type 𝓘}
-      {A : I → Type 𝓤} {B : I → Type 𝓥}
-      {f : (i : I) → A i → B i}
-      {X : Type 𝓦} (X-alg : Algebraic-injective f X)
-      {Y : Type 𝓜} (Y-alg : Algebraic-injective f Y)
-      (α : X → Y)
-    : Type (𝓘 ⊔ 𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓜) where
+    {𝓘 𝓤 𝓥 𝓦 𝓜} {I : Type 𝓘}
+    {A : I → Type 𝓤} {B : I → Type 𝓥}
+    {f : (i : I) → A i → B i}
+    {X : Type 𝓦} (X-alg : Algebraic-injective f X)
+    {Y : Type 𝓜} (Y-alg : Algebraic-injective f Y)
+    (α : X → Y)
+  : Type (𝓘 ⊔ 𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓜) where
   field
-    ext-comm : ∀ i p → (α ∘ lift-alg-inj X-alg i p)
-                         ~
-                      lift-alg-inj Y-alg i (α ∘ p)
-    ext-comm-coh : ∀ i → (postcomp (A i) α ◂ X-alg i .snd)
-                           ~
-                          (λ a → funext→ (ext-comm i a ∘ f i))
-                            ~∙
-                            Y-alg i .snd ▸ postcomp (A i) α
+
+    ext-comm
+      : ∀ i p
+        → (α ∘ lift-alg-inj X-alg i p)
+        ~ lift-alg-inj Y-alg i (α ∘ p)
+    ext-comm-coh
+      : ∀ i
+        → (postcomp (A i) α ◂ X-alg i .snd)
+        ~ (λ a → funext→ (ext-comm i a ∘ f i)) ~∙ Y-alg i .snd ▸ postcomp (A i) α
 }
 }
 
@@ -339,11 +358,13 @@ record Algebraic-injective-map
 \title{The universal property for free algebraic injectives}
 \taxon{Theorem}
 
-\p{We show that any map into an algebraically injective type
+\p{
+We show that any map into an algebraically injective type
 factors through the free algebraically injective type. In other
 words, given types #{X} and #{Y}, where #{X} is an algebraically
 injective type, the map #{{-} \circ \eta : (\mathcal{J}_{f}(X) \to Y) \to
-(X \to Y)} is an equivalence.}
+(X \to Y)} is an equivalence.
+}
 
 \todo{Proof}
 }

--- a/src/Axioms/FreeAlgebraicInjectives.lagda.tree
+++ b/src/Axioms/FreeAlgebraicInjectives.lagda.tree
@@ -64,24 +64,24 @@ is equivalent to type of sections of the [pullback power](stt-004D)
  #{\pullpow{f}{g}}.}
 
 \agda{
-sec-pb-power←weak-orthogonator
+sec-pb-power←lifting-operation
   : ∀ {𝓤 𝓥 𝓦 𝓛} {A : Type 𝓤} {B : Type 𝓥}
       {C : Type 𝓦} {D : Type 𝓛}
       {f : A → B} {g : C → D}
     → lifting-operation f g
     → section (pullback-power f g)
-sec-pb-power←weak-orthogonator {f = f} {g} lift
+sec-pb-power←lifting-operation {f = f} {g} lift
   = section←fibres _ fib where
   fib : ∀ (H : Arrow-map f g) → fibre (pullback-power f g) H
   fib H =  _≃_.bwd (pb-power-fibre≃lifts _ _ _) (lift H)
 
-sec-pb-power≃weak-orthogonator
+sec-pb-power≃lifting-operation
   : ∀ {𝓤 𝓥 𝓦 𝓛} {A : Type 𝓤} {B : Type 𝓥}
       {C : Type 𝓦} {D : Type 𝓛}
       {f : A → B} {g : C → D}
     → lifting-operation f g
     ≃ section (pullback-power f g)
-sec-pb-power≃weak-orthogonator {f = f}{g}
+sec-pb-power≃lifting-operation {f = f}{g}
   = Π (Arrow-map f g) Lift
       ≃⟨ postcomp-Π-≃ (λ c → pb-power-fibre≃lifts _ _ c e⁻¹) ⟩
     Π (Arrow-map f g) (fibre (pullback-power f g))

--- a/src/Axioms/FreeAlgebraicInjectives.lagda.tree
+++ b/src/Axioms/FreeAlgebraicInjectives.lagda.tree
@@ -37,8 +37,8 @@ lifting solution to lifting problems as above. When this
 uniqueness requirement is lifted we can speak of the type
 of \em{lifting operations} between a pair of maps, which give a chosen
 lift for each lifting problem. When this type is only merely
-inhabited we say that #{f} \em{merely lifts} against #{g}, and that
-#{f} has the \em{lifting property} with respect to #{g}.
+inhabited we say that #{g} \em{merely lifts} against #{f}, and that
+#{g} has the \em{lifting property} with respect to #{f}.
 }
 
 \p{

--- a/src/Modalities/Instances/Localisation.lagda.tree
+++ b/src/Modalities/Instances/Localisation.lagda.tree
@@ -154,7 +154,7 @@ module _ {𝓘 𝓤 𝓥 𝓦 : Level} {I : Type 𝓘}
     f' f (inr i) = ∇ (f i)
 
   Loc : (f : ∀ i → A i → B i) → Type 𝓦 → Type 𝓦
-  Loc f = Free-inj (f' f)
+  Loc f = FreeInj (f' f)
 
   Loc-is-local
     : ∀ {X : Type 𝓦}
@@ -164,8 +164,8 @@ module _ {𝓘 𝓤 𝓥 𝓦 : Level} {I : Type 𝓘}
     =  is-local←sec←sec-∇
          (λ i → sec-3-for-2 {f = precomp _ unlift} {precomp _ (f i)}
                              (precomp-equiv (is-equiv⁻¹ lift-is-equiv))
-                             (injector-Free-inj (inl i)))
-         (λ i → injector-Free-inj (inr i))
+                             (injector-FreeInj (inl i)))
+         (λ i → injector-FreeInj (inr i))
 }
 }
 
@@ -192,9 +192,9 @@ postcomp-inj
       {B : I → Type 𝓥}
       {f : (i : I) → A i → B i}
       (X : Type 𝓦) {Y : Type 𝓜}
-    → (Free-inj f X → Y)
+    → (FreeInj f X → Y)
     → (X → Y)
-postcomp-inj X {Y} = precomp Y Free-inj.inc
+postcomp-inj X {Y} = precomp Y FreeInj.inc
 }
 \proof{
 
@@ -204,7 +204,7 @@ postcomp-inj X {Y} = precomp Y Free-inj.inc
    \mathcal{J}_f(X) \to Y}.  }
 
 \agda{
-Free-inj-reflects
+FreeInj-reflects
   : ∀ {𝓘 𝓤 𝓥 𝓦 𝓜}
       {I : Type 𝓘} {A : I → Type 𝓤}
       {B : I → Type 𝓥}
@@ -212,7 +212,7 @@ Free-inj-reflects
       (X : Type 𝓦) {Y : Type 𝓜}
     → is-local f Y
     → is-equiv (postcomp-inj {f = f} X {Y})
-Free-inj-reflects {I = I} {A} {B} {f} X {Y} Y-loc
+FreeInj-reflects {I = I} {A} {B} {f} X {Y} Y-loc
   = is-equiv←is-pathsplit ps where
   module Y {i} = is-equiv (Y-loc i)
 }
@@ -238,11 +238,11 @@ algebraic injective:}
 
 \agda{
   sec-postcomp-inj : section (postcomp-inj X)
-  sec-postcomp-inj .fst g = Free-inj.ind
+  sec-postcomp-inj .fst g = FreeInj.ind
                      (λ _ → Y)
                      g
                      (λ _ → Y.bwd)
-                     λ g' h a → tr-const (Free-inj.is-ext g' a)
+                     λ g' h a → tr-const (FreeInj.is-ext g' a)
                                 ∙ happly (Y.ε h) a
   sec-postcomp-inj .snd h = refl
 }
@@ -330,35 +330,35 @@ h(x)}, which we do again by induction on #{x} with the motive #{x
 }
 
 \agda{
-  lem : (g h : Free-inj f X → Y)
+  lem : (g h : FreeInj f X → Y)
      (i : I)
-     (g' : A i → Free-inj _ X)
+     (g' : A i → FreeInj _ X)
      (q : g ∘ g' ~ h ∘ g') →
-     precomp Y (f i) (g ∘ Free-inj.ext g') ~
-     precomp Y (f i) (h ∘ Free-inj.ext g')
-  lem g h i g' K =      g ◂ (Free-inj.is-ext g')
+     precomp Y (f i) (g ∘ FreeInj.ext g') ~
+     precomp Y (f i) (h ∘ FreeInj.ext g')
+  lem g h i g' K =      g ◂ (FreeInj.is-ext g')
                      ~∙ K
-                     ~∙ (h ◂ Free-inj.is-ext g' ~⁻¹)
+                     ~∙ (h ◂ FreeInj.is-ext g' ~⁻¹)
 
   opaque
     secAp
-      : ∀ (g h : Free-inj f X → Y)
-        → section (prewhisker Free-inj.inc g h)
+      : ∀ (g h : FreeInj f X → Y)
+        → section (prewhisker FreeInj.inc g h)
     secAp g h .fst H
-      = Free-inj.ind (λ z → g z ＝ h z)
+      = FreeInj.ind (λ z → g z ＝ h z)
           H
           (λ f' (K : g ∘ f' ~ h ∘ f')
             → Y▸.bwd (lem g h _ f' K))
           λ f' (K : g ∘ f' ~ h ∘ f') a
             → Idᵈ-func←Square
-               (Free-inj.is-ext f' a)
+               (FreeInj.is-ext f' a)
                _
                (K a)
                (Square←brt＝l
-                 (ap g (Free-inj.is-ext f' a))
-                 {ap h (Free-inj.is-ext f' a)}
-                 {Y▸.bwd {g = g ∘ Free-inj.ext f'}
-                         {h = h ∘ Free-inj.ext f'}
+                 (ap g (FreeInj.is-ext f' a))
+                 {ap h (FreeInj.is-ext f' a)}
+                 {Y▸.bwd {g = g ∘ FreeInj.ext f'}
+                         {h = h ∘ FreeInj.ext f'}
                          (lem g h _ f' K) (f _ a)}
                  (sym (happly (Y▸.ε (lem g h _ f' K)) a)))
     secAp g h .snd K = refl
@@ -476,10 +476,10 @@ module _
   Local-global-reflectors
     : is-globally-reflective Local-gSubU
   Local-global-reflectors .○ = Loc f
-  Local-global-reflectors .η = Free-inj.inc
+  Local-global-reflectors .η = FreeInj.inc
   Local-global-reflectors .η-is-reflector .○∈S = Loc-is-local
   Local-global-reflectors .η-is-reflector .reflects cloc
-    = Free-inj-reflects _ λ where
+    = FreeInj-reflects _ λ where
        (inl i) → is-equiv-∘ (precomp-equiv (is-equiv⁻¹ lift-is-equiv))
                              (cloc i)
        (inr i) → is-local∇←is-local (f i) (cloc i)

--- a/src/Modalities/Instances/Nullification.lagda.tree
+++ b/src/Modalities/Instances/Nullification.lagda.tree
@@ -161,7 +161,7 @@ Null∙
   : ∀ {𝓘 𝓤 𝓥} {I : Type 𝓘} (A : I → Type 𝓤)
       (A∙ : Π _ A) (X : Type 𝓥)
     → Type 𝓥
-Null∙ A _ X = Free-inj
+Null∙ A _ X = FreeInj
                (λ i → !: A i)
                 X
 
@@ -173,9 +173,9 @@ Null∙-is-null
 Null∙-is-null a = is-null←is-local I where
   I : is-local (λ _ → !) _
   I i = is-equiv←qinv λ where
-    .fst → injector-Free-inj i .fst
-    .snd .fst α → funext→ (λ _ → Free-inj.is-ext (α ∘ !) (a i))
-    .snd .snd → injector-Free-inj i .snd
+    .fst → injector-FreeInj i .fst
+    .snd .fst α → funext→ (λ _ → FreeInj.is-ext (α ∘ !) (a i))
+    .snd .snd → injector-FreeInj i .snd
 }
 }
 
@@ -217,11 +217,11 @@ module _ where
           (a∙ : ∀ i → A i)
         → is-globally-reflective (Null-gSubU A)
     Null∙-global-reflectors a .○ = Null∙ _ a
-    Null∙-global-reflectors a .η = Free-inj.inc
+    Null∙-global-reflectors a .η = FreeInj.inc
     Null∙-global-reflectors a .η-is-reflector
       .○∈S = Null∙-is-null a
     Null∙-global-reflectors a .η-is-reflector
-      .reflects cnull = Free-inj-reflects _ (is-local←is-null cnull)
+      .reflects cnull = FreeInj-reflects _ (is-local←is-null cnull)
 
   Null∙-reflective
     : ∀ {𝓘 𝓤 𝓦} {I : Type 𝓘}

--- a/trees/stt/stt-006O.tree
+++ b/trees/stt/stt-006O.tree
@@ -10,7 +10,7 @@
 
 \ul{
 \li{Defined the notion of [pathsplit maps](stt-005Q) \ref{Foundations.PathSplit}}
-  \li{Defined the notion of [weak orthogonators](stt-005L)
+  \li{Defined the notion of [lifting operations](stt-005L)
       and [algebraic injectives](stt-005J), as well as a higher inductive
       type corresponding to [free algebraic injectives](stt-005I).
       \ref{Axioms.FreeAlgebraicInjectives}.}


### PR DESCRIPTION
Replaces the terminology "weak orthogonator" with the established term "lifting operation", and disambiguates it from the term "lifting property".

#150 