### PR TITLE
chore: Remove distributivity assumption in `Synthetic`

### DIFF
--- a/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
+++ b/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
@@ -94,6 +94,9 @@ module _ {𝓤} {A : Type 𝓤} {L : Lattice A} where
       : ∀ {a b : Δ² L} (p : a .Δ².s ＝ b .Δ².s) (q : a .Δ².t ＝ b .Δ².t)
         → ap Δ².t (Δ²-ext {a = a} {b = b} (p , q)) ＝ q
     Δ²-ext-ap-t {a} {b} refl refl = is-set←is-truncated carrier-is-0-truncated _ _ _ _
+
+  ι-const : A → Δ² L
+  ι-const x = (x , x)
 }
 }
 
@@ -259,10 +262,7 @@ constant terms are definitionally equal, for the linear terms we need:
 commutativity of #{\lor}.}
 
 \agda{
-  ι-const : A → Δ² L
-  ι-const x = (x , x)
-
-  L[x]-is-lattice-algebra : is-lattice-hom L L[x] ι-const
+  L[x]-is-lattice-algebra : is-lattice-hom L L[x] (ι-const {L = L})
   L[x]-is-lattice-algebra .is-lattice-hom.pres-∨
     = Δ²-ext (refl , refl)
   L[x]-is-lattice-algebra .is-lattice-hom.pres-∧
@@ -287,7 +287,7 @@ we show this map is a [morphism of lattice algebras](stt-009Z).}
   eval-polynomial
     : ∀ {𝓤} {B : Type 𝓤} (M : Lattice B) {i : A → B}
       → is-lattice-algebra L M i
-      → B → Coslice-map ι-const i
+      → B → Coslice-map (ι-const {L = L}) i
   eval-polynomial M {i} ialg x .fst (a₀ , a₁) = (i a₀ M.∧ x) M.∨ i a₁
     where module M = Lattice M
   eval-polynomial M {i} ialg b .snd a = M.∨-comm ∙ M.∨-∧-abs where

--- a/src/Synthetic/Boundaries.lagda.tree
+++ b/src/Synthetic/Boundaries.lagda.tree
@@ -9,7 +9,7 @@ open import Foundations.Prelude
 open import Algebra.Lattice
 
 module Synthetic.Boundaries
-  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹) (I-distr : is-distributive I)
+  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹)
   where
 
 open import Axioms.UF
@@ -17,18 +17,13 @@ open import Axioms.UF
 open Lattice I renaming (0l to i0; 1l to i1)
 import Algebra.Lattice.Instances.Polynomial as Poly
 open Poly  hiding (L[x]; Δ²)
-open is-distributive I-distr
 
 private
   Δ² = Poly.Δ² I
-  I[x] = Poly.L[x] I
-
 
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Horns Δ¹ I
-
-open import Ergonomics.Extensionality
 
 open import Modalities.GlobalReflectiveSubuniverses
 open import Modalities.Instances.Truncation

--- a/src/Synthetic/Boundaries.lagda.tree
+++ b/src/Synthetic/Boundaries.lagda.tree
@@ -26,7 +26,7 @@ private
 
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 
 open import Ergonomics.Extensionality
 

--- a/src/Synthetic/Categories/AlgebraicLaws.lagda.tree
+++ b/src/Synthetic/Categories/AlgebraicLaws.lagda.tree
@@ -26,7 +26,7 @@ open is-distributive I-distr
 open import Ergonomics.Extensionality
 
 open import Synthetic.Hom Δ¹ i0 i1
-open import Synthetic.Simplicial Δ¹ I I-distr
+open import Synthetic.Simplicial Δ¹ I
 open import Synthetic.Categories.CovariantFamilies Δ¹ I I-distr
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Homotopy Δ¹ I I-distr

--- a/src/Synthetic/Categories/CoComma.lagda.tree
+++ b/src/Synthetic/Categories/CoComma.lagda.tree
@@ -49,7 +49,7 @@ open import Ergonomics.Extensionality
 open import Ergonomics.Representation
 
 open import Synthetic.Hom Δ¹ i0 i1
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Categories.NaturalTransformations Δ¹ I I-distr
 }
 

--- a/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
@@ -31,7 +31,7 @@ open import Ergonomics.Notations.Orthogonality
 open Core.Orthogonal.notation
 
 open import Synthetic.Hom Δ¹ i0 i1
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 }
 

--- a/src/Synthetic/Categories/ContravariantHomFamilies.lagda.tree
+++ b/src/Synthetic/Categories/ContravariantHomFamilies.lagda.tree
@@ -54,7 +54,7 @@ open Core.Orthogonal.notation
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Categories.ContravariantFamilies Δ¹ I I-distr
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Comma Δ¹ I I-distr

--- a/src/Synthetic/Categories/ContravariantHomFamilies.lagda.tree
+++ b/src/Synthetic/Categories/ContravariantHomFamilies.lagda.tree
@@ -60,7 +60,7 @@ open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Comma Δ¹ I I-distr
 open import Synthetic.Categories.CoComma Δ¹ I I-distr
 open import Synthetic.Categories.JoinSlice Δ¹ I I-distr
-open import Synthetic.Simplicial Δ¹ I I-distr
+open import Synthetic.Simplicial Δ¹ I
 open import Synthetic.Categories.Homotopy Δ¹ I I-distr
 open import Synthetic.Categories.RightSegal Δ¹ I I-distr
 }

--- a/src/Synthetic/Categories/ContravariantHomFamilies.lagda.tree
+++ b/src/Synthetic/Categories/ContravariantHomFamilies.lagda.tree
@@ -55,7 +55,7 @@ open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Categories.ContravariantFamilies Δ¹ I I-distr
 open import Synthetic.Boundaries Δ¹ I I-distr
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Comma Δ¹ I I-distr
 open import Synthetic.Categories.CoComma Δ¹ I I-distr

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -35,7 +35,7 @@ open import Core.OrthogonalClosure
 open notation
 
 open import Synthetic.Hom Δ¹ i0 i1
-open import Synthetic.Simplicial Δ¹ I I-distr
+open import Synthetic.Simplicial Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.CovariantFamilies Δ¹ I I-distr
 open import Synthetic.Categories.ContravariantFamilies Δ¹ I I-distr

--- a/src/Synthetic/Categories/CovariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/CovariantFamilies.lagda.tree
@@ -53,7 +53,7 @@ open Core.Orthogonal.notation
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Categories.Groupoids Δ¹ I I-distr public
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Boundaries Δ¹ I I-distr
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 }

--- a/src/Synthetic/Categories/CovariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/CovariantFamilies.lagda.tree
@@ -54,7 +54,7 @@ open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Categories.Groupoids Δ¹ I I-distr public
 open import Synthetic.Horns Δ¹ I
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 }
 

--- a/src/Synthetic/Categories/CovariantHomFamily.lagda.tree
+++ b/src/Synthetic/Categories/CovariantHomFamily.lagda.tree
@@ -62,7 +62,7 @@ open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Comma Δ¹ I I-distr
 open import Synthetic.Categories.CoComma Δ¹ I I-distr
 open import Synthetic.Categories.JoinSlice Δ¹ I I-distr
-open import Synthetic.Simplicial Δ¹ I I-distr
+open import Synthetic.Simplicial Δ¹ I
 open import Synthetic.Categories.Homotopy Δ¹ I I-distr
 open import Synthetic.Categories.LeftSegal Δ¹ I I-distr
 }

--- a/src/Synthetic/Categories/CovariantHomFamily.lagda.tree
+++ b/src/Synthetic/Categories/CovariantHomFamily.lagda.tree
@@ -56,7 +56,7 @@ open Core.Orthogonal.notation
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Categories.CovariantFamilies Δ¹ I I-distr
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Comma Δ¹ I I-distr

--- a/src/Synthetic/Categories/CovariantHomFamily.lagda.tree
+++ b/src/Synthetic/Categories/CovariantHomFamily.lagda.tree
@@ -57,7 +57,7 @@ open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Categories.CovariantFamilies Δ¹ I I-distr
 open import Synthetic.Boundaries Δ¹ I I-distr
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Comma Δ¹ I I-distr
 open import Synthetic.Categories.CoComma Δ¹ I I-distr

--- a/src/Synthetic/Categories/FullyFaithfulMaps.lagda.tree
+++ b/src/Synthetic/Categories/FullyFaithfulMaps.lagda.tree
@@ -16,7 +16,7 @@ open Lattice I renaming (0l to i0; 1l to i1)
 
 open import Foundations.Embeddings
 
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Hom Δ¹ i0 i1
 
 open import Core.Arrows

--- a/src/Synthetic/Categories/Groupoids.lagda.tree
+++ b/src/Synthetic/Categories/Groupoids.lagda.tree
@@ -40,7 +40,7 @@ open import Ergonomics.Extensionality
 
 open import Synthetic.Simplicial Δ¹ I I-distr
 open import Synthetic.Hom Δ¹ i0 i1
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Boundaries Δ¹ I I-distr
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Homotopy Δ¹ I I-distr

--- a/src/Synthetic/Categories/Groupoids.lagda.tree
+++ b/src/Synthetic/Categories/Groupoids.lagda.tree
@@ -41,7 +41,7 @@ open import Ergonomics.Extensionality
 open import Synthetic.Simplicial Δ¹ I I-distr
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Horns Δ¹ I
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Homotopy Δ¹ I I-distr
 }

--- a/src/Synthetic/Categories/Groupoids.lagda.tree
+++ b/src/Synthetic/Categories/Groupoids.lagda.tree
@@ -38,7 +38,7 @@ open import Core.Joins
 
 open import Ergonomics.Extensionality
 
-open import Synthetic.Simplicial Δ¹ I I-distr
+open import Synthetic.Simplicial Δ¹ I
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Horns Δ¹ I
 open import Synthetic.Boundaries Δ¹ I

--- a/src/Synthetic/Categories/Homotopy.lagda.tree
+++ b/src/Synthetic/Categories/Homotopy.lagda.tree
@@ -48,7 +48,7 @@ open Core.Orthogonal.notation
 
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Boundaries Δ¹ I I-distr
 }
 

--- a/src/Synthetic/Categories/Homotopy.lagda.tree
+++ b/src/Synthetic/Categories/Homotopy.lagda.tree
@@ -49,7 +49,7 @@ open Core.Orthogonal.notation
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Horns Δ¹ I
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 }
 
 

--- a/src/Synthetic/Categories/Initial.lagda.tree
+++ b/src/Synthetic/Categories/Initial.lagda.tree
@@ -20,7 +20,7 @@ open import Axioms.UF
 open import Ergonomics.Extensionality
 
 open import Synthetic.Hom Δ¹ i0 i1
-open import Synthetic.Simplicial Δ¹ I I-distr
+open import Synthetic.Simplicial Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.CovariantFamilies Δ¹ I I-distr
 open import Synthetic.Categories.Comma Δ¹ I I-distr

--- a/src/Synthetic/Categories/JoinSlice.lagda.tree
+++ b/src/Synthetic/Categories/JoinSlice.lagda.tree
@@ -37,7 +37,7 @@ open import Ergonomics.Extensionality
 
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Categories.CoComma Δ¹ I I-distr
 open import Synthetic.Categories.Comma Δ¹ I I-distr
 open import Synthetic.Horns Δ¹ I

--- a/src/Synthetic/Categories/JoinSlice.lagda.tree
+++ b/src/Synthetic/Categories/JoinSlice.lagda.tree
@@ -40,7 +40,7 @@ open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Boundaries Δ¹ I I-distr
 open import Synthetic.Categories.CoComma Δ¹ I I-distr
 open import Synthetic.Categories.Comma Δ¹ I I-distr
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 }
 
 

--- a/src/Synthetic/Categories/LeftSegal.lagda.tree
+++ b/src/Synthetic/Categories/LeftSegal.lagda.tree
@@ -62,7 +62,7 @@ open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Comma Δ¹ I I-distr
 open import Synthetic.Categories.CoComma Δ¹ I I-distr
 open import Synthetic.Categories.JoinSlice Δ¹ I I-distr
-open import Synthetic.Simplicial Δ¹ I I-distr
+open import Synthetic.Simplicial Δ¹ I
 open import Synthetic.Categories.Homotopy Δ¹ I I-distr
 }
 

--- a/src/Synthetic/Categories/LeftSegal.lagda.tree
+++ b/src/Synthetic/Categories/LeftSegal.lagda.tree
@@ -56,7 +56,7 @@ open Core.Orthogonal.notation
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Categories.CovariantFamilies Δ¹ I I-distr
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Comma Δ¹ I I-distr

--- a/src/Synthetic/Categories/LeftSegal.lagda.tree
+++ b/src/Synthetic/Categories/LeftSegal.lagda.tree
@@ -57,7 +57,7 @@ open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Categories.CovariantFamilies Δ¹ I I-distr
 open import Synthetic.Boundaries Δ¹ I I-distr
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Comma Δ¹ I I-distr
 open import Synthetic.Categories.CoComma Δ¹ I I-distr

--- a/src/Synthetic/Categories/Precategories.lagda.tree
+++ b/src/Synthetic/Categories/Precategories.lagda.tree
@@ -42,7 +42,7 @@ open import Core.OrthogonalClosure
 open notation
 open import Ergonomics.Notations.Orthogonality
 
-open import Synthetic.Simplicial Δ¹ I I-distr
+open import Synthetic.Simplicial Δ¹ I
 open import Synthetic.Horns Δ¹ I
 open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Hom Δ¹ i0 i1

--- a/src/Synthetic/Categories/Precategories.lagda.tree
+++ b/src/Synthetic/Categories/Precategories.lagda.tree
@@ -43,7 +43,7 @@ open notation
 open import Ergonomics.Notations.Orthogonality
 
 open import Synthetic.Simplicial Δ¹ I I-distr
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Boundaries Δ¹ I I-distr
 open import Synthetic.Hom Δ¹ i0 i1
 

--- a/src/Synthetic/Categories/Precategories.lagda.tree
+++ b/src/Synthetic/Categories/Precategories.lagda.tree
@@ -44,7 +44,7 @@ open import Ergonomics.Notations.Orthogonality
 
 open import Synthetic.Simplicial Δ¹ I I-distr
 open import Synthetic.Horns Δ¹ I
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Hom Δ¹ i0 i1
 
 open import Ergonomics.Extensionality

--- a/src/Synthetic/Categories/RightSegal.lagda.tree
+++ b/src/Synthetic/Categories/RightSegal.lagda.tree
@@ -35,7 +35,7 @@ open import Modalities.Instances.Localisation
 open import Modalities.Instances.Truncation
 
 open import Synthetic.Hom Δ¹ i0 i1
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.CoComma Δ¹ I I-distr

--- a/src/Synthetic/Categories/RightSegal.lagda.tree
+++ b/src/Synthetic/Categories/RightSegal.lagda.tree
@@ -36,7 +36,7 @@ open import Modalities.Instances.Truncation
 
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Boundaries Δ¹ I I-distr
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.CoComma Δ¹ I I-distr
 

--- a/src/Synthetic/Categories/Spaces.lagda.tree
+++ b/src/Synthetic/Categories/Spaces.lagda.tree
@@ -63,7 +63,7 @@ open import Core.GlobalClassesMaps
 open import Core.UniversalFibrations
 
 open import Synthetic.Hom Δ¹ i0 i1
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Categories.CovariantFamilies Δ¹ I I-distr
 open import Synthetic.Categories.CovariantClosure Δ¹ I I-distr
 }

--- a/src/Synthetic/Categories/SpineLifting.lagda.tree
+++ b/src/Synthetic/Categories/SpineLifting.lagda.tree
@@ -62,7 +62,7 @@ open import Ergonomics.Auto
 
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 }

--- a/src/Synthetic/Categories/SpineLifting.lagda.tree
+++ b/src/Synthetic/Categories/SpineLifting.lagda.tree
@@ -63,7 +63,7 @@ open import Ergonomics.Auto
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Boundaries Δ¹ I I-distr
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 }
 

--- a/src/Synthetic/Categories/UniversalElements.lagda.tree
+++ b/src/Synthetic/Categories/UniversalElements.lagda.tree
@@ -40,7 +40,7 @@ open import Core.Postwhisker
 open import Core.PiSection
 
 open import Synthetic.Hom Δ¹ i0 i1
-open import Synthetic.Simplicial Δ¹ I I-distr
+open import Synthetic.Simplicial Δ¹ I
 open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Homotopy Δ¹ I I-distr

--- a/src/Synthetic/Categories/UniversalElements.lagda.tree
+++ b/src/Synthetic/Categories/UniversalElements.lagda.tree
@@ -41,7 +41,7 @@ open import Core.PiSection
 
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Simplicial Δ¹ I I-distr
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.Homotopy Δ¹ I I-distr
 open import Synthetic.Categories.CovariantFamilies Δ¹ I I-distr

--- a/src/Synthetic/Categories/Yoneda.lagda.tree
+++ b/src/Synthetic/Categories/Yoneda.lagda.tree
@@ -16,7 +16,7 @@ open Lattice I renaming (0l to i0; 1l to i1)
 open import Axioms.UF
 
 open import Synthetic.Hom Δ¹ i0 i1
-open import Synthetic.Simplicial Δ¹ I I-distr
+open import Synthetic.Simplicial Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I I-distr
 open import Synthetic.Categories.CovariantFamilies Δ¹ I I-distr
 open import Synthetic.Categories.CovariantClosure Δ¹ I I-distr

--- a/src/Synthetic/Disjunctive.lagda.tree
+++ b/src/Synthetic/Disjunctive.lagda.tree
@@ -41,7 +41,7 @@ open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Horns Δ¹ I
 open import Synthetic.Boundaries Δ¹ I
-open import Synthetic.Simplicial Δ¹ I I-distr
+open import Synthetic.Simplicial Δ¹ I
   using (is-simplicial; fam-is-simplicial)
 }
 

--- a/src/Synthetic/Disjunctive.lagda.tree
+++ b/src/Synthetic/Disjunctive.lagda.tree
@@ -11,7 +11,7 @@ open import Foundations.Prelude
 open import Algebra.Lattice
 
 module Synthetic.Disjunctive
-  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹) (I-distr : is-distributive I)
+  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹)
   where
 
 open import Axioms.UF

--- a/src/Synthetic/Disjunctive.lagda.tree
+++ b/src/Synthetic/Disjunctive.lagda.tree
@@ -39,7 +39,7 @@ open import Core.OrthogonalClosure
 
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Boundaries Δ¹ I I-distr
 open import Synthetic.Simplicial Δ¹ I I-distr
   using (is-simplicial; fam-is-simplicial)

--- a/src/Synthetic/Disjunctive.lagda.tree
+++ b/src/Synthetic/Disjunctive.lagda.tree
@@ -40,7 +40,7 @@ open import Core.OrthogonalClosure
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Horns Δ¹ I
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Simplicial Δ¹ I I-distr
   using (is-simplicial; fam-is-simplicial)
 }

--- a/src/Synthetic/Horns.lagda.tree
+++ b/src/Synthetic/Horns.lagda.tree
@@ -11,7 +11,7 @@ open import Foundations.Prelude
 open import Algebra.Lattice
 
 module Synthetic.Horns
-  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹) (I-distr : is-distributive I)
+  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹)
   where
 
 open import Axioms.UF
@@ -19,25 +19,19 @@ open import Axioms.UF
 open Lattice I renaming (0l to i0; 1l to i1)
 import Algebra.Lattice.Instances.Polynomial as Poly
 open Poly  hiding (L[x]; Δ²)
-open is-distributive I-distr
 
 private
   Δ² = Poly.Δ² I
-  I[x] = Poly.L[x] I
 
-open import Modalities.Subuniverses
+open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Cubes Δ¹ i0 i1
-open import Modalities.GlobalSubuniverses
-open import Modalities.GlobalReflectiveSubuniverses
-open import Modalities.Instances.Localisation
-open import Modalities.Instances.Nullification
+
 open import Modalities.Instances.Truncation
 
 open import Core.Joins
 open import Core.Arrows
 open import Core.ArrowRetracts
 open import Core.PushoutSums
-open import Foundations.Pushouts
 open import Core.FunctorialityPushouts
 open import Core.CanonicalPushouts
 open import Core.FlatteningPushouts
@@ -45,7 +39,6 @@ open import Core.SpanMaps
 
 open import Ergonomics.Extensionality
 
-open import Synthetic.Hom Δ¹ i0 i1
 }
 
 

--- a/src/Synthetic/Simplicial.lagda.tree
+++ b/src/Synthetic/Simplicial.lagda.tree
@@ -16,7 +16,7 @@ open import Foundations.Prelude
 open import Algebra.Lattice
 
 module Synthetic.Simplicial
-  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹) (I-distr : is-distributive I)
+  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹)
   where
 
 open import Axioms.UF
@@ -24,7 +24,6 @@ open import Axioms.UF
 open Lattice I renaming (0l to i0; 1l to i1)
 import Algebra.Lattice.Instances.Polynomial as Poly
 open Poly  hiding (L[x]; Δ²)
-open is-distributive I-distr
 
 private
   Δ² = Poly.Δ² I
@@ -281,8 +280,8 @@ which #{(i \leq j) \lor (j \leq i)}.}
                       (is-set←is-truncated (□-is-truncated carrier-is-0-truncated) _ _)
                       λ p → Δ²-ext (ap snd p , ap fst p)
 
-⧅-square : Arrow-map (ι-const I I-distr) □←Δ²-upper
-⧅-square .Arrow-map.top = ι-const I I-distr
+⧅-square : Arrow-map ι-const □←Δ²-upper
+⧅-square .Arrow-map.top = ι-const
 ⧅-square .Arrow-map.bot = □←Δ²-lower
 ⧅-square .Arrow-map.comm = ~refl
 

--- a/src/Synthetic/Simplicial.lagda.tree
+++ b/src/Synthetic/Simplicial.lagda.tree
@@ -54,7 +54,7 @@ open import Ergonomics.Auto
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Horns Δ¹ I
-open import Synthetic.Boundaries Δ¹ I I-distr
+open import Synthetic.Boundaries Δ¹ I
 }
 
 

--- a/src/Synthetic/Simplicial.lagda.tree
+++ b/src/Synthetic/Simplicial.lagda.tree
@@ -53,7 +53,7 @@ open import Ergonomics.Auto
 
 open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Hom Δ¹ i0 i1
-open import Synthetic.Horns Δ¹ I I-distr
+open import Synthetic.Horns Δ¹ I
 open import Synthetic.Boundaries Δ¹ I I-distr
 }
 


### PR DESCRIPTION
None of the files in the base folder `Synthetic` use distributivity, so why assume it?

Builds on #154 