### PR TITLE
Simplify the definition of meet on the 2-simplex

### DIFF
--- a/src/Algebra/Lattice.lagda.tree
+++ b/src/Algebra/Lattice.lagda.tree
@@ -230,6 +230,10 @@ record is-lattice-hom
     pres-0 : f A.0l ＝ B.0l
     pres-1 : f A.1l ＝ B.1l
 
+  instance
+    pres-≤ : {x y : A} → ⦃ x A.≤ y ⦄ → f x B.≤ f y
+    pres-≤ ⦃ p ⦄ = sym pres-∧ ∙ ap f p
+
 unquoteDecl lattice-hom-repr≊ lattice-hom-repr≃
   = make-record-repr lattice-hom-repr≊ lattice-hom-repr≃
                      (quote is-lattice-hom)
@@ -703,6 +707,25 @@ record is-distributive {𝓤} {L : Type 𝓤} (Lat : Lattice L)  : Type 𝓤 whe
         (a₁ ∧ b₁ ∨ (a₀ ∧ b₁ ∨ a₁ ∧ b₀ ∨ a₀ ∧ b₀) ∧ x)
           ＝⟨ ∨-comm ⟩
         ((a₀ ∧ b₁ ∨ a₁ ∧ b₀ ∨ a₀ ∧ b₀) ∧ x ∨ a₁ ∧ b₁) ∎
+
+    polynomial-mult'-≤
+      : ∀ {a₀ a₁ b₀ b₁} → ⦃ a₁ ≤ a₀ ⦄ → ⦃ b₁ ≤ b₀ ⦄ → ∀ x →
+           ((a₀ ∧ x) ∨ a₁) ∧ ((b₀ ∧ x) ∨ b₁)
+        ＝ ((a₀ ∧ b₀) ∧ x) ∨ (a₁ ∧ b₁)
+    polynomial-mult'-≤ {a₀} {a₁} {b₀} {b₁} x
+      = ((a₀ ∧ x) ∨ a₁) ∧ ((b₀ ∧ x) ∨ b₁)
+          ＝⟨ polynomial-mult' x ⟩
+        (⌜ (a₀ ∧ b₁) ∨ (a₁ ∧ b₀) ∨ (a₀ ∧ b₀) ⌝ ∧ x) ∨ (a₁ ∧ b₁)
+          ＝⟨ ap! lemma ⟩
+        ((a₀ ∧ b₀) ∧ x) ∨ (a₁ ∧ b₁) ∎
+      where
+      lemma : (a₀ ∧ b₁) ∨ (a₁ ∧ b₀) ∨ (a₀ ∧ b₀) ＝ (a₀ ∧ b₀)
+      lemma
+        = ((a₀ ∧ b₁) ∨ ⌜ (a₁ ∧ b₀) ∨ (a₀ ∧ b₀) ⌝)
+            ＝⟨ ap! (≤-max auto!) ⟩
+          ((a₀ ∧ b₁) ∨ (a₀ ∧ b₀))
+            ＝⟨ ≤-max auto! ⟩
+          (a₀ ∧ b₀) ∎
 
 is-distributive-algebra
   : ∀ {𝓤 𝓥} {L : Type 𝓤} {Lat : Lattice L}

--- a/src/Algebra/Lattice.lagda.tree
+++ b/src/Algebra/Lattice.lagda.tree
@@ -708,8 +708,8 @@ record is-distributive {𝓤} {L : Type 𝓤} (Lat : Lattice L)  : Type 𝓤 whe
         ((a₀ ∧ b₁ ∨ a₁ ∧ b₀ ∨ a₀ ∧ b₀) ∧ x ∨ a₁ ∧ b₁) ∎
 
     polynomial-mult'-≤
-      : ∀ {a₀ a₁ b₀ b₁} → ⦃ a₁ ≤ a₀ ⦄ → ⦃ b₁ ≤ b₀ ⦄ → ∀ x →
-           ((a₀ ∧ x) ∨ a₁) ∧ ((b₀ ∧ x) ∨ b₁)
+      : ∀ {a₀ a₁ b₀ b₁} → ⦃ a₁ ≤ a₀ ⦄ → ⦃ b₁ ≤ b₀ ⦄ → ∀ x
+        → ((a₀ ∧ x) ∨ a₁) ∧ ((b₀ ∧ x) ∨ b₁)
         ＝ ((a₀ ∧ b₀) ∧ x) ∨ (a₁ ∧ b₁)
     polynomial-mult'-≤ {a₀} {a₁} {b₀} {b₁} x
       = ((a₀ ∧ x) ∨ a₁) ∧ ((b₀ ∧ x) ∨ b₁)

--- a/src/Algebra/Lattice.lagda.tree
+++ b/src/Algebra/Lattice.lagda.tree
@@ -230,9 +230,8 @@ record is-lattice-hom
     pres-0 : f A.0l ＝ B.0l
     pres-1 : f A.1l ＝ B.1l
 
-  instance
-    pres-≤ : {x y : A} → ⦃ x A.≤ y ⦄ → f x B.≤ f y
-    pres-≤ ⦃ p ⦄ = sym pres-∧ ∙ ap f p
+  pres-≤ : {x y : A} → ⦃ x A.≤ y ⦄ → f x B.≤ f y
+  pres-≤ ⦃ p ⦄ = sym pres-∧ ∙ ap f p
 
 unquoteDecl lattice-hom-repr≊ lattice-hom-repr≃
   = make-record-repr lattice-hom-repr≊ lattice-hom-repr≃

--- a/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
+++ b/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
@@ -136,7 +136,9 @@ module _ {𝓤} {A : Type 𝓤} (L : Lattice A) (distr : is-distributive L) wher
 \li{#{(ax \lor b) \lor (cx \lor d) = (a \lor c)x \lor (b \lor d)}}
 \li{#{(ax \lor b) \land (cx \lor d) = (ac)x \lor (bd)}}
 
-Because #{a \ge b} and #{c \ge d}, we can equivalently write the meet as the polynomial multiplication #{(ax \lor b) \land (cx \lor d) = ((bc \lor ad \lor ac)x \lor (bd))}.
+Because #{a \ge b} and #{c \ge d}, we can equivalently write the meet as the
+polynomial multiplication
+#{(ax \lor b) \land (cx \lor d) = ((bc \lor ad \lor ac)x \lor (bd))}.
 }
 
 \agda{

--- a/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
+++ b/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
@@ -236,9 +236,7 @@ we show this map is a [morphism of lattice algebras](stt-009Z).}
         ((M.ι a₀ M.∧ x M.∨ M.ι a₁) M.∨ M.ι b₀ M.∧ x M.∨ M.ι b₁) ∎
     l .pres-∧ {(a₀ , a₁)} {(b₀ , b₁)}
       = ap₂ M._∨_ (ap (M._∧ x) (M.ι-alg .pres-∧)) (M.ι-alg .pres-∧)
-        ∙ sym (Md.polynomial-mult'-≤ x)
-      where
-      open is-lattice-hom M.ι-alg
+        ∙ sym (Md.polynomial-mult'-≤ ⦃ pres-≤ M.ι-alg ⦄ ⦃ pres-≤ M.ι-alg ⦄ x)
 }
 
 \p{We exhibit #{L[x]} as the free algebra by showing that every

--- a/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
+++ b/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
@@ -134,7 +134,9 @@ module _ {𝓤} {A : Type 𝓤} (L : Lattice A) (distr : is-distributive L) wher
 \li{#{0 = 0x \lor 0}}
 \li{#{1 = 1x \lor 1}}
 \li{#{(ax \lor b) \lor (cx \lor d) = (a \lor c)x \lor (b \lor d)}}
-\li{#{(ax \lor b) \land (cx \lor d) = ((bc \lor ad \lor ac)x \lor (bd))}}
+\li{#{(ax \lor b) \land (cx \lor d) = (ac)x \lor (bd))}}
+
+Because #{a \ge b} and #{c \ge d}, we can equivalently write the meet as the polynomial multiplication #{(ax \lor b) \land (cx \lor d) = ((bc \lor ad \lor ac)x \lor (bd))}.
 }
 
 \agda{
@@ -173,14 +175,6 @@ tedious algebra:}
 
 \p{The inclusion #{\iota : L \to L[x]} that takes an #{a : L} to #{ax \lor a}
 exhibits #{L[x]} as an #{L}-algebra.}
-
-\p{The only part of the proof which does not hold definitionally is showing:
-##{\iota(x) \land \iota(y) = \iota(x \land y)}
-
-Extensionality for the 2-simplex says that we can just compare coefficients. The
-constant terms are definitionally equal, for the linear terms we need:
-#{xy \lor yy \lox xy = xy}, but this follows from the idempotence and
-commutativity of #{\lor}.}
 
 \agda{
   Free-Lattice-is-lattice-algebra

--- a/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
+++ b/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
@@ -144,7 +144,7 @@ module _ {𝓤} {A : Type 𝓤} (L : Lattice A) (distr : is-distributive L) wher
   Free-Lattice .Lattice._∨_ (a₀ , a₁) (b₀ , b₁)
     = (a₀ ∨ b₀ , a₁ ∨ b₁)
   Free-Lattice .Lattice._∧_ (a₀ , a₁) (b₀ , b₁)
-    = ((a₀ ∧ b₁) ∨ (a₁ ∧ b₀) ∨ (a₀ ∧ b₀), a₁ ∧ b₁) ⦃ ∨-≤-introl auto! ⦄
+    = (a₀ ∧ b₀ , a₁ ∧ b₁)
   Free-Lattice .Lattice.str-is-lattice = l where
 }
 
@@ -153,102 +153,17 @@ tedious algebra:}
 
 \details{
 \agda{
-    opaque
-      lemma1 : ∀ {a₀ a₁ : A} ⦃ p : a₁ ≤ a₀ ⦄ →
-               (a₀ ∧ 1l) ∨
-               (a₁ ∧ 1l) ∨ (a₀ ∧ 1l)
-               ＝ a₀
-      lemma1 {a₀} {a₁}
-        = ((a₀ ∧ 1l) ∨ (a₁ ∧ 1l) ∨ (a₀ ∧ 1l))
-            ＝⟨ ap₂ (_∨_) 1-top (ap₂ (_∨_) 1-top 1-top) ⟩
-          a₀ ∨ a₁ ∨ a₀
-            ＝⟨ ∨-assoc ∙ ∨-comm ∙ ∨-assoc ∙ ap (_∨ a₁) ∨-idem ⟩
-          a₀ ∨ a₁
-            ＝⟨ ∨-comm ∙ ≤-max auto! ⟩
-          a₀ ∎
-
-      lemma2
-        : ∀ {a₀ a₁ b₀ b₁} ⦃ p : a₀ ≤ a₁ ⦄ ⦃ q : b₀ ≤ b₁ ⦄
-          → a₁ ∨ (a₁ ∧ b₀) ∨ (a₀ ∧ b₁) ∨ (a₁ ∧ b₁) ＝ a₁
-      lemma2 {a₀} {a₁} {b₀} {b₁} ⦃ p ⦄
-        = (a₁ ∨ a₁ ∧ b₀ ∨ a₀ ∧ b₁ ∨ a₁ ∧ b₁) ＝⟨ ∨-assoc ∙ ap₂ (_∨_) ∨-∧-abs refl ⟩
-          (a₁ ∨ a₀ ∧ b₁ ∨ a₁ ∧ b₁)           ＝⟨ ∨-assoc ∙ ∨-comm ∙ ∨-assoc
-                                               ∙ ap₂ (_∨_) (∨-comm ∙ ∨-∧-abs) refl ⟩
-          (a₁ ∨ a₀ ∧ b₁)                     ＝⟨ distrib-∨-∧ ⟩
-          ((a₁ ∨ a₀) ∧ (a₁ ∨ b₁))            ＝⟨ ap (_∧ (a₁ ∨ b₁))
-                                                    (∨-comm ∙ ≤-max p) ⟩
-          a₁ ∧ (a₁ ∨ b₁)                     ＝⟨ ∧-∨-abs ⟩
-          a₁    ∎
-
-      lemma3
-        : ∀ {a₀ a₁ b₀ b₁} ⦃ m : a₀ ≤ a₁ ⦄ ⦃ n : b₀ ≤ b₁ ⦄
-          → a₁ ∧ (a₀ ∨ b₀) ∨ a₀ ∧ (a₁ ∨ b₁) ∨ a₁ ∧ (a₁ ∨ b₁) ＝ a₁
-      lemma3 {a₀} {a₁} {b₀} {b₁} ⦃ m ⦄ ⦃ n ⦄
-        = (a₁ ∧ (a₀ ∨ b₀) ∨ a₀ ∧ (a₁ ∨ b₁) ∨ a₁ ∧ (a₁ ∨ b₁))
-            ＝⟨ ap₂ (_∨_) refl (ap₂ (_∨_) (∨-≤-introl m) ∧-∨-abs) ⟩
-          ((a₁ ∧ (a₀ ∨ b₀)) ∨ a₀ ∨ a₁)
-            ＝⟨ ap₂ (_∨_) distrib-∧-∨ (≤-max m) ⟩
-          ((a₁ ∧ a₀ ∨ a₁ ∧ b₀) ∨ a₁)
-            ＝⟨ sym ∨-assoc ∙ ap (_ ∨_) (∨-comm ∙ ∨-∧-abs) ⟩
-          (a₁ ∧ a₀ ∨ a₁)
-            ＝⟨ ap (_∨ a₁) (∧-comm ∙ m) ∙ ≤-max m ⟩
-          a₁ ∎
-
-      lemma-assoc
-        : ∀ {a b c d e f}
-          → a ∧ d ∧ f ∨
-            b ∧ (c ∧ f ∨ d ∧ e ∨ c ∧ e) ∨ a ∧ (c ∧ f ∨ d ∧ e ∨ c ∧ e)
-          ＝
-              (a ∧ d ∨ b ∧ c ∨ a ∧ c) ∧ f
-            ∨ (b ∧ d) ∧ e
-            ∨ (a ∧ d ∨ b ∧ c ∨ a ∧ c) ∧ e
-      lemma-assoc {a} {b} {c} {d} {e} {f}
-        = (a ∧ d ∧ f ∨
-           b ∧ (c ∧ f ∨ d ∧ e ∨ c ∧ e) ∨ a ∧ (c ∧ f ∨ d ∧ e ∨ c ∧ e))
-             ＝⟨ ap (a ∧ d ∧ f ∨_)
-                  (ap₂ (_∨_) distrib₂-∧-∨ distrib₂-∧-∨) ⟩
-           (a ∧ d ∧ f ∨ ((b ∧ c ∧ f) ∨ (b ∧ d ∧ e) ∨ (b ∧ c ∧ e))
-             ∨ ((a ∧ c ∧ f) ∨ (a ∧ d ∧ e) ∨ a ∧ c ∧ e))
-             ＝⟨ ap (_ ∨_) (sym ∨-assoc ∙ ap (_ ∨_) (∨-assoc
-                                                    ∙ ap (_∨ (a ∧ d ∧ e ∨ a ∧ c ∧ e))
-                                                         ∨-comm
-                                                    ∙ sym ∨-assoc))
-               ∙ ∨-assoc ∙ ∨-assoc
-               ∙ ap₂ (_∨_) (sym ∨-assoc ∙ ap₃ (λ x y z → x ∨ (y ∨ z)) ∧-assoc ∧-assoc ∧-assoc)
-                         (ap₂ (_∨_) (ap₂ (_∨_) ∧-assoc ∧-assoc)
-                                  (ap₂ (_∨_) ∧-assoc ∧-assoc)
-                         ∙ sym ∨-assoc ∙ ap ((b ∧ d) ∧ e ∨_)
-                                            (∨-assoc
-                                            ∙ ap (_∨ (a ∧ c) ∧ e) ∨-comm
-                                            ∙ sym ∨-assoc)) ⟩
-           (((a ∧ d) ∧ f ∨ (b ∧ c) ∧ f ∨ (a ∧ c) ∧ f) ∨
-            (b ∧ d) ∧ e ∨ (a ∧ d) ∧ e ∨ (b ∧ c) ∧ e ∨ (a ∧ c) ∧ e)
-             ＝⟨ sym (ap₃ (λ x y z → x ∨ (y ∨ z)) distrib₂-∧-∨' refl distrib₂-∧-∨') ⟩
-           ((a ∧ d ∨ b ∧ c ∨ a ∧ c) ∧ f
-            ∨ (b ∧ d) ∧ e
-            ∨ (a ∧ d ∨ b ∧ c ∨ a ∧ c) ∧ e)    ∎
-
     l : is-lattice (Lattice.0l Free-Lattice) (Lattice.1l Free-Lattice)
                    (Lattice._∧_ Free-Lattice) (Lattice._∨_ Free-Lattice)
     l .is-lattice.carrier-is-0-truncated = Δ²-is-0-truncated
-    l .is-lattice.∧-assoc {a , b} {c , d} {e , f}
-      = Δ²-ext (lemma-assoc , ∧-assoc)
-    l .is-lattice.∨-assoc
-      = Δ²-ext (∨-assoc , ∨-assoc)
-    l .is-lattice.∧-comm {(a₀ , a₁) ⦃ m ⦄} {(b₀ , b₁) ⦃ n ⦄}
-      = Δ²-ext (ap₂ (_∨_) ∧-comm (ap₂ (_∨_) ∧-comm ∧-comm)
-                       ∙ ∨-assoc ∙ ap (_∨ b₀ ∧ a₀) ∨-comm ∙ sym ∨-assoc
-               , ∧-comm)
-    l .is-lattice.∨-comm
-      = Δ²-ext (∨-comm , ∨-comm)
-    l .is-lattice.∨-∧-abs {(a₀ , a₁) ⦃ m ⦄} {(b₀ , b₁) ⦃ n ⦄}
-      = Δ²-ext (lemma2 , ∨-∧-abs)
-    l .is-lattice.∧-∨-abs {(a₀ , a₁) ⦃ m ⦄} {(b₀ , b₁) ⦃ n ⦄}
-      = Δ²-ext (lemma3 , ∧-∨-abs)
-    l .is-lattice.0-bottom
-      = Δ²-ext (0-bottom , 0-bottom)
-    l .is-lattice.1-top {(a₀ , a₁) ⦃ m ⦄}
-      = Δ²-ext (lemma1 , auto!)
+    l .is-lattice.∧-assoc = Δ²-ext (∧-assoc , ∧-assoc)
+    l .is-lattice.∨-assoc = Δ²-ext (∨-assoc , ∨-assoc)
+    l .is-lattice.∧-comm = Δ²-ext (∧-comm , ∧-comm)
+    l .is-lattice.∨-comm = Δ²-ext (∨-comm , ∨-comm)
+    l .is-lattice.∨-∧-abs = Δ²-ext (∨-∧-abs , ∨-∧-abs)
+    l .is-lattice.∧-∨-abs = Δ²-ext (∧-∨-abs , ∧-∨-abs)
+    l .is-lattice.0-bottom = Δ²-ext (0-bottom , 0-bottom)
+    l .is-lattice.1-top = Δ²-ext (1-top , 1-top)
 }
 }
 
@@ -273,7 +188,7 @@ commutativity of #{\lor}.}
   Free-Lattice-is-lattice-algebra .is-lattice-hom.pres-∨
     = Δ²-ext (refl , refl)
   Free-Lattice-is-lattice-algebra .is-lattice-hom.pres-∧
-    = Δ²-ext (sym (ap ((_ ∧ _) ∨_)∨-idem ∙ ∨-idem) , refl)
+    = Δ²-ext (refl , refl)
   Free-Lattice-is-lattice-algebra .is-lattice-hom.pres-0
     = Δ²-ext (refl , refl)
   Free-Lattice-is-lattice-algebra .is-lattice-hom.pres-1
@@ -317,8 +232,8 @@ we show this map is a [morphism of lattice algebras](stt-009Z).}
     l : is-lattice-hom Free-Lattice M.str-Lattice (fst (eval-polynomial M x))
     l .pres-0 =  M.∨-comm ∙ M.∨-∧-abs ∙ M.ι-alg .pres-0
     l .pres-1 =  M.∨-comm ∙ M.∨-∧-abs ∙ M.ι-alg .pres-1
-    l .pres-∨ {(a₀ , a₁)} {(b₀ , b₁)} =
-        (⌜ M.ι (a₀ ∨ b₀)⌝ M.∧ x M.∨ M.ι (a₁ ∨ b₁))
+    l .pres-∨ {(a₀ , a₁)} {(b₀ , b₁)}
+      = (⌜ M.ι (a₀ ∨ b₀)⌝ M.∧ x M.∨ M.ι (a₁ ∨ b₁))
          ＝⟨  ap₂ M._∨_ (ap! (M.ι-alg .pres-∨) ∙ Md.distrib-∧-∨') (M.ι-alg .pres-∨)  ⟩
         ((M.ι a₀ M.∧ x M.∨ M.ι b₀ M.∧ x) M.∨ M.ι a₁ M.∨ M.ι b₁)
           ＝⟨ sym M.∨-assoc ⟩
@@ -326,14 +241,10 @@ we show this map is a [morphism of lattice algebras](stt-009Z).}
           ＝⟨  ap! (M.∨-assoc ∙ ap₂ M._∨_ M.∨-comm refl ∙ sym M.∨-assoc) ∙ M.∨-assoc ⟩
         ((M.ι a₀ M.∧ x M.∨ M.ι a₁) M.∨ M.ι b₀ M.∧ x M.∨ M.ι b₁) ∎
     l .pres-∧ {(a₀ , a₁)} {(b₀ , b₁)}
-      = sym (Md.polynomial-mult' x
-        ∙ ap₂ M._∨_ (ap (M._∧ x)
-                        (sym (M.ι-alg .pres-∨
-                          ∙ ap₂ M._∨_ (M.ι-alg .pres-∧)
-                                      (M.ι-alg .pres-∨
-                                      ∙ ap₂ M._∨_ (M.ι-alg .pres-∧)
-                                                  (M.ι-alg .pres-∧)))))
-                    (sym (M.ι-alg .pres-∧)))
+      = ap₂ M._∨_ (ap (M._∧ x) (M.ι-alg .pres-∧)) (M.ι-alg .pres-∧)
+        ∙ sym (Md.polynomial-mult'-≤ x)
+      where
+      open is-lattice-hom M.ι-alg
 }
 
 \p{We exhibit #{L[x]} as the free algebra by showing that every
@@ -373,13 +284,8 @@ from elements of #{M} to algebra morphisms #{L[x] \to M} is an equivalence.}
               ＝⟨ ap₂ M._∨_ (ap (M._∧ _) (sym (K a))) (sym (K b)) ⟩
             f (a , a) M.∧ f (1l , 0l) M.∨ f (b , b)
               ＝⟨ ap (M._∨ _) (sym (ishom .pres-∧)) ⟩
-            (f ((a , a) L[x].∧ (1l , 0l)) M.∨ f (b , b))
-              ＝⟨⟩
-            (f (((a ∧ 0l ∨ a ∧ 1l ∨ a ∧ 1l) , (a ∧ 0l)) ⦃ _ ⦄) M.∨ f (b , b))
-              ＝⟨ ap (λ x → f x M.∨ f (b , b))
-                     (Δ²-ext (ap (_ ∨_) ∨-idem ∙ sym distrib-∧-∨
-                             ∙ ap (a ∧_) (∨-comm ∙ 0-bottom) ∙ auto!
-                             , (∧-comm ∙ 0-init))) ⟩
+            (f ⌜ (a , a) L[x].∧ (1l , 0l) ⌝ M.∨ f (b , b))
+              ＝⟨ ap! (Δ²-ext (auto! , ∧-comm ∙ 0-init)) ⟩
             (f (a , 0l) M.∨ f (b , b))
               ＝⟨ sym (ishom .pres-∨) ⟩
             (f ((a , 0l) L[x].∨ (b , b)))

--- a/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
+++ b/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
@@ -134,7 +134,7 @@ module _ {𝓤} {A : Type 𝓤} (L : Lattice A) (distr : is-distributive L) wher
 \li{#{0 = 0x \lor 0}}
 \li{#{1 = 1x \lor 1}}
 \li{#{(ax \lor b) \lor (cx \lor d) = (a \lor c)x \lor (b \lor d)}}
-\li{#{(ax \lor b) \land (cx \lor d) = (ac)x \lor (bd))}}
+\li{#{(ax \lor b) \land (cx \lor d) = (ac)x \lor (bd)}}
 
 Because #{a \ge b} and #{c \ge d}, we can equivalently write the meet as the polynomial multiplication #{(ax \lor b) \land (cx \lor d) = ((bc \lor ad \lor ac)x \lor (bd))}.
 }


### PR DESCRIPTION
Currently, the definition of multiplication in the 2-simplex lattice is polynomial multiplication: (a, b) ∧ (c, d) = (bc ∨ ad ∨ ac, bd). However, since in this case a ≥ b and c ≥ d, the simpler pointwise definition (a, b) ∧ (c, d) = (ac, bd) is equivalent. Using the other definition makes the proof that Δ² is a lattice much simpler, and so far doesn't seem to make anything else more complicated.