### PR TITLE
chore: typos and a pre-commit fix

### DIFF
--- a/.codespell/dictionary.txt
+++ b/.codespell/dictionary.txt
@@ -98,6 +98,7 @@ cummuting->commuting
 defintition->definition
 defition->definition
 denfition->definition
+depedent->dependent
 dependance->dependence
 dependancies->dependencies
 dependancy->dependency
@@ -197,7 +198,6 @@ formalize->formalise
 formalized->formalised
 formalizes->formalises
 formalizing->formalising
-generalizable->generalisable
 generalization->generalisation
 generalizations->generalisations
 generalize->generalise

--- a/.codespell/ignore.txt
+++ b/.codespell/ignore.txt
@@ -18,4 +18,5 @@ refl
 singl
 snd
 sym
+uiver
 whitelist

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 skip = *.css,*.bib,_build,_tmp,autogen,build,output,result,MAlonzo,theme,./trees/ref,./trees/licenses
 
 # Ignore fenced code, words with interior capitals, and all 2-letter words
-ignore-regex = ```.*?```|\b\S+[A-Z]\S*\b|\b[A-Za-z]{2}\b
+ignore-regex = ```.*?```|\b[A-Za-z]*[a-z][A-Z][A-Za-z]*\b|\b[A-Za-z]{2}\b
 ignore-words = .codespell/ignore.txt
 
 # Check file names as well

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,12 +78,6 @@ repos:
     hooks:
       - id: shfmt
 
-  - repo: https://github.com/NixOS/nixfmt
-    rev: v1.2.0
-    hooks:
-      - id: nixfmt
-        exclude: ^nix/.+/thunk\.nix$
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
     hooks:

--- a/src/Core/FlatteningSequentialColimits.lagda.tree
+++ b/src/Core/FlatteningSequentialColimits.lagda.tree
@@ -18,7 +18,7 @@ open import Core.FlatteningCoequalisers
 
 
 \subtree[stt-009I]{
-\title{Flatteninig for sequential colimits}
+\title{Flattening for sequential colimits}
 \taxon{Theorem}
 
 \agda{

--- a/src/Foundations/Singletons.lagda.tree
+++ b/src/Foundations/Singletons.lagda.tree
@@ -106,7 +106,7 @@ is-prop A = ∀ (x y : A) → x ＝ y
  }
 
  \subtree[stt-000A]{
-   \taxon{Theorm}
+   \taxon{Theorem}
    \p{Every singleton is a subsingleton}
 
 

--- a/src/Foundations/TheoremOfChoice.lagda.tree
+++ b/src/Foundations/TheoremOfChoice.lagda.tree
@@ -91,7 +91,7 @@ module _
 \subtree[stt-0061]{
 \date{2025-06-19}
 \title{Sections from inhabited fibres}
-\taxon{Corolary}
+\taxon{Corollary}
 
 \p{Suppose you have a map #{f : A \to B}, with #{\Pi_{b : B}\fibre{f}{B}},
 then #{f} has a section. In fact, these types are equivalent.}


### PR DESCRIPTION
Removes the pre-commit hook `nixfmt`, which apparantly causes issues on linux?? Also makes the ignore pattern for codespell more permissive so to detect more typos.

---

Co-authored-by: Mark Williams <35178855+markrd-williams@users.noreply.github.com>