### PR TITLE
Add symmetry to ≤ for lattices

### DIFF
--- a/src/Algebra/Lattice.lagda.tree
+++ b/src/Algebra/Lattice.lagda.tree
@@ -70,9 +70,17 @@ record Lattice {ℓ} (L : Type ℓ) : Type ℓ where
   infixr 35 _∨_
 
   _≤_ : L → L → Type ℓ
-  x ≤ y = x ∧ y ＝ x
+  x ≤ y = (x ∧ y ＝ x) × (x ∨ y ＝ y)
+
+  {-# NOINLINE _≤_ #-}
 
   open is-lattice str-is-lattice public
+
+  ≤-min : ∀ {a b} → a ≤ b → a ∧ b ＝ a
+  ≤-min p = p .fst
+
+  ≤-max : ∀ {a b} → a ≤ b → a ∨ b ＝ b
+  ≤-max p = p .snd
 
   1-coinit : ∀ {x} → x ∨ 1l ＝ 1l
   1-coinit {x}
@@ -120,20 +128,26 @@ record Lattice {ℓ} (L : Type ℓ) : Type ℓ where
            ; ≤-antisym = ≤-antisym }
     where
       ≤-is-prop : {x y : L} → is-prop (x ≤ y)
-      ≤-is-prop = carrier-is-set _ _
+      ≤-is-prop = ×-is-prop (carrier-is-set _ _) (carrier-is-set _ _)
 
       ≤-refl : {x : L} → x ≤ x
-      ≤-refl = ∧-idem
+      ≤-refl = (∧-idem , ∨-idem)
 
       ≤-trans : {x y z : L} → x ≤ y → y ≤ z → x ≤ z
-      ≤-trans {x} {y} {z} p q =  x ∧ z        ＝⟨ ap (_∧ z) (sym p) ⟩
-                                  (x ∧ y) ∧ z ＝⟨ sym ∧-assoc ⟩
-                                  x ∧ (y ∧ z) ＝⟨ ap (x ∧_) q ⟩
-                                  x ∧ y       ＝⟨ p ⟩
-                                  x ∎
+      ≤-trans {x} {y} {z} p q =
+          ( x ∧ z        ＝⟨ ap (_∧ z) (sym (≤-min p)) ⟩
+            (x ∧ y) ∧ z ＝⟨ sym ∧-assoc ⟩
+            x ∧ (y ∧ z) ＝⟨ ap (x ∧_) (≤-min q) ⟩
+            x ∧ y       ＝⟨ ≤-min p ⟩
+            x ∎)
+        , ( x ∨ z        ＝⟨ ap (x ∨_) (sym (≤-max q)) ⟩
+            x ∨ (y ∨ z) ＝⟨ ∨-assoc ⟩
+            (x ∨ y) ∨ z ＝⟨ ap (_∨ z) (≤-max p) ⟩
+            y ∨ z       ＝⟨ ≤-max q ⟩
+            z ∎)
 
       ≤-antisym : {x y : L} → x ≤ y → y ≤ x → x ＝ y
-      ≤-antisym {x} {y} p q = sym p ∙ ∧-comm ∙ q
+      ≤-antisym {x} {y} p q = sym (≤-min p) ∙ ∧-comm ∙ ≤-min q
 
   ≤-poset : Poset ℓ L
   ≤-poset = mk-poset {_≤_ = _≤_} ≤-is-poset
@@ -146,60 +160,71 @@ record Lattice {ℓ} (L : Type ℓ) : Type ℓ where
   ≥←＝ : ∀ {a b} → a ＝ b → b ≤ a
   ≥←＝ refl = ≤-refl
 
-  ≤-max : ∀ {a b} → a ≤ b → a ∨ b ＝ b
-  ≤-max {a} {b} p
-    = a ∨ b             ＝⟨ ap (_∨ b) (sym p) ⟩
-      (a ∧ b) ∨ b       ＝⟨ ∧-∨-abs' ⟩
+  =∨←=∧ : ∀ {a b} → a ∧ b ＝ a → a ∨ b ＝ b
+  =∨←=∧ {a} {b} p =
+      a ∨ b       ＝⟨ ap (_∨ b) (sym p) ⟩
+      (a ∧ b) ∨ b ＝⟨ ∧-∨-abs' ⟩
       b ∎
+
+  ≤←∧ : ∀ {a b} → a ∧ b ＝ a → a ≤ b
+  ≤←∧ p = p , =∨←=∧ p
 
   ≤-max' : ∀ {a b} → b ≤ a → a ∨ b ＝ a
   ≤-max' b≤a = ∨-comm ∙ ≤-max b≤a
 
-  ≤←∨ : ∀ {a b} → a ∨ b ＝ b → a ≤ b
-  ≤←∨ {a} {b} p
-    = a ∧ b           ＝⟨ ap (a ∧_) (sym p) ⟩
-      a ∧ (a ∨ b)     ＝⟨ ∧-∨-abs ⟩
+  =∧←=∨ : ∀ {a b} → a ∨ b ＝ b → a ∧ b ＝ a
+  =∧←=∨ {a} {b} p =
+      a ∧ b       ＝⟨ ap (a ∧_) (sym p) ⟩
+      a ∧ (a ∨ b) ＝⟨ ∧-∨-abs ⟩
       a ∎
+
+  ≤←∨ : ∀ {a b} → a ∨ b ＝ b → a ≤ b
+  ≤←∨ p = =∧←=∨ p , p
 
   ∨-UP : ∀ {a b c} → a ≤ c × b ≤ c → (a ∨ b ≤ c)
   ∨-UP {a} {b} {c} (f , g)
-    = ≤←∨ (sym ∨-assoc ∙ ≤-max (ap (a ∧_) (≤-max g) ∙ f) ∙ ≤-max g)
+    = ≤←∨
+        (sym ∨-assoc ∙ ≤-max (≤←∧ (ap (a ∧_) (≤-max g) ∙ ≤-min f))
+          ∙ ≤-max g)
 
   ∨-UP-is-equiv : ∀ {a b c} → is-equiv (∨-UP {a} {b} {c})
   ∨-UP-is-equiv {a} {b} {c} = is-equiv←inverse
-                    (×-is-prop (carrier-is-set _ _) (carrier-is-set _ _))
-                    (carrier-is-set _ _)
-                    λ x → ap (_∧ _) (sym (∧-∨-abs {a} {b}))
-                          ∙ sym ∧-assoc ∙ ap (a ∧_) x
-                          ∙ ∧-∨-abs
-                        , ap (_∧ _) (sym (∧-∨-abs {b} {a}))
+                    (×-is-prop ≤-is-prop ≤-is-prop)
+                    ≤-is-prop
+                    λ x
+                    → ≤←∧ ( ap (_∧ _) (sym (∧-∨-abs {a} {b}))
+                          ∙ sym ∧-assoc ∙ ap (a ∧_) (≤-min x)
+                          ∙ ∧-∨-abs)
+                    , ≤←∧ ( ap (_∧ _) (sym (∧-∨-abs {b} {a}))
                           ∙ sym ∧-assoc
-                          ∙ ap (b ∧_) (ap (_∧ c) ∨-comm ∙ x ∙ ∨-comm)
-                          ∙ ∧-∨-abs
+                          ∙ ap (b ∧_) (ap (_∧ c) ∨-comm ∙ ≤-min x ∙ ∨-comm)
+                          ∙ ∧-∨-abs)
 
   ∨-≤-introl : ∀ {a b c} → a ≤ b → a ≤ (b ∨ c)
-  ∨-≤-introl p = ≤-trans p ∧-∨-abs
+  ∨-≤-introl p = ≤-trans p (≤←∧ ∧-∨-abs)
 
   ∨-≤-intror : ∀ {a b c} → a ≤ c → a ≤ (b ∨ c)
-  ∨-≤-intror p = ≤-trans p (ap (_ ∧_) ∨-comm ∙ ∧-∨-abs)
+  ∨-≤-intror p = ≤-trans p (≤←∧ (ap (_ ∧_) ∨-comm ∙ ∧-∨-abs))
 
   ∧-UP : ∀ {a b c} → a ≤ b × a ≤ c → a ≤ b ∧ c
-  ∧-UP (p , q) = ∧-assoc ∙ ap (_∧ _) p ∙ q
+  ∧-UP (p , q) = ≤←∧ (∧-assoc ∙ ap (_∧ _) (≤-min p) ∙ ≤-min q)
 
   ∧-≤-eliml : ∀ {a b c} → a ≤ c → (a ∧ b) ≤ c
-  ∧-≤-eliml {a} {b} {c} p = ∧-comm ∙ ∧-assoc ∙ ap (_∧ b) (∧-comm ∙ p)
+  ∧-≤-eliml {a} {b} {c} p =
+    ≤←∧ (∧-comm ∙ ∧-assoc ∙ ap (_∧ b) (∧-comm ∙ ≤-min p))
 
   ∧-≤-elimr : ∀ {a b c} → b ≤ c → (a ∧ b) ≤ c
-  ∧-≤-elimr {a} {b} {c} q = sym ∧-assoc ∙ ap (a ∧_) q
+  ∧-≤-elimr {a} {b} {c} q = ≤←∧ (sym ∧-assoc ∙ ap (a ∧_) (≤-min q))
 
   instance
     ≤-bot : ∀ {i} → 0l ≤ i
-    ≤-bot = 0-init
+    ≤-bot = (0-init , ∨-comm ∙ 0-bottom)
 
     ≤-refl-inst : ∀ {i} → i ≤ i
     ≤-refl-inst = ≤-refl
 
-    ≤-top = 1-top
+    ≤-top : ∀ {i} → i ≤ 1l
+    ≤-top = (1-top , 1-coinit)
     {-# INCOHERENT ≤-refl-inst ≤-top #-}
 
     ≤-∧
@@ -237,7 +262,9 @@ record is-lattice-hom
     pres-1 : f A.1l ＝ B.1l
 
   pres-≤ : {x y : A} → ⦃ x A.≤ y ⦄ → f x B.≤ f y
-  pres-≤ ⦃ p ⦄ = sym pres-∧ ∙ ap f p
+  pres-≤ ⦃ p ⦄
+    = ( sym pres-∧ ∙ ap f (A.≤-min p)
+      , sym pres-∨ ∙ ap f (A.≤-max p))
 
 unquoteDecl lattice-hom-repr≊ lattice-hom-repr≃
   = make-record-repr lattice-hom-repr≊ lattice-hom-repr≃

--- a/src/Algebra/Lattice/Instances/Coslice.lagda.tree
+++ b/src/Algebra/Lattice/Instances/Coslice.lagda.tree
@@ -51,7 +51,7 @@ module _ {𝓤} {A : Type 𝓤} (L : Lattice A) (i : A) (let module L = Lattice 
     0l = (i , L.≤-refl)
 
     1l : Carrier
-    1l = (L.1l , L.1-top)
+    1l = (L.1l , L.≤-top)
 
   open CosliceLat
   open Subtype (mk-subtype (λ (a : A) → L.≤-is-prop {i} {a}))

--- a/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
+++ b/src/Algebra/Lattice/Instances/Polynomial.lagda.tree
@@ -79,7 +79,7 @@ module _ {𝓤} {A : Type 𝓤} {L : Lattice A} where
       = unap-equiv (Δ²-repr≃ ._≃_.fwd-is-equiv)
          (Σ-path→ (refl
                   , (Σ-path→ (refl
-                  , ((is-set←is-truncated carrier-is-0-truncated _ _ _ _))))))
+                  , (≤-is-prop _ _)))))
 
   Δ²-ext-is-equiv : ∀ {a b : Δ² L} → is-equiv (Δ²-ext {a} {b})
   Δ²-ext-is-equiv = is-equiv←inverse
@@ -279,7 +279,7 @@ from elements of #{M} to algebra morphisms #{L[x] \to M} is an equivalence.}
             f (a , a) M.∧ f (1l , 0l) M.∨ f (b , b)
               ＝⟨ ap (M._∨ _) (sym (ishom .pres-∧)) ⟩
             (f ⌜ (a , a) L[x].∧ (1l , 0l) ⌝ M.∨ f (b , b))
-              ＝⟨ ap! (Δ²-ext (auto! , ∧-comm ∙ 0-init)) ⟩
+              ＝⟨ ap! (Δ²-ext (1-top , ∧-comm ∙ 0-init)) ⟩
             (f (a , 0l) M.∨ f (b , b))
               ＝⟨ sym (ishom .pres-∨) ⟩
             (f ((a , 0l) L[x].∨ (b , b)))

--- a/src/Algebra/Lattice/Instances/Slice.lagda.tree
+++ b/src/Algebra/Lattice/Instances/Slice.lagda.tree
@@ -48,7 +48,7 @@ module _ {𝓤} {A : Type 𝓤} (L : Lattice A) (i : A) (let module L = Lattice 
     (a , a≤i) ∨ (b , b≤i) = (a L.∨ b) , L.∨-UP (a≤i , b≤i)
 
     0l : Carrier
-    0l = (L.0l , L.0-init)
+    0l = (L.0l , L.≤-bot)
 
     1l : Carrier
     1l = (i , L.≤-refl)
@@ -67,7 +67,7 @@ module _ {𝓤} {A : Type 𝓤} (L : Lattice A) (i : A) (let module L = Lattice 
   slice-is-lattice .is-lattice.∨-∧-abs = subtype-path L.∨-∧-abs
   slice-is-lattice .is-lattice.∧-∨-abs = subtype-path L.∧-∨-abs
   slice-is-lattice .is-lattice.0-bottom = subtype-path L.0-bottom
-  slice-is-lattice .is-lattice.1-top {x , x≤i} = subtype-path x≤i
+  slice-is-lattice .is-lattice.1-top {x , x≤i} = subtype-path (L.≤-min x≤i)
 
   Lattice-slice : Lattice Carrier
   Lattice-slice .Lattice.0l = 0l

--- a/src/Synthetic/Categories/CovariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/CovariantFamilies.lagda.tree
@@ -469,8 +469,10 @@ by #{id : \Delta^1 \to \Delta^1}.}
 \agda{
 Δ¹-hom←≤  : ∀ {i j} → i ≤ j → Hom Δ¹ i j
 Δ¹-hom←≤ {i} {j} p .Homᵈ.hom l = (l ∨ i) ∧ (i ∨ j)
-Δ¹-hom←≤ p .Homᵈ.hom0 = ap₂ (_∧_) (∨-comm ∙ 0-bottom) (≤-max p) ∙ p
-Δ¹-hom←≤ p .Homᵈ.hom1 = ap₂ (_∧_) (∨-comm ∙ 1-coinit) (≤-max p) ∙ ∧-comm ∙ 1-top
+Δ¹-hom←≤ p .Homᵈ.hom0 =
+  ap₂ (_∧_) (∨-comm ∙ 0-bottom) (≤-max p) ∙ ≤-min p
+Δ¹-hom←≤ p .Homᵈ.hom1
+  = ap₂ (_∧_) (∨-comm ∙ 1-coinit) (≤-max p) ∙ ∧-comm ∙ 1-top
 
 Δ¹-hom-≤-refl : ∀ {i} (p : i ≤ i) → Δ¹-hom←≤ p ＝ idH i
 Δ¹-hom-≤-refl {i} p

--- a/src/Synthetic/Categories/Homotopy.lagda.tree
+++ b/src/Synthetic/Categories/Homotopy.lagda.tree
@@ -282,19 +282,19 @@ Hom2×~▵←Hom-over {A = A} {a = a} {c = c} (g@(mk-hom gh refl refl)) f {h} α
     : {i j : Δ¹} {p q : j ≤ i} → ap right-square Δ²-refl ＝ refl
   right-proof-ap {i} {j} {p} {q}
     = ap (ap right-square) (Δ²-is-set _ _ _ _)
-    ∙ sym (ap-∘ right-square (λ m → (i , j) ⦃ m ⦄) (carrier-is-set _ _ p q))
+    ∙ sym (ap-∘ right-square (λ m → (i , j) ⦃ m ⦄) (≤-is-prop p q))
     ∙ sym (∙-reflr _)
-    ∙ ∙-reflr (ap (λ m → right-square ((i , j) ⦃ m ⦄)) (carrier-is-set _ _ p q))
-    ∙ ap-const (carrier-is-set _ _ p q)
+    ∙ ∙-reflr (ap (λ m → right-square ((i , j) ⦃ m ⦄)) (≤-is-prop p q))
+    ∙ ap-const (≤-is-prop p q)
 
   left-proof-ap
     : {i j : Δ¹} {p q : j ≤ i} → ap left-square Δ²-refl ＝ refl
   left-proof-ap {i} {j} {p} {q}
     = ap (ap left-square) (Δ²-is-set _ _ _ _)
-    ∙ sym (ap-∘ left-square (λ m → (i , j) ⦃ m ⦄) (carrier-is-set _ _ p q))
+    ∙ sym (ap-∘ left-square (λ m → (i , j) ⦃ m ⦄) (≤-is-prop p q))
     ∙ sym (∙-reflr _)
-    ∙ ∙-reflr (ap (λ m → left-square ((i , j) ⦃ m ⦄)) (carrier-is-set _ _ p q))
-    ∙ ap-const (carrier-is-set _ _ p q)
+    ∙ ∙-reflr (ap (λ m → left-square ((i , j) ⦃ m ⦄)) (≤-is-prop p q))
+    ∙ ap-const (≤-is-prop p q)
 
   right-horn~ : right-square ∘ Λ[2,1]-incl ~ make-horn g f
   right-horn~

--- a/src/Synthetic/Categories/LeftSegal.lagda.tree
+++ b/src/Synthetic/Categories/LeftSegal.lagda.tree
@@ -144,7 +144,7 @@ which furthermore preserves the inner horn inclusion.
 
 private
   sec-weird-is-sec : Δ²←Δ¹◅ ∘ Δ¹◅←Δ² ~ id
-  sec-weird-is-sec ((a , b) ⦃ p ⦄) = Δ²-ext (refl , ∧-comm ∙ p)
+  sec-weird-is-sec ((a , b) ⦃ p ⦄) = Δ²-ext (refl , ∧-comm ∙ ≤-min p)
 
   weird-retract : retract Δ² (Δ¹ ◅)
   weird-retract = Δ¹◅←Δ² , Δ²←Δ¹◅ , sec-weird-is-sec

--- a/src/Synthetic/Categories/Spaces.lagda.tree
+++ b/src/Synthetic/Categories/Spaces.lagda.tree
@@ -744,9 +744,9 @@ to verify that this map is an equivalence at each endpoint.}
 \agda{
   opaque
     dua-retract→ : ∀ {@♭ 𝓤} f i → f i .Carrier → GlΣ {𝓤} (dua→ f) i .Carrier
-    dua-retract→ f i x .fst =  coe-cov (Carrier ∘ f) (UFib-is-fib f) 1-top x
+    dua-retract→ f i x .fst =  coe-cov (Carrier ∘ f) (UFib-is-fib f) ≤-top x
     dua-retract→ f i x .snd refl
-      = (x , sym (happly (coe-cov-0≤1 (Carrier ∘ f) (UFib-is-fib f) 1-top) x))
+      = (x , sym (happly (coe-cov-0≤1 (Carrier ∘ f) (UFib-is-fib f) ≤-top) x))
 
     dua-retract : ∀ {@♭ 𝓤} f i → f i .Carrier ≃ GlΣ {𝓤} (dua→ f) i .Carrier
     dua-retract f i ._≃_.fwd = dua-retract→ f i
@@ -761,13 +761,13 @@ to verify that this map is an equivalence at each endpoint.}
       fr0 .fst x = x .snd refl .fst
       fr0 .snd .fst = ~refl
       fr0 .snd .snd a = Gl-path→ {A = f i0} {f i1} i0
-        ( happly ( coe-cov-0≤1 (Carrier ∘ f) (UFib-is-fib f) 1-top) (fr0 .fst a)
+        ( happly ( coe-cov-0≤1 (Carrier ∘ f) (UFib-is-fib f) ≤-top) (fr0 .fst a)
                  ∙ a .snd refl .snd
         , J-set! _
             ( refl
             , mk-square
                 (sym'∙ (happly
-                         (coe-cov-0≤1 (Carrier ∘ f) (UFib-is-fib f) 1-top) (a .snd refl .fst))
+                         (coe-cov-0≤1 (Carrier ∘ f) (UFib-is-fib f) ≤-top) (a .snd refl .fst))
                          (a .snd refl .snd))))
 
       fr1 : quasi-inv (dua-retract→ f i1)

--- a/src/Synthetic/Horns.lagda.tree
+++ b/src/Synthetic/Horns.lagda.tree
@@ -320,7 +320,7 @@ two propositions. This goes via the [flattening lemma for pushouts](stt-008D).
 Δ²-retract-Δ¹×Δ¹'
   = (λ x → (x .Poly.Δ².s , x .Poly.Δ².t))
   , (λ { (i , j) → (i , i ∧ j) ⦃ ∧-≤-eliml ≤-refl ⦄ })
-  , λ ((i , j) ⦃ p ⦄) → Δ²-ext (refl , ∧-comm ∙ p)
+  , λ ((i , j) ⦃ p ⦄) → Δ²-ext (refl , ∧-comm ∙ ≤-min p)
 }
 }
 

--- a/src/Synthetic/Quasicoherence.lagda.tree
+++ b/src/Synthetic/Quasicoherence.lagda.tree
@@ -306,13 +306,14 @@ module _ (phoa : phoas-principle) where
 
   Δ¹-endos-are-mono←phoa : Δ¹-endos-are-mono
   Δ¹-endos-are-mono←phoa f {a} {b} x
-    = f a ∧ f b
-        ＝⟨ ap₂ _∧_ (phoa f a) (phoa f b) ⟩
-      ((f i1 ∧ a) ∨ f i0) ∧ ((f i1 ∧ b) ∨ f i0)
-        ＝⟨ poly-mono ⟩
-      (f i1 ∧ a) ∨ f i0
-        ＝⟨ sym (phoa f a) ⟩
-      f a ∎
+    = ≤←∧
+        ( f a ∧ f b
+            ＝⟨ ap₂ _∧_ (phoa f a) (phoa f b) ⟩
+          ((f i1 ∧ a) ∨ f i0) ∧ ((f i1 ∧ b) ∨ f i0)
+            ＝⟨ ≤-min poly-mono ⟩
+          (f i1 ∧ a) ∨ f i0
+            ＝⟨ sym (phoa f a) ⟩
+          f a ∎)
     where
       poly-mono : ((f i1 ∧ a) ∨ f i0) ≤ ((f i1 ∧ b) ∨ f i0)
       poly-mono

--- a/src/Synthetic/Simplicial.lagda.tree
+++ b/src/Synthetic/Simplicial.lagda.tree
@@ -138,9 +138,9 @@ module Simp where
     → ((p : i ＝ j) → l (≤←＝ p) ＝ r (≥←＝ p)) → A
 Δ²-≤-rec {i = i} {j} asimp l r eq
   = is-equiv.bwd (asimp (i , j)) (cogap (mk-cocone l r
-      λ (p , q) → ap l (carrier-is-set _ _ _ _)
+      λ (p , q) → ap l (≤-is-prop _ _)
                 ∙ eq (≤-antisym p q)
-                ∙ ap r (carrier-is-set _ _ _ _)))
+                ∙ ap r (≤-is-prop _ _)))
 
 Δ²-≤-rec!
   : ∀ {𝓤} {A : Type 𝓤} i j → is-simplicial A


### PR DESCRIPTION
Redefines `≤` via

$$
  (i ≤ j) \coloneqq ((i \land j) = i) \times ((i \lor j) = j)
$$ 


Not entirely sure if this is the right step yet, but I wanted to try it out after it was suggested by @rwbarton.

