### PR TITLE
bug: Fix `\agda-imports` macro name

### DIFF
--- a/trees/macros/basic-macros.tree
+++ b/trees/macros/basic-macros.tree
@@ -5,7 +5,7 @@
  \stopverb
 }
 
-\def\imports[~body]{
+\def\agda-imports[~body]{
 \scope{
 \put\transclude/expanded{false}
 \subtree{


### PR DESCRIPTION
I had forgotten to rename the actual macro in #158, this fixes that.

As an aside, it's strange to me that forester does not pick up on this with an error.