### PR TITLE
chore: fix CI triggers

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,7 @@ on:
       - main
   workflow_dispatch:
 
+# Don't cancel previous runs
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,12 @@
 on:
   pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -10,6 +17,7 @@ on:
         required: false
         default: false
 
+# Cancel previous runs of the same branch except `main`
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'main') }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,12 +1,21 @@
 name: pre-commit
 
 on:
+  # To run this workflow manually
+  workflow_dispatch:
   push:
-    branches-ignore:
+    branches:
       - main
-      - benchmark-data
   pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
+# Cancel previous runs of the same branch except `main`
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'main') }}


### PR DESCRIPTION
Pre-commit no longer triggers on pushes to arbitrary branches in this repo in addition to on pushes to pull requests. Also, currently pre-commit and build triggers on draft pull requests. This changes it so they only run once it is marked as ready for review.