### PR TITLE
Covariance lemma for exponentiating by (- = 0)

### DIFF
--- a/src/Algebra/Order/Monotone.lagda.tree
+++ b/src/Algebra/Order/Monotone.lagda.tree
@@ -62,16 +62,14 @@ module _
   {𝓤 𝓤' 𝓥 𝓥' 𝓦 𝓦'}
   {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
   (pA : Poset 𝓤' A) (pB : Poset 𝓥' B) (pC : Poset 𝓦' C)
-  (f : B → C)
-  (g : A → B)
-  (let module A = Poset pA)
-  (let module B = Poset pB)
-  (let module C = Poset pC)
+  (g : B → C)
+  (f : A → B)
   where
 
   ∘-is-monotone
-    : is-monotone pB pC f → is-monotone pA pB g
-    → is-monotone pA pC (f ∘ g)
-  ∘-is-monotone fm gm = fm ∘ gm
+    : is-monotone pB pC g
+    → is-monotone pA pB f
+    → is-monotone pA pC (g ∘ f)
+  ∘-is-monotone gm fm = gm ∘ fm
 }
 }

--- a/src/Algebra/Order/Monotone.lagda.tree
+++ b/src/Algebra/Order/Monotone.lagda.tree
@@ -29,7 +29,6 @@ A \em{monotone map} between posets is a function that preserves the order relati
 }
 
 \agda{
-
 module _
   {𝓤 𝓥 𝓦 𝓣}
   {A : Type 𝓤} {B : Type 𝓦}
@@ -49,5 +48,30 @@ module _
     → Πᵢ-is-prop λ {b}
     → Π-is-prop λ (_ : a A.≤ b)
     → B.≤-is-prop {a = f a} {b = f b}
+}
+}
+
+\subtree[tot-0005]{
+\author{samueltoth}
+\date{2026-06-18}
+\taxon{Lemma}
+\title{Composition of monotone maps}
+
+\agda{
+module _
+  {𝓤 𝓤' 𝓥 𝓥' 𝓦 𝓦'}
+  {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
+  (pA : Poset 𝓤' A) (pB : Poset 𝓥' B) (pC : Poset 𝓦' C)
+  (f : B → C)
+  (g : A → B)
+  (let module A = Poset pA)
+  (let module B = Poset pB)
+  (let module C = Poset pC)
+  where
+
+  ∘-is-monotone
+    : is-monotone pB pC f → is-monotone pA pB g
+    → is-monotone pA pC (f ∘ g)
+  ∘-is-monotone fm gm = fm ∘ gm
 }
 }

--- a/src/Algebra/Order/Monotone.lagda.tree
+++ b/src/Algebra/Order/Monotone.lagda.tree
@@ -51,7 +51,7 @@ module _
 }
 }
 
-\subtree[tot-0005]{
+\subtree[stt-00UA]{
 \author{samueltoth}
 \date{2026-06-18}
 \taxon{Lemma}

--- a/src/Core/OrthogonalClosure.lagda.tree
+++ b/src/Core/OrthogonalClosure.lagda.tree
@@ -384,6 +384,18 @@ left-orthogonal-equiv f f' F Feq g fperp
           (precomp-square-is-equiv F Feq , precomp-square-is-equiv F Feq)
           (transpose-is-cartesian _ (is-cartesian←are-orthogonal fperp))))
 
+left-orthogonal-fam←equiv
+  : ∀ {𝓤 𝓥 𝓦 𝓜 𝓝 𝓛} {A : Type 𝓤} {B : Type 𝓥} (f : A → B)
+      {X : Type 𝓦} {Y : Type 𝓜} (f' : X → Y)
+    → Arrow-equiv f f'
+    → {C : Type 𝓝} (D : C → Type 𝓛)
+    → are-orthogonal-fam f D → are-orthogonal-fam f' D
+left-orthogonal-fam←equiv f f' eq D fD
+  = are-orthogonal-fam←are-orthogonal-fst
+      (left-orthogonal-equiv
+        f f' (eq .fst) (eq .snd) (fst: D)
+        (are-orthogonal-fst←are-orthogonal-fam fD))
+
 is-anodyne←equiv
   : ∀ {𝓤 𝓥 𝓦 𝓜 𝓧 𝓨} {A : Type 𝓤} {B : Type 𝓥} (f : A → B)
       {X : Type 𝓦} {Y : Type 𝓜} (f' : X → Y)

--- a/src/Foundations/DependentIdentity.lagda.tree
+++ b/src/Foundations/DependentIdentity.lagda.tree
@@ -111,6 +111,13 @@ Idᵈ-const-coe
       (t : f x ＝ l)
     → tr (λ z → f z ＝ l) p t ＝ ap f (sym p) ∙ t
 Idᵈ-const-coe f refl t = refl
+
+adjust-idᵈ
+  : ∀ {𝓤} {A B : Type 𝓤}
+      {P Q : A ＝ B} (_ : P ＝ Q)
+      {a : A} {b : B}
+    → a ＝[ P ] b → a ＝[ Q ] b
+adjust-idᵈ refl = id
 }
 }
 

--- a/src/Foundations/DependentIdentity.lagda.tree
+++ b/src/Foundations/DependentIdentity.lagda.tree
@@ -114,9 +114,11 @@ Idᵈ-const-coe f refl t = refl
 
 adjust-idᵈ
   : ∀ {𝓤} {A B : Type 𝓤}
-      {P Q : A ＝ B} (_ : P ＝ Q)
-      {a : A} {b : B}
-    → a ＝[ P ] b → a ＝[ Q ] b
+      {P Q : A ＝ B}
+    → (P ＝ Q)
+    → {a : A} {b : B}
+    → a ＝[ P ] b
+    → a ＝[ Q ] b
 adjust-idᵈ refl = id
 }
 }

--- a/src/Foundations/DependentIdentity.lagda.tree
+++ b/src/Foundations/DependentIdentity.lagda.tree
@@ -112,14 +112,14 @@ Idᵈ-const-coe
     → tr (λ z → f z ＝ l) p t ＝ ap f (sym p) ∙ t
 Idᵈ-const-coe f refl t = refl
 
-adjust-idᵈ
+adjust-Idᵈ
   : ∀ {𝓤} {A B : Type 𝓤}
       {P Q : A ＝ B}
     → (P ＝ Q)
     → {a : A} {b : B}
     → a ＝[ P ] b
     → a ＝[ Q ] b
-adjust-idᵈ refl = id
+adjust-Idᵈ refl = id
 }
 }
 

--- a/src/Foundations/DependentIdentity.lagda.tree
+++ b/src/Foundations/DependentIdentity.lagda.tree
@@ -172,10 +172,20 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : A → Type 𝓥} where
     → x ＝ tr B (sym p) y → Idᶠ B p x y
   Idᶠ-inr {p = refl} h = h
 
+  Idᶠ-inr'
+    : {a a' : A} {p : a' ＝ a} {x : B a} {y : B a'}
+    → x ＝ tr B p y → Idᶠ B (sym p) x y
+  Idᶠ-inr' {p = refl} h = h
+
   Idᶠ-right
     : {a a' : A} {p : a ＝ a'} {x : B a} {y : B a'}
     → Idᶠ B p x y → x ＝ tr B (sym p) y
   Idᶠ-right {p = refl} h = h
+
+  Idᶠ-right'
+    : {a a' : A} {p : a' ＝ a} {x : B a} {y : B a'}
+    → Idᶠ B (sym p) x y → x ＝ tr B p y
+  Idᶠ-right' {p = refl} h = h
 
   reflᶠ : {a : A} {p : a ＝ a} → p ＝ refl → {x : B a} → Idᶠ B p x x
   reflᶠ {a = a} {p = p} r {x = x}

--- a/src/Synthetic/Categories/CoComma.lagda.tree
+++ b/src/Synthetic/Categories/CoComma.lagda.tree
@@ -50,6 +50,7 @@ open import Ergonomics.Representation
 
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Boundaries Δ¹ I
+open import Synthetic.Categories.WalkingHom Δ¹ I
 open import Synthetic.Categories.NaturalTransformations Δ¹ I
 }
 }

--- a/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
@@ -175,9 +175,9 @@ module _ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) where
     = ( is-contravariant←has-unique-extensions
       , has-unique-extensions←is-contravariant)
 
-  is-right-family↔is-covariant
+  is-right-family↔is-contravariant
     : is-right-family P ↔ is-contravariant P
-  is-right-family↔is-covariant
+  is-right-family↔is-contravariant
     =  are-orthogonal-fam↔has-unique-extensions
     ∙iff has-unique-extensions↔is-contravariant
 }
@@ -212,7 +212,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) where opaque
   is-contravariant↔is-right-fibration
     : is-contravariant P ↔ is-right-fibration (fst: P)
   is-contravariant↔is-right-fibration
-    = (is-right-family↔is-covariant P iff⁻¹)
+    = (is-right-family↔is-contravariant P iff⁻¹)
     ∙iff are-orthogonal-fam↔are-orthogonal-fst
 
   is-right-fibration←is-contravariant

--- a/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
@@ -33,11 +33,9 @@ open Core.Orthogonal.notation
 
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Horns Δ¹ I
+open import Synthetic.Categories.WalkingHom Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I
 open import Synthetic.Categories.Comma Δ¹ I
-
--- TODO: Remove, only imported for `Δ¹-hom-≤-refl` which should live elsewhere
-open import Synthetic.Categories.CovariantFamilies Δ¹ I
 }
 }
 
@@ -466,19 +464,6 @@ same as contravariant transport over the canonical morphisms from #{0} to #{1} g
 by #{id : \Delta^1 \to \Delta^1}.}
 
 \agda{
--- Δ¹-hom←≤  : ∀ {i j} → i ≤ j → Hom Δ¹ i j
--- Δ¹-hom←≤ {i} {j} p .Homᵈ.hom l = (l ∨ i) ∧ (i ∨ j)
--- Δ¹-hom←≤ p .Homᵈ.hom0 = ap₂ (_∧_) (∨-comm ∙ 0-bottom) (≤-max p) ∙ p
--- Δ¹-hom←≤ p .Homᵈ.hom1 = ap₂ (_∧_) (∨-comm ∙ 1-coinit) (≤-max p) ∙ ∧-comm ∙ 1-top
-
--- Δ¹-hom-≤-refl : ∀ {i} (p : i ≤ i) → Δ¹-hom←≤ p ＝ idH i
--- Δ¹-hom-≤-refl {i} p
---   = Hom-ext→ ( (λ a → ap ((a ∨ i) ∧_) ∨-idem ∙ ∨-∧-abs') , prop! , prop!)
-
--- Δ¹-hom-0≤1 : (p : i0 ≤ i1) → Δ¹-hom←≤ p ＝ 0≤1
--- Δ¹-hom-0≤1 p
---   = Hom-ext→ ( (λ a → ap₂ (_∧_) 0-bottom 1-coinit ∙ 1-top) , prop! , prop!)
-
 module _ {𝓤} (B : Δ¹ → Type 𝓤) (bc : is-contravariant B) where
 
   coe-contrav : {i j : Δ¹} → i ≤ j → B j → B i

--- a/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
@@ -483,3 +483,17 @@ module _ {𝓤} (B : Δ¹ → Type 𝓤) (bc : is-contravariant B) where
     coe-contrav-0≤1 p = ap (tr-contrav-hom bc) (Δ¹-hom-0≤1 p)
 }
 }
+
+\subtree[tot-AUUV]{
+\title{Contravariance is stable under base change}
+\taxon{Lemma}
+\date{2026-06-24}
+
+\agda{
+contravariant-base-change
+  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {P : B → Type 𝓦}
+    → (f : A → B)
+    → is-contravariant P → is-contravariant (P ∘ f)
+contravariant-base-change F Pc f x₀ = Pc (F ∘ f) x₀
+}
+}

--- a/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
@@ -404,51 +404,47 @@ an equivalence.}
 }
 
 \agda{
-Hom-contrav
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P)
-      (f : Δ¹ → A) x' y'
-    → tr-contrav {P = P} contrav f y' ＝ x' → Homᵈ (P ∘ f) x' y'
-Hom-contrav _ Pc f x' y' refl = Pc f y' .centre .snd
+module _ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (Pc : is-contravariant P) where
 
-Hom-contrav-is-equiv
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P)
-      (f : Δ¹ → A) x' y'
-    → is-equiv (Hom-contrav P contrav f x' y')
-Hom-contrav-is-equiv P Pc f x' y'
-  = fundamental-Id _ (Pc f y') (λ x' → Hom-contrav P Pc f x' y') x'
+  Hom-contrav
+    : ∀ (f : Δ¹ → A) x' y'
+      → tr-contrav {P = P} Pc f y' ＝ x' → Homᵈ (P ∘ f) x' y'
+  Hom-contrav f x' y' refl = Pc f y' .centre .snd
 
-opaque
-  unfolding tr-contrav-hom
-  Hom-contrav'
-    : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P)
-        {x y} (f : Hom A x y) x' y'
-      → tr-contrav-hom {P = P} contrav f y' ＝ x' → Hom-over f x' y'
-  Hom-contrav' P contrav f x' y' refl
-    =  is-contravariant-hom←is-contravariant contrav f y' .centre .snd
+  Hom-contrav-is-equiv
+    : ∀ (f : Δ¹ → A) x' y'
+      → is-equiv (Hom-contrav f x' y')
+  Hom-contrav-is-equiv f x' y'
+    = fundamental-Id _ (Pc f y') (λ x' → Hom-contrav f x' y') x'
 
-Hom-contrav'-is-equiv
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P)
-      {x y} (f : Hom A x y) x' y'
-    → is-equiv (Hom-contrav' P contrav f x' y')
-Hom-contrav'-is-equiv P Pc f x' y'
-  = fundamental-Id
-      _
-      (is-contravariant-hom←is-contravariant Pc f y')
-      (λ x' → Hom-contrav' P Pc f x' y')
-      x'
+  opaque
+    unfolding tr-contrav-hom
+    Hom-contrav'
+      : ∀ {x y} (f : Hom A x y) x' y'
+        → tr-contrav-hom {P = P} Pc f y' ＝ x' → Hom-over f x' y'
+    Hom-contrav' f x' y' refl
+      =  is-contravariant-hom←is-contravariant Pc f y' .centre .snd
 
-Hom-contrav'≃
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P)
-      {x y} (f : Hom A x y) x' y'
-    → (tr-contrav-hom {P = P} contrav f y' ＝ x') ≃ (Hom-over f x' y')
-Hom-contrav'≃  P Pc f x' y'
-  = mk≃ (Hom-contrav' P Pc f x' y') (Hom-contrav'-is-equiv P Pc f x' y')
+  Hom-contrav'-is-equiv
+    : ∀ {x y} (f : Hom A x y) x' y'
+      → is-equiv (Hom-contrav' f x' y')
+  Hom-contrav'-is-equiv f x' y'
+    = fundamental-Id
+        _
+        (is-contravariant-hom←is-contravariant Pc f y')
+        (λ x' → Hom-contrav' f x' y')
+        x'
 
-tr-contrav-hom-unique
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P)
-      {x y} (f : Hom A x y) x' y'
-    → (Hom-over f x' y') → tr-contrav-hom {P = P} contrav f y' ＝ x'
-tr-contrav-hom-unique P Pc f x' y' = _≃_.bwd (Hom-contrav'≃ P Pc f x' y')
+  Hom-contrav'≃
+    : ∀ {x y} (f : Hom A x y) x' y'
+      → (tr-contrav-hom {P = P} Pc f y' ＝ x') ≃ (Hom-over f x' y')
+  Hom-contrav'≃  f x' y'
+    = mk≃ (Hom-contrav' f x' y') (Hom-contrav'-is-equiv f x' y')
+
+  tr-contrav-hom-unique
+    : ∀ {x y} (f : Hom A x y) x' y'
+      → (Hom-over f x' y') → tr-contrav-hom {P = P} Pc f y' ＝ x'
+  tr-contrav-hom-unique f x' y' = _≃_.bwd (Hom-contrav'≃ f x' y')
 }
 }
 

--- a/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
@@ -35,6 +35,9 @@ open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I
 open import Synthetic.Categories.Comma Δ¹ I
+
+-- TODO: Remove, only imported for `Δ¹-hom-≤-refl` which should live elsewhere
+open import Synthetic.Categories.CovariantFamilies Δ¹ I
 }
 }
 
@@ -97,20 +100,21 @@ tr-contrav-filler
     → ∀ p → Homᵈ (P ∘ h) (tr-contrav {P = P} Pc h p) p
 tr-contrav-filler cov h = snd ∘ centre ∘ cov h
 
-tr-contrav-hom
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥}
-    → is-contravariant P
-    → ∀ {x y} (h : Hom A x y) → P y → P x
-tr-contrav-hom contrav h
-  = fst ∘ centre ∘ is-contravariant-hom←is-contravariant contrav h
+opaque
+  tr-contrav-hom
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥}
+      → is-contravariant P
+      → ∀ {x y} (h : Hom A x y) → P y → P x
+  tr-contrav-hom contrav h
+    = fst ∘ centre ∘ is-contravariant-hom←is-contravariant contrav h
 
-tr-contrav-over
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥}
-    → (cov : is-contravariant P)
-    → ∀ {x y} (h : Hom A x y) → (y' : P y)
-    → Hom-over h (tr-contrav-hom cov h y') y'
-tr-contrav-over contrav h
-  = snd ∘ centre ∘ is-contravariant-hom←is-contravariant contrav h
+  tr-contrav-over
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥}
+      → (cov : is-contravariant P)
+      → ∀ {x y} (h : Hom A x y) → (y' : P y)
+      → Hom-over h (tr-contrav-hom cov h y') y'
+  tr-contrav-over contrav h
+    = snd ∘ centre ∘ is-contravariant-hom←is-contravariant contrav h
 }
 }
 
@@ -345,23 +349,152 @@ tr-contrav-id
     → tr-contrav Pc (λ _ → x) ~ id
 tr-contrav-id P contrav {x} x' = ap fst (contrav (λ _ → x) x' .central (x' , idH x'))
 
-tr-contrav-idH
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (Pc : is-contravariant P) {x}
-    → tr-contrav-hom {P = P} Pc (idH x) ~ id
-tr-contrav-idH P contrav {x} x' = ap fst
-  (is-contravariant-hom←is-contravariant contrav (idH x) x' .central (x' , idH x'))
+opaque
+  unfolding tr-contrav-hom
+  tr-contrav-idH
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (Pc : is-contravariant P) {x}
+      → tr-contrav-hom {P = P} Pc (idH x) ~ id
+  tr-contrav-idH P contrav {x} x' = ap fst
+    (is-contravariant-hom←is-contravariant contrav (idH x) x' .central (x' , idH x'))
 
-tr-contrav-∘
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} (Apc : is-segal A) (P : A → Type 𝓥)
-      (contrav : is-contravariant P) {x y z} (g : Hom A y z) (f : Hom A x y)
-      (z' : P z)
-    → tr-contrav-hom contrav (g ∘[ Apc ] f) z'
-    ＝ tr-contrav-hom contrav f (tr-contrav-hom contrav g z')
-tr-contrav-∘ apc P contrav g f z'
-  = ap fst
-      (is-contravariant-hom←is-contravariant contrav (g ∘[ apc ] f) z' .central
-        ( tr-contrav-hom contrav f (tr-contrav-hom contrav g z')
-        , Compᵈ apc P (is-inner-family←is-contravariant contrav) g f
-                (tr-contrav-over contrav g _) (tr-contrav-over contrav f _)))
+  tr-contrav-idH~
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P) {x}
+        (f : Hom A x x)
+      → f ＝ idH x
+      → tr-contrav-hom {P = P} contrav f ~ id
+  tr-contrav-idH~ P contrav _ refl = tr-contrav-idH P contrav
+
+  tr-contrav-∘
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} (Apc : is-segal A) (P : A → Type 𝓥)
+        (contrav : is-contravariant P) {x y z} (g : Hom A y z) (f : Hom A x y)
+        (z' : P z)
+      → tr-contrav-hom contrav (g ∘[ Apc ] f) z'
+      ＝ tr-contrav-hom contrav f (tr-contrav-hom contrav g z')
+  tr-contrav-∘ apc P contrav g f z'
+    = ap fst
+        (is-contravariant-hom←is-contravariant contrav (g ∘[ apc ] f) z' .central
+          ( tr-contrav-hom contrav f (tr-contrav-hom contrav g z')
+          , Compᵈ apc P (is-inner-family←is-contravariant contrav) g f
+                  (tr-contrav-over contrav g _) (tr-contrav-over contrav f _)))
+
+
+tr∘tr-contrav
+  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P) {x y z}
+      (p : y ＝ z) (f : Hom A y x)
+    → tr P p ∘ tr-contrav-hom {P = P} contrav f
+    ~ tr-contrav-hom {P = P} contrav (adjust-hom p refl f)
+tr∘tr-contrav P Pc refl f a
+  = ap (λ f → tr-contrav-hom Pc f a) (adjust-hom-refl f)
+}
+}
+
+\subtree[tot-00DH]{
+\title{Morphisms in Hom types}
+\taxon{Lemma}
+
+\p{We show that for a covariant family #{P}, given any #{f : \Hom_A(x,y)},
+the type of dependent morphisms #{\Hom_{Pf}(x',y')} is equivalent to
+#{f^*(x') = y'}.}
+
+\proof{
+\p{We first give a map #{f^*(x') = y'}, by identity induction, it suffices to give
+a morphism #{\Hom_{Pf}(x', f^*(x'))} for each #{x'}, but this is just the
+coherence you get from covariant transport.
+Now since #{\Sigma_{y' : P(f(1))} \Hom_{Pf}(x',y')} is a singleton by the
+definition of transport, the fundamental theorem of identity types gives us that
+this map is an equivalence.}
+}
+
+\agda{
+Hom-contrav
+  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P)
+      (f : Δ¹ → A) x' y'
+    → tr-contrav {P = P} contrav f y' ＝ x' → Homᵈ (P ∘ f) x' y'
+Hom-contrav _ Pc f x' y' refl = Pc f y' .centre .snd
+
+Hom-contrav-is-equiv
+  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P)
+      (f : Δ¹ → A) x' y'
+    → is-equiv (Hom-contrav P contrav f x' y')
+Hom-contrav-is-equiv P Pc f x' y'
+  = fundamental-Id _ (Pc f y') (λ x' → Hom-contrav P Pc f x' y') x'
+
+opaque
+  unfolding tr-contrav-hom
+  Hom-contrav'
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P)
+        {x y} (f : Hom A x y) x' y'
+      → tr-contrav-hom {P = P} contrav f y' ＝ x' → Hom-over f x' y'
+  Hom-contrav' P contrav f x' y' refl
+    =  is-contravariant-hom←is-contravariant contrav f y' .centre .snd
+
+Hom-contrav'-is-equiv
+  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P)
+      {x y} (f : Hom A x y) x' y'
+    → is-equiv (Hom-contrav' P contrav f x' y')
+Hom-contrav'-is-equiv P Pc f x' y'
+  = fundamental-Id
+      _
+      (is-contravariant-hom←is-contravariant Pc f y')
+      (λ x' → Hom-contrav' P Pc f x' y')
+      x'
+
+Hom-contrav'≃
+  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P)
+      {x y} (f : Hom A x y) x' y'
+    → (tr-contrav-hom {P = P} contrav f y' ＝ x') ≃ (Hom-over f x' y')
+Hom-contrav'≃  P Pc f x' y'
+  = mk≃ (Hom-contrav' P Pc f x' y') (Hom-contrav'-is-equiv P Pc f x' y')
+
+tr-contrav-hom-unique
+  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (contrav : is-contravariant P)
+      {x y} (f : Hom A x y) x' y'
+    → (Hom-over f x' y') → tr-contrav-hom {P = P} contrav f y' ＝ x'
+tr-contrav-hom-unique P Pc f x' y' = _≃_.bwd (Hom-contrav'≃ P Pc f x' y')
+}
+}
+
+\subtree[tot-00K3]{
+\title{Contravariant transport along inequalities in #{Δ¹}}
+\taxon{Lemma}
+
+\p{Each #{i \le j} in #{\Delta^1} induces a morphism #{\Hom_{\Delta^1}(i,j)}.
+consequently, for contravariant families over #{\Delta^1}, we may coerce along
+#{i \le j}. Since #{i \le j} is a proposition, we have the coercing along
+#{i \le i} for any #{i} is the identity and coercing along #{0 \le 1} is the
+same as contravariant transport over the canonical morphisms from #{0} to #{1} given
+by #{id : \Delta^1 \to \Delta^1}.}
+
+\agda{
+-- Δ¹-hom←≤  : ∀ {i j} → i ≤ j → Hom Δ¹ i j
+-- Δ¹-hom←≤ {i} {j} p .Homᵈ.hom l = (l ∨ i) ∧ (i ∨ j)
+-- Δ¹-hom←≤ p .Homᵈ.hom0 = ap₂ (_∧_) (∨-comm ∙ 0-bottom) (≤-max p) ∙ p
+-- Δ¹-hom←≤ p .Homᵈ.hom1 = ap₂ (_∧_) (∨-comm ∙ 1-coinit) (≤-max p) ∙ ∧-comm ∙ 1-top
+
+-- Δ¹-hom-≤-refl : ∀ {i} (p : i ≤ i) → Δ¹-hom←≤ p ＝ idH i
+-- Δ¹-hom-≤-refl {i} p
+--   = Hom-ext→ ( (λ a → ap ((a ∨ i) ∧_) ∨-idem ∙ ∨-∧-abs') , prop! , prop!)
+
+-- Δ¹-hom-0≤1 : (p : i0 ≤ i1) → Δ¹-hom←≤ p ＝ 0≤1
+-- Δ¹-hom-0≤1 p
+--   = Hom-ext→ ( (λ a → ap₂ (_∧_) 0-bottom 1-coinit ∙ 1-top) , prop! , prop!)
+
+module _ {𝓤} (B : Δ¹ → Type 𝓤) (bc : is-contravariant B) where
+
+  coe-contrav : {i j : Δ¹} → i ≤ j → B j → B i
+  coe-contrav p = tr-contrav-hom bc (Δ¹-hom←≤ p)
+
+  opaque
+    unfolding tr-contrav-hom
+    coe-contrav-id : {i  : Δ¹} (p : i ≤ i) → coe-contrav p ~ id
+    coe-contrav-id {i} p
+      =  happly (ap (tr-contrav-hom bc) (Δ¹-hom-≤-refl p))
+      ∙h tr-contrav-idH B bc
+
+    coe-contrav-＝ : {i j : Δ¹} (p : j ＝ i) (q : i ≤ j) → coe-contrav q ~ tr B p
+    coe-contrav-＝ refl = coe-contrav-id
+
+    coe-contrav-0≤1 : (p : i0 ≤ i1) → coe-contrav p ＝ tr-contrav bc id
+    coe-contrav-0≤1 p = ap (tr-contrav-hom bc) (Δ¹-hom-0≤1 p)
 }
 }

--- a/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
@@ -387,20 +387,20 @@ tr∘tr-contrav P Pc refl f a
 }
 
 \subtree[tot-00DH]{
-\title{Morphisms in Hom types}
+\title{Morphisms in the total type of a contravariant family}
 \taxon{Lemma}
 
-\p{We show that for a covariant family #{P}, given any #{f : \Hom_A(x,y)},
+\p{We show that for a contravariant type family #{P}, given any #{f : \Hom_A(x,y)},
 the type of dependent morphisms #{\Hom_{Pf}(x',y')} is equivalent to
-#{f^*(x') = y'}.}
+#{f^*(y') = x'}.}
 
 \proof{
-\p{We first give a map #{f^*(x') = y'}, by identity induction, it suffices to give
-a morphism #{\Hom_{Pf}(x', f^*(x'))} for each #{x'}, but this is just the
-coherence you get from covariant transport.
-Now since #{\Sigma_{y' : P(f(1))} \Hom_{Pf}(x',y')} is a singleton by the
-definition of transport, the fundamental theorem of identity types gives us that
-this map is an equivalence.}
+\p{We first give a map #{(f^*(y') = x') \to \Hom_{Pf}(x', y')}. By identity
+induction, it suffices to give a morphism #{\Hom_{Pf}(f^*(y'), y')} for each #{y'},
+but this is just the coherence you get from contravariant transport. Now since
+#{\Sigma_{x' : P(x)} \Hom_{Pf}(x',y')} is a singleton by the definition of
+contravariance, the fundamental theorem of identity types tells us that this map is
+an equivalence.}
 }
 
 \agda{
@@ -457,8 +457,8 @@ tr-contrav-hom-unique P Pc f x' y' = _≃_.bwd (Hom-contrav'≃ P Pc f x' y')
 \taxon{Lemma}
 
 \p{Each #{i \le j} in #{\Delta^1} induces a morphism #{\Hom_{\Delta^1}(i,j)}.
-consequently, for contravariant families over #{\Delta^1}, we may coerce along
-#{i \le j}. Since #{i \le j} is a proposition, we have the coercing along
+consequently, for contravariant families over #{\Delta^1}, we may coerce backwards
+along #{i \le j}. Since #{i \le j} is a proposition, we have the coercing along
 #{i \le i} for any #{i} is the identity and coercing along #{0 \le 1} is the
 same as contravariant transport over the canonical morphisms from #{0} to #{1} given
 by #{id : \Delta^1 \to \Delta^1}.}

--- a/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
@@ -363,16 +363,16 @@ opaque
   tr-contrav-idH~ P contrav _ refl = tr-contrav-idH P contrav
 
   tr-contrav-∘
-    : ∀ {𝓤 𝓥} {A : Type 𝓤} (Apc : is-segal A) (P : A → Type 𝓥)
-        (contrav : is-contravariant P) {x y z} (g : Hom A y z) (f : Hom A x y)
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} (𝐴 : is-segal A) (P : A → Type 𝓥)
+        (contrav : is-contravariant P) {x y z : A} (g : Hom A y z) (f : Hom A x y)
         (z' : P z)
-      → tr-contrav-hom contrav (g ∘[ Apc ] f) z'
+      → tr-contrav-hom contrav (g ∘[ 𝐴 ] f) z'
       ＝ tr-contrav-hom contrav f (tr-contrav-hom contrav g z')
-  tr-contrav-∘ apc P contrav g f z'
+  tr-contrav-∘ 𝐴 P contrav g f z'
     = ap fst
-        (is-contravariant-hom←is-contravariant contrav (g ∘[ apc ] f) z' .central
+        (is-contravariant-hom←is-contravariant contrav (g ∘[ 𝐴 ] f) z' .central
           ( tr-contrav-hom contrav f (tr-contrav-hom contrav g z')
-          , Compᵈ apc P (is-inner-family←is-contravariant contrav) g f
+          , Compᵈ 𝐴 P (is-inner-family←is-contravariant contrav) g f
                   (tr-contrav-over contrav g _) (tr-contrav-over contrav f _)))
 
 

--- a/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/ContravariantFamilies.lagda.tree
@@ -386,7 +386,7 @@ tr∘tr-contrav P Pc refl f a
 }
 }
 
-\subtree[tot-00DH]{
+\subtree[stt-00UB]{
 \title{Morphisms in the total type of a contravariant family}
 \taxon{Lemma}
 
@@ -448,7 +448,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (Pc : is-contravarian
 }
 }
 
-\subtree[tot-00K3]{
+\subtree[stt-00UC]{
 \title{Contravariant transport along inequalities in #{Δ¹}}
 \taxon{Lemma}
 
@@ -480,7 +480,7 @@ module _ {𝓤} (B : Δ¹ → Type 𝓤) (bc : is-contravariant B) where
 }
 }
 
-\subtree[tot-AUUV]{
+\subtree[stt-00UI]{
 \title{Contravariance is stable under base change}
 \taxon{Lemma}
 \date{2026-06-24}

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -185,7 +185,7 @@ opaque
 \subtree[tot-0556]{
 \title{Contravariance of the family #{i \mapsto (i = 0)}}
 \date{2026-06-22}
-\taxon{Lemma}
+\taxon{Example}
 
 \p{Assuming [quasicoherence](stt-00TA), or more specifically that every endomap on #{Δ^1} is
 monotone, the family #{i \mapsto (i = 0)} is contravariant.}
@@ -200,12 +200,6 @@ monotone.
 }
 
 \agda{
-contravariant-base-change
-  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {P : B → Type 𝓦}
-    → (f : A → B)
-    → is-contravariant P → is-contravariant (P ∘ f)
-contravariant-base-change F Pc f x₀ = Pc (F ∘ f) x₀
-
 module _ (phoa : Δ¹-endos-are-mono) where
 
   ●-unique-extensions : has-unique-extensions (point i1) (_＝ i0)

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -41,6 +41,7 @@ open notation
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Simplicial Δ¹ I
 open import Synthetic.Quasicoherence Δ¹ I I-distr
+open import Synthetic.Categories.WalkingHom Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I
 open import Synthetic.Categories.CovariantFamilies Δ¹ I
 open import Synthetic.Categories.ContravariantFamilies Δ¹ I
@@ -186,7 +187,7 @@ opaque
 \date{2026-06-22}
 \taxon{Lemma}
 
-\p{Assuming [quasicoherence](), or more specifically that every endomap on #{Δ^1} is
+\p{Assuming [quasicoherence](stt-00TA), or more specifically that every endomap on #{Δ^1} is
 monotone, the family #{i \mapsto (i = 0)} is contravariant.}
 
 \proof{
@@ -298,13 +299,6 @@ applying uniqueness of transport with a similarly constructed dependent morphism
 }
 
 \agda{
-0≤i : ∀ i → Hom Δ¹ i0 i
-0≤i i .Homᵈ.hom j = j ∧ i
-0≤i i .Homᵈ.hom0 = 0-init
-0≤i i .Homᵈ.hom1 = ∧-comm ∙ 1-top
-
-0≤i-at-0 : 0≤i i0 ＝ idH i0
-0≤i-at-0 = Hom-ext→ ((λ a → ∧-comm ∙ 0-init) , prop! , prop!)
 
 module _
   {𝓤 𝓥 𝓦} {B : Type 𝓤}

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -224,6 +224,20 @@ base change by right fibrations.}
 }
 
 \agda{
+contravariant-base-change
+  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {P : B → Type 𝓦}
+    → (f : A → B)
+    → is-contravariant P → is-contravariant (P ∘ f)
+contravariant-base-change F Pc f x₀ = Pc (F ∘ f) x₀
+
+0≤i : ∀ i → Hom Δ¹ i0 i
+0≤i i .Homᵈ.hom j = j ∧ i
+0≤i i .Homᵈ.hom0 = 0-init
+0≤i i .Homᵈ.hom1 = ∧-comm ∙ 1-top
+
+0≤i-at-0 : 0≤i i0 ＝ idH i0
+0≤i-at-0 = Hom-ext→ ((λ a → ∧-comm ∙ 0-init) , prop! , prop!)
+
 module _
   {𝓤 𝓥 𝓦} {B : Type 𝓤}
   (F : B → Type 𝓥) (G : B → Type 𝓦)
@@ -268,6 +282,120 @@ module _
           (base-change-left-anodyne
                 (fst: (F ∘ σ)) (point i0) (is-self-anodyne (point i0))
                 (is-right-fibration←is-contravariant (F ∘ σ) (rfib ∘ (σ ∘_))))
+
+    cov^contrav-is-covariant-lemma
+      : ∀ (F-contrav : is-contravariant F) (G-cov : is-covariant G)
+        → is-equiv (precomp-Π {B = Σ[ i ∶ Δ¹ ] F (σ i)} (G ∘ σ ∘ fst) (λ p → (i0 , p)))
+    cov^contrav-is-covariant-lemma Fc Gc = is-equiv←qinv qinv where
+      Gσ = G ∘ σ
+      Gσ-cov = covariant-base-change {P = G} σ Gc
+      Fσ = F ∘ σ
+      Fσ-contrav = contravariant-base-change {P = F} σ Fc
+
+      connection
+        : ∀ i (p : F (σ i))
+            (a : ∀ (x : Σ[ i ∶ Δ¹ ] F (σ i)) → G (σ (fst x)))
+          → Hom-over {B = Gσ}
+              (0≤i i)
+              (a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p))
+              (a (i , p))
+      connection i p a .Homᵈ.hom j
+        = a ( j ∧ i
+            , tr-contrav-hom
+                Fσ-contrav
+                (Δ¹-hom←≤ {i = j ∧ i} {j = i} (∧-≤-elimr ≤-refl))
+                p)
+
+      connection i p a .Homᵈ.hom0 = sym lemma1 where
+
+        path : i0 ＝ i0 ∧ i
+        path = sym 0-init
+
+        lemma3
+          : Id (Σ Δ¹ Fσ)
+               (i0 , tr-contrav-hom {P = Fσ} Fσ-contrav (0≤i i) p)
+               (i0 ∧ i , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+        lemma3 = Σ-path→
+          ( path
+          , tr∘tr-contrav Fσ Fσ-contrav path (0≤i i) p
+          ∙ ap (λ f → tr-contrav-hom Fσ-contrav f p)
+               (Hom-ext→
+                 ( (λ j → ap₂ _∧_
+                              (≤-antisym
+                                (∨-≤-introl auto!)
+                                (∨-UP (auto! , (∧-≤-eliml auto!))))
+                              (sym (∧-∨-abs')))
+                 , carrier-is-set _ _ _ _
+                 , carrier-is-set _ _ _ _)))
+
+        lemma2 : a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p)
+               ＝[ ap (Gσ ∘ fst) lemma3 ]
+                 a (i0 ∧ i
+                   , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+        lemma2 = apᶠ a lemma3
+
+        lemma1 : a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p)
+               ＝[ ap Gσ (sym 0-init) ]
+                 a (i0 ∧ i
+                   , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+        lemma1 = adjust-idᵈ (ap-∘ Gσ fst lemma3 ∙ ap (ap Gσ) Σ-path-ap-fst) lemma2
+
+      connection i p a .Homᵈ.hom1 = sym lemma1 where
+
+        lemma3 : Id (Σ Δ¹ Fσ)
+                    (i , p)
+                    ( i1 ∧ i
+                    , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+        lemma3 = Σ-path→
+          ( sym (∧-comm ∙ 1-top)
+          , Idᶠ-inr' {B = Fσ} {p = ∧-comm ∙ 1-top}
+               {x = p}
+               {y = tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p}
+               (sym (tr∘tr-contrav Fσ Fσ-contrav (∧-comm ∙ 1-top) _ p
+                    ∙ tr-contrav-hom-unique
+                        Fσ Fσ-contrav
+                        (adjust-hom (∧-comm ∙ 1-top) refl (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))
+                        p p
+                        (tr (λ f → Hom-over f p p)
+                            {a = idH i}
+                            {b = (adjust-hom (∧-comm ∙ 1-top) refl
+                                             (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))}
+                            (Hom-ext→
+                              ((λ j → ≤-antisym
+                                       (∧-UP
+                                         ( ∨-≤-intror (∧-UP (1-top , ∧-idem))
+                                         , ∨-≤-intror ≤-refl))
+                                       (∧-≤-elimr
+                                         (∨-UP
+                                           ( (∧-≤-elimr ≤-refl)
+                                           , ≤-refl))))
+                              , carrier-is-set _ _ _ _
+                              , carrier-is-set _ _ _ _))
+                            (idH p)))))
+
+        lemma2 : a (i , p)
+               ＝[ ap (Gσ ∘ fst) lemma3 ]
+                 a ( i1 ∧ i
+                   , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+        lemma2 = apᶠ a lemma3
+
+        lemma1 : a (i , p)
+               ＝[ ap Gσ (sym (∧-comm ∙ 1-top)) ]
+                 a ( i1 ∧ i
+                   , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+        lemma1 = adjust-idᵈ (ap-∘ Gσ fst lemma3 ∙ ap (ap Gσ) Σ-path-ap-fst) lemma2
+
+      qinv : quasi-inv (precomp-Π (G ∘ σ ∘ fst) (λ p → i0 , p))
+      qinv .fst x (i , p) = tr-cov-hom Gσ-cov (0≤i i)
+                               (x (tr-contrav-hom Fσ-contrav (0≤i i) p))
+      qinv .snd .fst x = funext→
+        (λ where (i , p) → tr-cov-hom-unique Gσ Gσ-cov (0≤i i)
+                             (x (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p))
+                             (x (i , p))
+                             (connection i p x))
+      qinv .snd .snd x = funext→
+        (λ p → tr-cov-idH~ Gσ Gσ-cov _ 0≤i-at-0 (x (tr-contrav-hom Fσ-contrav (0≤i i0) p))
+             ∙ ap x (tr-contrav-idH~ Fσ Fσ-contrav _ 0≤i-at-0 p))
 
   cov^contrav-is-covariant
     : (base-change-left-anodyne

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -183,7 +183,7 @@ opaque
 }
 }
 
-\subtree[tot-0556]{
+\subtree[stt-00UD]{
 \title{Contravariance of the family #{i \mapsto (i = 0)}}
 \date{2026-06-22}
 \taxon{Example}
@@ -223,7 +223,7 @@ module _ (Δ¹-mono : Δ¹-endos-are-mono) where
 }
 }
 
-\subtree[tot-CEIY]{
+\subtree[stt-00UJ]{
 \taxon{Lemma}
 
 \p{Given type families #{F} and #{G}, solutions of the left lifting problem are
@@ -339,7 +339,7 @@ conceptually simpler, but relies on a yet to be formalised lemma and the second
 takes a somewhat more bruteforce approach, but is completely formalised within the
 library.}
 
-\subtree[tot-56BA]{
+\subtree[stt-00UG]{
 \p{
 We may see that the leftmost map of the second of the [above diagrams](stt-00OM) is
 obtained as the pullback of #{\{0\} \to \Delta^1} by the projection #{\Sigma_{i}
@@ -397,7 +397,7 @@ module FromBaseChangeLeftAnodyne
 }
 }
 
-\subtree[tot-0AAI]{
+\subtree[stt-00UE]{
 \p{Alternatively we can show directly that lifts exist uniquely for lifting problems
 in the shape of the rightmost diagram. In particular we show that for any covariant
 type family #{G}, the natural map ##{(\Pi_{i}\ (F\sigma(i) \to G\sigma(i))) \to
@@ -605,7 +605,7 @@ module _
 }
 }
 
-\subtree[tot-0AGU]{
+\subtree[stt-00UF]{
 \taxon{Corollary}
 
 \p{For any #{f : A \to Δ^1} and covariant family #{F}, the type family

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -287,13 +287,35 @@ module _
                   (mk-afmap (σ ∘ fst) (h tt)))})
 }
 
-\p{We give a concrete proof of this fact (without the need for the yet unformalised
-assumption) for the case that #{F} is the contravariant family #{i \mapsto (f(i) = 0)}
-for any #{f : \Delta^1 \to \Delta^1}.
-By the above argument it suffices to show that the arrow map from #{(f(\sigma(0)) = 0)
-\to \Sigma_{i} (f(\sigma(i))=0)} to any left fibration #{G}, where the bottom map is
+\p{We give a concrete proof for a specific instance of this fact (without the need
+for the yet unformalised assumption) for the case that #{F} is the contravariant
+family #{i \mapsto (f(i) = 0)} for any #{f : \Delta^1 \to \Delta^1}.  By the above
+argument it suffices to show that any arrow map from #{(f(\sigma(0)) = 0) \to
+\Sigma_{i} (f(\sigma(i))=0)} to any left fibration #{G}, where the bottom map is
 given by #{\sigma\pi}, has unique extensions when #{f \sigma} is monotone (which it
 always is under the assumption of quasi-coherence).}
+
+
+\proof{
+\p{We give an explicit inverse to the map ##{(\Pi_{(i , p) : \Sigma_{i} f(\sigma(i))
+= 0} P(\sigma(i))) \to (\Pi_{(p : f(\sigma(0)) = 0) P(\sigma(0))} )} Namely we need
+take a function #{x : (f(\sigma(0)) = 0) \to P(0)} and a pair #{i : \Delta^1}, #{p :
+f(\sigma(i)) = 0} to #{P(\sigma(i))}. By the monotonicity of #{f\sigma} we have a map
+#{h : (f(\sigma(i)) = 0) \to (f(\sigma(0)) = 0)}, which is the identity when #{i =
+0}, and by covariance of #{P} we have a map #{P(\sigma(0)) \to P(\sigma(i))}, which
+is also the identity when #{i} is #{0}. Consequently, we may construct a map which is
+clearly a left inverse. To show it is also a right inverse, we require that for any
+#{a : \Pi_{(i , p) : \Sigma_{i} (f(\sigma(i)) = 0)} P(\sigma(i))} and #{(i,p) :
+\Sigma_{i} (f(\sigma(i)) = 0)} that #{P_*(a(0, h_i(p)))} is equal to #{a (i, p)}. By
+the uniqueness of covariant transport, we may give a morphism #{\Hom_{Pσ}^{0 \le
+i}(a(0 , h_i(p)), a (i , p))}. The mapping #{j \mapsto a(i \land j, h'_{j \land i \le
+i}(p))} does the job, where #{h'} generalises #{h} by replacing #{i} and #{0} with
+any pair #{i \ge j}.}
+
+\p{Note that for technical reasons due to the construction of the
+map from #{i \le j \to \Hom(i,j)}, in the formalisation, we have to use the mapping
+#{j \mapsto a((j \lor 0) \land (i \lor 0), ...)}.}
+}
 
 \agda{
 module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Lattice.≤-poset I) σ) where
@@ -304,12 +326,14 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Latt
   transpose-●-is-left-anodyne P P-cov f fm = is-equiv←qinv
     ( (λ x (i , p) → coe-cov Pσ Pσ-cov 0-init (x (map1 i i0 0-init p)))
     , (λ a → funext→ (λ
-      where (i , p)→ coe-cov Pσ Pσ-cov (0-init {i}) (a (i0 , map1' i p))
+      where (i , p) → coe-cov Pσ Pσ-cov (0-init {i}) (a (i0 , map1' i p))
                   ＝⟨⟩
-                     tr-cov-hom {P = P ∘ σ} Pσ-cov (Δ¹-hom←≤ 0-init) (a (i0 , map1' i p))
-                  ＝⟨ tr-cov-hom-unique Pσ Pσ-cov (Δ¹-hom←≤ 0-init) (a (i0 , map1' i p))
-                        (a (i , p)) (connection i p a) ⟩
-                      a (i , p) ∎))
+                     tr-cov-hom Pσ-cov (Δ¹-hom←≤ 0-init) (a (i0 , map1' i p))
+                  ＝⟨ tr-cov-hom-unique Pσ Pσ-cov
+                       (Δ¹-hom←≤ 0-init) (a (i0 , map1' i p))
+                       (a (i , p))
+                       (connection i p a) ⟩
+                     a (i , p) ∎))
     , (λ a → funext→ (λ p →
                           coe-cov-id
                             (P ∘ σ)
@@ -322,7 +346,10 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Latt
       opaque
         map1 : ∀ i j → j ≤ i → f (σ i) ＝ i0 → f (σ j) ＝ i0
         map1 i j l p = ≤-antisym
-          (≤-trans (∘-is-monotone ≤-poset ≤-poset ≤-poset f σ fm σ-mono l) (≤←＝ p)) 0-init
+          (≤-trans
+            (∘-is-monotone ≤-poset ≤-poset ≤-poset f σ fm σ-mono l)
+            (≤←＝ p))
+          0-init
 
         map1-at-0 : ∀ p → map1 i0 i0 p ~ id
         map1-at-0 _ p = carrier-is-set _ _ _ p
@@ -331,8 +358,12 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Latt
 
       opaque
         connection
-          : ∀ i (p : f (σ i) ＝ i0) (a : (∀ (x : Σ[ i ∶ Δ¹ ] (f (σ i) ＝ i0)) → P (σ (fst x))))
-            → Hom-over {B = P ∘ σ} (Δ¹-hom←≤ 0-init) (a (i0 , map1 i i0 0-init p)) (a (i , p))
+          : ∀ (i : Δ¹) (p : f (σ i) ＝ i0)
+              (a : ∀ (x : Σ[ i ∶ Δ¹ ] (f (σ i) ＝ i0)) → P (σ (fst x)))
+            → Hom-over {B = P ∘ σ}
+                (Δ¹-hom←≤ 0-init)
+                (a (i0 , map1 i i0 0-init p))
+                (a (i , p))
         connection i p a .Homᵈ.hom j
           = a ( (j ∨ i0) ∧ (i0 ∨ i)
               , map1 i ((j ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
@@ -342,7 +373,8 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Latt
           path = sym
             (ap₂ _∧_ (∨-comm ∙ 0-bottom)
                      ( ap (_∨ i)
-                          (sym (ap (_∧_ i0) (sym (∨-comm ∙ 0-bottom)) ∙ ∧-∨-abs ∙ refl))
+                          (sym (ap (_∧_ i0) (sym (∨-comm ∙ 0-bottom))
+                               ∙ ∧-∨-abs ∙ refl))
                      ∙ (ap (_∨ i) ∧-comm ∙ ∨-comm ∙ ∨-∧-abs)
                      ∙ refl)
             ∙ ap (_∧_ i0) (sym (∨-comm ∙ 0-bottom)) ∙ ∧-∨-abs ∙ refl)
@@ -350,19 +382,22 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Latt
           lemma3 : Id (Σ[ i ∶ Δ¹ ] (f (σ i) ＝ i0))
                       (i0 , map1' i p)
                       ( (i0 ∨ i0) ∧ (i0 ∨ i)
-                      , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
+                      , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i))
+                               (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
           lemma3 = Σ-path→ (path , carrier-is-set _ _ _ _)
 
           lemma2 : a (i0 , map1' i p)
                  ＝[ ap (P ∘ σ ∘ fst) lemma3 ]
                    a ( (i0 ∨ i0) ∧ (i0 ∨ i)
-                     , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
+                     , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i))
+                              (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
           lemma2 = apᶠ a lemma3
 
           lemma1 : a (i0 , map1' i p)
                  ＝[ ap (P ∘ σ) path ]
                    a ( (i0 ∨ i0) ∧ (i0 ∨ i)
-                     , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
+                     , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i))
+                              (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
           lemma1 = adjust-idᵈ
                      {P = ap (P ∘ σ ∘ fst) lemma3} {Q = ap (P ∘ σ) path}
                      (ap-∘ (P ∘ σ) fst lemma3 ∙ ap (ap (P ∘ σ)) Σ-path-ap-fst)
@@ -375,14 +410,16 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Latt
           Σpath : Id (Σ[ i ∶ Δ¹ ] (f (σ i) ＝ i0))
                      (i , p)
                      ( (i1 ∨ i0) ∧ (i0 ∨ i)
-                     , map1 i ((i1 ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
+                     , map1 i ((i1 ∨ i0) ∧ (i0 ∨ i))
+                              (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
           Σpath = Σ-path→ (path , (carrier-is-set _ _ _ _))
 
           lemma1
             : a (i , p)
             ＝[ ap (P ∘ σ) path ]
               a ( (i1 ∨ i0) ∧ (i0 ∨ i)
-                , map1 i ((i1 ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
+                , map1 i ((i1 ∨ i0) ∧ (i0 ∨ i))
+                         (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
           lemma1 = adjust-idᵈ {P = ap (P ∘ σ ∘ fst) Σpath} {Q = ap (P ∘ σ) path}
                      (ap-∘ (P ∘ σ) fst Σpath ∙ ap (ap (P ∘ σ)) Σ-path-ap-fst)
                      (apᶠ a Σpath)
@@ -398,7 +435,7 @@ module _ (phoa : Δ¹-endos-are-mono) where
           → is-single←equiv-to-single
               ( fibre-precomp-Π≃Ext (F ∘ σ ∘ fst) (λ z → i0 , z) (p tt)
               ∙e transpose-ext-exponentials ((_＝ i0) ∘ f) F σ (p tt)  e⁻¹)
-              ( has-singleton-fibres←is-equiv
+              (has-singleton-fibres←is-equiv
                    (transpose-●-is-left-anodyne σ (phoa σ) F Fc f (phoa f)) (p tt) )
 }
 }

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -278,20 +278,19 @@ module _
   {𝓤 𝓥 𝓦 𝓜 𝓝} {A : Type 𝓤} {B : Type 𝓥} (p : A → B)
   {C : Type 𝓝} (F : C → Type 𝓦) (G : C → Type 𝓜)
   (let G^F b = F b → G b)
+  (σ : B → C)
   where
 
-  module _ (σ : B → C) where
-    transpose-ext-exponentials'
-      : ∀ (h : (a : A) → F (σ (p a)) → G (σ (p a)))
-        → Extᵈ p (G^F ∘ σ) h
-        ≃ Extᵈ (base-change-fst p (F ∘ σ)) (G ∘ σ ∘ fst) (uncurry h)
-    transpose-ext-exponentials' h
-      = Σ-≃
-          uncurry≃
-          (λ h
-           →  postcomp-Π-≃ (λ c → funext≃)
-           ∙e uncurry≃)
-
+  transpose-ext-exponentials'
+    : ∀ (h : (a : A) → F (σ (p a)) → G (σ (p a)))
+      → Extᵈ p (G^F ∘ σ) h
+      ≃ Extᵈ (base-change-fst p (F ∘ σ)) (G ∘ σ ∘ fst) (uncurry h)
+  transpose-ext-exponentials' h
+    = Σ-≃
+        uncurry≃
+        (λ h
+         →  postcomp-Π-≃ (λ c → funext≃)
+         ∙e uncurry≃)
 
 module _
   {𝓤 𝓥 𝓦} {B : Type 𝓤}
@@ -388,12 +387,12 @@ module FromBaseChangeLeftAnodyne
   cov^contrav-is-covariant-alternative Fctr Gcov
     = is-covariant←has-unique-extensions G^F
         (λ {(mk-afmap σ h)
-         → is-single←equiv-to-single
-             (transpose-ext-exponentials-at-point-i0 F G σ (h tt) e⁻¹)
-             (unique-extensions←are-orthogonal-fam {P = G}
-               (are-orthogonal-fam←are-orthogonal-fst
-                 (transposed-left-map-is-left-anodyne σ Fctr (fst: G)
-                   (is-covariant↔is-left-fibration G .fst Gcov)))
+           → is-single←equiv-to-single
+               (transpose-ext-exponentials-at-point-i0 F G σ (h tt) e⁻¹)
+               (unique-extensions←are-orthogonal-fam {P = G}
+                 (are-orthogonal-fam←are-orthogonal-fst
+                   (transposed-left-map-is-left-anodyne σ Fctr (fst: G)
+                     (is-covariant↔is-left-fibration G .fst Gcov)))
                (mk-afmap (σ ∘ fst) (h tt)))})
 }
 }
@@ -594,12 +593,12 @@ module _
   cov^contrav-is-covariant Fc Gc
     = is-covariant←has-unique-extensions G^F
         (λ {(mk-afmap σ h)
-         → is-single←equiv-to-single
-             (  fibre-precomp-Π≃Ext (G ∘ σ ∘ fst) (i0 ,_) (h tt)
-             ∙e transpose-ext-exponentials-at-point-i0 F G σ (h tt) e⁻¹)
-             (has-singleton-fibres←is-equiv
-               (cov^contrav-is-covariant-lemma F G σ Fc Gc)
-               (h tt))})
+           → is-single←equiv-to-single
+               (  fibre-precomp-Π≃Ext (G ∘ σ ∘ fst) (i0 ,_) (h tt)
+               ∙e transpose-ext-exponentials-at-point-i0 F G σ (h tt) e⁻¹)
+               (has-singleton-fibres←is-equiv
+                 (cov^contrav-is-covariant-lemma F G σ Fc Gc)
+                 (h tt))})
 
 }
 }
@@ -615,11 +614,11 @@ module _
 \agda{
 module _ (Δ¹-mono : Δ¹-endos-are-mono) where
 
-  exp-●-is-covariant
+  ^●-is-covariant
     : ∀ {𝓤 𝓥} {A : Type 𝓥} (F : A → Type 𝓤) (F-cov : is-covariant F)
       → (f : A → Δ¹)
       → is-covariant (λ i → (f i ＝ i0) → F i)
-  exp-●-is-covariant F Fc f
+  ^●-is-covariant F Fc f
     = cov^contrav-is-covariant ((_＝ i0) ∘ f) F (●-is-contravariant Δ¹-mono f) Fc
 }
 }

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -293,7 +293,6 @@ applying uniqueness of transport with a similarly constructed dependent morphism
 }
 
 \agda{
-
 module _
   {𝓤 𝓥 𝓦} {B : Type 𝓤}
   (F : B → Type 𝓥) (G : B → Type 𝓦)

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -155,9 +155,10 @@ opaque
   ＝-is-covariant {A = A} {B} x y Bc
     = is-covariant↔is-left-fibration _ .snd lf where
     is-left : is-left-fibration {A = A} {B = Σ A B} (λ a → a , y a)
-    is-left = right-orthogonal-left-cancel (point i0)
-                (is-covariant↔is-left-fibration _ .fst Bc)
-                (point i0 ⊥id)
+    is-left
+      = right-orthogonal-left-cancel (point i0)
+          (is-covariant↔is-left-fibration _ .fst Bc)
+          (point i0 ⊥id)
 
     pb : Arrow-map (fst: λ a → x a ＝ y a) {D = Σ A B} (λ a → a , y a)
     pb .Arrow-Π.top = fst
@@ -316,10 +317,11 @@ module _
     transposed-left-map-is-pb .fst .Arrow-Π.top a = ((_ , a) , tt , refl)
     transposed-left-map-is-pb .fst .Arrow-Π.bot = id
     transposed-left-map-is-pb .fst .Arrow-Π.comm = ~refl
-    transposed-left-map-is-pb .snd .fst = is-equiv←qinv
-      ( (λ {((_ , a) , _ , refl) → a})
-      , ~refl
-      , λ {(_ , _ , refl) → refl})
+    transposed-left-map-is-pb .snd .fst
+      = is-equiv←qinv
+          ( (λ {((_ , a) , _ , refl) → a})
+          , ~refl
+          , λ {(_ , _ , refl) → refl})
     transposed-left-map-is-pb .snd .snd = id-is-equiv
 
     transposed-left-map-is-left-anodyne
@@ -335,8 +337,8 @@ module _
           (inv-Arrow-equiv transposed-left-map-is-pb)
           (point i0)
           (base-change-left-anodyne
-                (fst: (F ∘ σ)) (point i0) (is-self-anodyne (point i0))
-                (is-right-fibration←is-contravariant (F ∘ σ) (rfib ∘ (σ ∘_))))
+            (fst: (F ∘ σ)) (point i0) (is-self-anodyne (point i0))
+            (is-right-fibration←is-contravariant (F ∘ σ) (rfib ∘ (σ ∘_))))
 }
 
 \agda{
@@ -372,84 +374,97 @@ module _
           : Id (Σ Δ¹ Fσ)
                (i0 , tr-contrav-hom {P = Fσ} Fσ-contrav (0≤i i) p)
                (i0 ∧ i , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
-        lemma3 = Σ-path→
-          ( path
-          , tr∘tr-contrav Fσ Fσ-contrav path (0≤i i) p
-          ∙ ap (λ f → tr-contrav-hom Fσ-contrav f p)
-               (Hom-ext→
-                 ( (λ j → ap₂ _∧_
-                              (≤-antisym
-                                (∨-≤-introl auto!)
-                                (∨-UP (auto! , (∧-≤-eliml auto!))))
-                              (sym (∧-∨-abs')))
-                 , carrier-is-set _ _ _ _
-                 , carrier-is-set _ _ _ _)))
+        lemma3
+          = Σ-path→
+            ( path
+            , tr∘tr-contrav Fσ Fσ-contrav path (0≤i i) p
+            ∙ ap (λ f → tr-contrav-hom Fσ-contrav f p)
+                 (Hom-ext→
+                   ( (λ j
+                      → ap₂ _∧_
+                          (≤-antisym
+                            (∨-≤-introl auto!)
+                            (∨-UP (auto! , (∧-≤-eliml auto!))))
+                          (sym (∧-∨-abs')))
+                   , carrier-is-set _ _ _ _
+                   , carrier-is-set _ _ _ _)))
 
-        lemma2 : a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p)
-               ＝[ ap (Gσ ∘ fst) lemma3 ]
-                 a (i0 ∧ i
-                   , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+        lemma2
+          : a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p)
+          ＝[ ap (Gσ ∘ fst) lemma3 ]
+            a (i0 ∧ i
+              , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
         lemma2 = apᶠ a lemma3
 
-        lemma1 : a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p)
-               ＝[ ap Gσ (sym 0-init) ]
-                 a (i0 ∧ i
-                   , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
-        lemma1 = adjust-idᵈ (ap-∘ Gσ fst lemma3 ∙ ap (ap Gσ) Σ-path-ap-fst) lemma2
+        lemma1
+          : a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p)
+          ＝[ ap Gσ (sym 0-init) ]
+            a (i0 ∧ i
+              , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+        lemma1 = adjust-Idᵈ (ap-∘ Gσ fst lemma3 ∙ ap (ap Gσ) Σ-path-ap-fst) lemma2
 
       connection i p a .Homᵈ.hom1 = sym lemma1 where
 
-        lemma3 : Id (Σ Δ¹ Fσ)
-                    (i , p)
-                    ( i1 ∧ i
-                    , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+        lemma3
+          : Id (Σ Δ¹ Fσ)
+             (i , p)
+             ( i1 ∧ i
+             , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
         lemma3 = Σ-path→
           ( sym (∧-comm ∙ 1-top)
           , Idᶠ-inr' {B = Fσ} {p = ∧-comm ∙ 1-top}
                {x = p}
                {y = tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p}
-               (sym (tr∘tr-contrav Fσ Fσ-contrav (∧-comm ∙ 1-top) _ p
+               (sym ( tr∘tr-contrav Fσ Fσ-contrav (∧-comm ∙ 1-top) _ p
                     ∙ tr-contrav-hom-unique
                         Fσ Fσ-contrav
                         (adjust-hom (∧-comm ∙ 1-top) refl (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))
                         p p
-                        (tr (λ f → Hom-over f p p)
-                            {a = idH i}
-                            {b = (adjust-hom (∧-comm ∙ 1-top) refl
-                                             (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))}
-                            (Hom-ext→
-                              ((λ j → ≤-antisym
-                                       (∧-UP
-                                         ( ∨-≤-intror (∧-UP (1-top , ∧-idem))
-                                         , ∨-≤-intror ≤-refl))
-                                       (∧-≤-elimr
-                                         (∨-UP
-                                           ( (∧-≤-elimr ≤-refl)
-                                           , ≤-refl))))
-                              , carrier-is-set _ _ _ _
-                              , carrier-is-set _ _ _ _))
-                            (idH p)))))
+                        (tr
+                          (λ f → Hom-over f p p)
+                          {a = idH i}
+                          {b = (adjust-hom
+                                 (∧-comm ∙ 1-top)
+                                 refl
+                                 (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))}
+                          (Hom-ext→
+                            ((λ j
+                              → ≤-antisym
+                                  (∧-UP
+                                    ( ∨-≤-intror (∧-UP (1-top , ∧-idem))
+                                    , ∨-≤-intror ≤-refl))
+                                  (∧-≤-elimr
+                                    (∨-UP
+                                      ( (∧-≤-elimr ≤-refl)
+                                      , ≤-refl))))
+                            , carrier-is-set _ _ _ _
+                            , carrier-is-set _ _ _ _))
+                          (idH p)))))
 
-        lemma2 : a (i , p)
-               ＝[ ap (Gσ ∘ fst) lemma3 ]
-                 a ( i1 ∧ i
-                   , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+        lemma2
+          : a (i , p)
+          ＝[ ap (Gσ ∘ fst) lemma3 ]
+            a ( i1 ∧ i
+              , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
         lemma2 = apᶠ a lemma3
 
-        lemma1 : a (i , p)
-               ＝[ ap Gσ (sym (∧-comm ∙ 1-top)) ]
-                 a ( i1 ∧ i
-                   , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
-        lemma1 = adjust-idᵈ (ap-∘ Gσ fst lemma3 ∙ ap (ap Gσ) Σ-path-ap-fst) lemma2
+        lemma1
+          : a (i , p)
+          ＝[ ap Gσ (sym (∧-comm ∙ 1-top)) ]
+            a ( i1 ∧ i
+              , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+        lemma1 = adjust-Idᵈ (ap-∘ Gσ fst lemma3 ∙ ap (ap Gσ) Σ-path-ap-fst) lemma2
 
       qinv : quasi-inv (precomp-Π (G ∘ σ ∘ fst) (λ p → i0 , p))
-      qinv .fst x (i , p) = tr-cov-hom Gσ-cov (0≤i i)
-                               (x (tr-contrav-hom Fσ-contrav (0≤i i) p))
+      qinv .fst x (i , p)
+        = tr-cov-hom Gσ-cov (0≤i i)
+            (x (tr-contrav-hom Fσ-contrav (0≤i i) p))
       qinv .snd .fst x = funext→
-        (λ where (i , p) → tr-cov-hom-unique Gσ Gσ-cov (0≤i i)
-                             (x (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p))
-                             (x (i , p))
-                             (connection i p x))
+        (λ {(i , p)
+         → tr-cov-hom-unique Gσ Gσ-cov (0≤i i)
+             (x (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p))
+             (x (i , p))
+             (connection i p x)})
       qinv .snd .snd x = funext→
         (λ p → tr-cov-idH~ Gσ Gσ-cov _ 0≤i-at-0 (x (tr-contrav-hom Fσ-contrav (0≤i i0) p))
              ∙ ap x (tr-contrav-idH~ Fσ Fσ-contrav _ 0≤i-at-0 p))
@@ -458,8 +473,9 @@ module _
 \agda{
   cov^contrav-is-covariant
     : is-contravariant F → is-covariant G → is-covariant G^F
-  cov^contrav-is-covariant Fc Gc = is-covariant←has-unique-extensions G^F
-    (λ {(mk-afmap σ h)
+  cov^contrav-is-covariant Fc Gc
+    = is-covariant←has-unique-extensions G^F
+        (λ {(mk-afmap σ h)
          → is-single←equiv-to-single
              (  fibre-precomp-Π≃Ext (G ∘ σ ∘ fst) (i0 ,_) (h tt)
              ∙e transpose-ext-exponentials σ (h tt) e⁻¹)
@@ -469,20 +485,20 @@ module _
 
   cov^contrav-is-covariant-alternative
     : (base-change-left-anodyne
-          : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} (f : B → A) {C : Type 𝓦}
-              (p : C → A) → is-left-anodyne p → is-right-fibration f
-            → is-left-anodyne (base-change-arrow f p))
+        : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} (f : B → A) {C : Type 𝓦}
+            (p : C → A) → is-left-anodyne p → is-right-fibration f
+          → is-left-anodyne (base-change-arrow f p))
     → is-contravariant F → is-covariant G → is-covariant G^F
   cov^contrav-is-covariant-alternative bcla Fctr Gcov
-    = is-covariant←has-unique-extensions G^F (λ
-        {(mk-afmap σ h)
-            → is-single←equiv-to-single
-                (transpose-ext-exponentials σ (h tt) e⁻¹)
-                (unique-extensions←are-orthogonal-fam {P = G}
-                  (are-orthogonal-fam←are-orthogonal-fst
-                    (transposed-left-map-is-left-anodyne σ bcla Fctr (fst: G)
-                      (is-covariant↔is-left-fibration G .fst Gcov)))
-                  (mk-afmap (σ ∘ fst) (h tt)))})
+    = is-covariant←has-unique-extensions G^F
+        (λ {(mk-afmap σ h)
+         → is-single←equiv-to-single
+             (transpose-ext-exponentials σ (h tt) e⁻¹)
+             (unique-extensions←are-orthogonal-fam {P = G}
+               (are-orthogonal-fam←are-orthogonal-fst
+                 (transposed-left-map-is-left-anodyne σ bcla Fctr (fst: G)
+                   (is-covariant↔is-left-fibration G .fst Gcov)))
+               (mk-afmap (σ ∘ fst) (h tt)))})
 }
 }
 

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -9,7 +9,7 @@ open import Foundations.Universes
 open import Algebra.Lattice
 
 module Synthetic.Categories.CovariantClosure
-  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹)
+  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹) (I-distr : is-distributive I)
   where
 
 open Lattice I renaming (0l to i0; 1l to i1)
@@ -22,6 +22,8 @@ open import Axioms.UF
 \agda-imports{
 \agda{
 open import Foundations.Prelude
+
+open import Algebra.Order.Monotone
 
 open import Ergonomics.Auto
 open import Ergonomics.Extensionality
@@ -38,6 +40,7 @@ open notation
 
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Simplicial Δ¹ I
+open import Synthetic.Quasicoherence Δ¹ I I-distr
 open import Synthetic.Categories.Precategories Δ¹ I
 open import Synthetic.Categories.CovariantFamilies Δ¹ I
 open import Synthetic.Categories.ContravariantFamilies Δ¹ I
@@ -286,15 +289,13 @@ module _
 
 \p{We give a concrete proof of this fact (without the need for the yet unformalised
 assumption) for the case that #{F} is the contravariant family #{i \mapsto (i = 0)}.
-In particular we show that the map #{(\sigma(0) = 0) \to \Sigma_{i} (\sigma(i)=0)} is
-left-anodyne when #{\sigma} is monotone (which it always is under the assumption of
-quasi-coherence).}
+By the above argument it suffices to show that the arrow map from #{(\sigma(0) = 0)
+\to \Sigma_{i} (\sigma(i)=0)} to any left fibration #{G}, where the bottom map is
+given by #{\sigma\pi}, has unique extensions when #{\sigma} is monotone (which it
+always is under the assumption of quasi-coherence).}
 
 \agda{
-is-monotone : (Δ¹ → Δ¹) → Type 𝓘
-is-monotone σ = ∀ {i j} → i ≤ j → σ i ≤ σ j
-
-module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone σ) where
+module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Lattice.≤-poset I) σ) where
   transpose-●-is-left-anodyne
     : ∀ {𝓥} (P : Δ¹ → Type 𝓥) (P-cov : is-covariant P)
       → is-equiv (precomp-Π {B = Σ[ i ∶ Δ¹ ] (σ i ＝ i0)} (P ∘ σ ∘ fst) (λ p → (i0 , p)))
@@ -387,7 +388,7 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone σ) where
                      (ap-∘ (P ∘ σ) fst Σpath ∙ ap (ap (P ∘ σ)) Σ-path-ap-fst)
                      (apᶠ a Σpath)
 
-module _ (phoa : ∀ (σ : Δ¹ → Δ¹) → is-monotone σ) where
+module _ (phoa : Δ¹-endos-are-mono) where
   exp-●-is-covariant
     : ∀ {𝓤} (F : Δ¹ → Type 𝓤) (F-cov : is-covariant F)
       → is-covariant (λ i → (i ＝ i0) → F i)

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -181,6 +181,51 @@ opaque
 }
 }
 
+\subtree[tot-0556]{
+\title{Contravariance at #{i = 0}}
+\date{2026-06-22}
+\taxon{Lemma}
+
+\p{Assuming [quasicoherence](), or more specifically that every endomap on #{Δ^1} is
+monotone, the family #{- = 0} is contravariant }
+
+\proof{
+\p{We want to show the family #{{-} = 0} is orthogonal to #{\{1\} \to \Delta^1}. Since
+this family is a proposition it suffices to show that lifts merely exist. Then for
+each #{\sigma : Δ^1 \to Δ^1} such that #{\sigma(1) = 0} we need to show that
+#{\sigma(i) = 0} for each #{0}. But this follows from the fact that #{\sigma} is
+monotone.
+}
+}
+
+\agda{
+contravariant-base-change
+  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {P : B → Type 𝓦}
+    → (f : A → B)
+    → is-contravariant P → is-contravariant (P ∘ f)
+contravariant-base-change F Pc f x₀ = Pc (F ∘ f) x₀
+
+module _ (phoa : Δ¹-endos-are-mono) where
+
+  ●-unique-extensions : has-unique-extensions (point i1) (_＝ i0)
+  ●-unique-extensions (mk-afmap σ p) .centre .fst a
+    = ≤-antisym (≤-trans (phoa σ auto!) (≤←＝ (p tt))) auto!
+  ●-unique-extensions (mk-afmap σ p) .centre .snd a = prop!
+  ●-unique-extensions F .central
+    = Extᵈ-Subtype-is-prop
+        (point i1)
+        (mk-subtype {family = _＝ i0} λ _ _ _ → prop!)
+        F _
+
+  ●-is-contravariant
+    : ∀ {𝓤} {A : Type 𝓤} (f : A → Δ¹)
+      → is-contravariant ((_＝ i0) ∘ f)
+  ●-is-contravariant f
+    = contravariant-base-change {P = _＝ i0} f
+        (is-right-family↔is-contravariant (_＝ i0) .fst
+          (are-orthogonal-fam←unique-extensions ●-unique-extensions))
+}
+}
 
 \subtree[stt-00OM]{
 \title{Exponentiating covariant families}
@@ -224,12 +269,6 @@ base change by right fibrations.}
 }
 
 \agda{
-contravariant-base-change
-  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {P : B → Type 𝓦}
-    → (f : A → B)
-    → is-contravariant P → is-contravariant (P ∘ f)
-contravariant-base-change F Pc f x₀ = Pc (F ∘ f) x₀
-
 0≤i : ∀ i → Hom Δ¹ i0 i
 0≤i i .Homᵈ.hom j = j ∧ i
 0≤i i .Homᵈ.hom0 = 0-init
@@ -398,12 +437,23 @@ module _
              ∙ ap x (tr-contrav-idH~ Fσ Fσ-contrav _ 0≤i-at-0 p))
 
   cov^contrav-is-covariant
+    : is-contravariant F → is-covariant G → is-covariant G^F
+  cov^contrav-is-covariant Fc Gc = is-covariant←has-unique-extensions G^F
+    (λ {(mk-afmap σ h)
+         → is-single←equiv-to-single
+             (  fibre-precomp-Π≃Ext (G ∘ σ ∘ fst) (i0 ,_) (h tt)
+             ∙e transpose-ext-exponentials σ (h tt) e⁻¹)
+             (has-singleton-fibres←is-equiv
+               (cov^contrav-is-covariant-lemma σ Fc Gc)
+               (h tt))})
+
+  cov^contrav-is-covariant-alternative
     : (base-change-left-anodyne
           : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} (f : B → A) {C : Type 𝓦}
               (p : C → A) → is-left-anodyne p → is-right-fibration f
             → is-left-anodyne (base-change-arrow f p))
     → is-contravariant F → is-covariant G → is-covariant G^F
-  cov^contrav-is-covariant bcla Fctr Gcov
+  cov^contrav-is-covariant-alternative bcla Fctr Gcov
     = is-covariant←has-unique-extensions G^F (λ
         {(mk-afmap σ h)
             → is-single←equiv-to-single
@@ -444,125 +494,19 @@ any pair #{i \ge j}.}
 map from #{i \le j \to \Hom(i,j)}, in the formalisation, we have to use the mapping
 #{j \mapsto a((j \lor 0) \land (i \lor 0), ...)}.}
 }
+}
+
+\subtree[tot-0AGU]{
+\taxon{Example}
 
 \agda{
-module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Lattice.≤-poset I) σ) where
-  transpose-●-is-left-anodyne
-    : ∀ {𝓥} (P : Δ¹ → Type 𝓥) (P-cov : is-covariant P)
-        (f : Δ¹ → Δ¹) (f-mono : is-monotone ≤-poset ≤-poset f)
-      → is-equiv (precomp-Π {B = Σ[ i ∶ Δ¹ ] (f (σ i) ＝ i0)} (P ∘ σ ∘ fst) (λ p → (i0 , p)))
-  transpose-●-is-left-anodyne P P-cov f fm = is-equiv←qinv
-    ( (λ x (i , p) → coe-cov Pσ Pσ-cov 0-init (x (map1 i i0 0-init p)))
-    , (λ a → funext→ (λ
-      where (i , p) → coe-cov Pσ Pσ-cov (0-init {i}) (a (i0 , map1' i p))
-                    ＝⟨⟩
-                      tr-cov-hom Pσ-cov (Δ¹-hom←≤ 0-init) (a (i0 , map1' i p))
-                    ＝⟨ tr-cov-hom-unique Pσ Pσ-cov
-                         (Δ¹-hom←≤ 0-init) (a (i0 , map1' i p))
-                         (a (i , p))
-                         (connection i p a) ⟩
-                      a (i , p) ∎))
-    , (λ a → funext→ (λ p → coe-cov-id
-                              (P ∘ σ)
-                              (covariant-base-change {P = P} σ P-cov)
-                              0-init (a (map1' i0 p))
-                          ∙ ap a (map1-at-0 0-init p)))) where
-      Pσ = P ∘ σ
-      Pσ-cov = covariant-base-change {P = P} σ P-cov
-
-      opaque
-        map1 : ∀ i j → j ≤ i → f (σ i) ＝ i0 → f (σ j) ＝ i0
-        map1 i j l p = ≤-antisym
-          (≤-trans
-            (∘-is-monotone ≤-poset ≤-poset ≤-poset f σ fm σ-mono l)
-            (≤←＝ p))
-          0-init
-
-        map1-at-0 : ∀ p → map1 i0 i0 p ~ id
-        map1-at-0 _ p = carrier-is-set _ _ _ p
-
-      map1' = λ i → map1 i i0 0-init
-
-      opaque
-        connection
-          : ∀ (i : Δ¹) (p : f (σ i) ＝ i0)
-              (a : ∀ (x : Σ[ i ∶ Δ¹ ] (f (σ i) ＝ i0)) → P (σ (fst x)))
-            → Hom-over {B = P ∘ σ}
-                (Δ¹-hom←≤ 0-init)
-                (a (i0 , map1 i i0 0-init p))
-                (a (i , p))
-        connection i p a .Homᵈ.hom j
-          = a ( (j ∨ i0) ∧ (i0 ∨ i)
-              , map1 i ((j ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
-        connection i p a .Homᵈ.hom0 = sym lemma1 where
-          -- it is important to chose this path in particular
-          path : i0 ＝ (i0 ∨ i0) ∧ (i0 ∨ i)
-          path = sym
-            (ap₂ _∧_ (∨-comm ∙ 0-bottom)
-                     ( ap (_∨ i)
-                          (sym (ap (_∧_ i0) (sym (∨-comm ∙ 0-bottom))
-                               ∙ ∧-∨-abs ∙ refl))
-                     ∙ (ap (_∨ i) ∧-comm ∙ ∨-comm ∙ ∨-∧-abs)
-                     ∙ refl)
-            ∙ ap (_∧_ i0) (sym (∨-comm ∙ 0-bottom)) ∙ ∧-∨-abs ∙ refl)
-
-          lemma3 : Id (Σ[ i ∶ Δ¹ ] (f (σ i) ＝ i0))
-                      (i0 , map1' i p)
-                      ( (i0 ∨ i0) ∧ (i0 ∨ i)
-                      , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i))
-                               (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
-          lemma3 = Σ-path→ (path , carrier-is-set _ _ _ _)
-
-          lemma2 : a (i0 , map1' i p)
-                 ＝[ ap (P ∘ σ ∘ fst) lemma3 ]
-                   a ( (i0 ∨ i0) ∧ (i0 ∨ i)
-                     , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i))
-                              (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
-          lemma2 = apᶠ a lemma3
-
-          lemma1 : a (i0 , map1' i p)
-                 ＝[ ap (P ∘ σ) path ]
-                   a ( (i0 ∨ i0) ∧ (i0 ∨ i)
-                     , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i))
-                              (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
-          lemma1 = adjust-idᵈ
-                     {P = ap (P ∘ σ ∘ fst) lemma3} {Q = ap (P ∘ σ) path}
-                     (ap-∘ (P ∘ σ) fst lemma3 ∙ ap (ap (P ∘ σ)) Σ-path-ap-fst)
-                     lemma2
-
-        connection i p a .Homᵈ.hom1 = sym lemma1 where
-          path : i ＝ (i1 ∨ i0) ∧ (i0 ∨ i)
-          path = sym (ap₂ _∧_ (∨-comm ∙ 1-coinit) (≤-max 0-init) ∙ ∧-comm ∙ 1-top)
-
-          Σpath : Id (Σ[ i ∶ Δ¹ ] (f (σ i) ＝ i0))
-                     (i , p)
-                     ( (i1 ∨ i0) ∧ (i0 ∨ i)
-                     , map1 i ((i1 ∨ i0) ∧ (i0 ∨ i))
-                              (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
-          Σpath = Σ-path→ (path , (carrier-is-set _ _ _ _))
-
-          lemma1
-            : a (i , p)
-            ＝[ ap (P ∘ σ) path ]
-              a ( (i1 ∨ i0) ∧ (i0 ∨ i)
-                , map1 i ((i1 ∨ i0) ∧ (i0 ∨ i))
-                         (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
-          lemma1 = adjust-idᵈ {P = ap (P ∘ σ ∘ fst) Σpath} {Q = ap (P ∘ σ) path}
-                     (ap-∘ (P ∘ σ) fst Σpath ∙ ap (ap (P ∘ σ)) Σ-path-ap-fst)
-                     (apᶠ a Σpath)
-
 module _ (phoa : Δ¹-endos-are-mono) where
+
   exp-●-is-covariant
-    : ∀ {𝓤} (F : Δ¹ → Type 𝓤) (F-cov : is-covariant F)
-      → (f : Δ¹ → Δ¹)
+    : ∀ {𝓤 𝓥} {A : Type 𝓥} (F : A → Type 𝓤) (F-cov : is-covariant F)
+      → (f : A → Δ¹)
       → is-covariant (λ i → (f i ＝ i0) → F i)
   exp-●-is-covariant F Fc f
-    = is-covariant←has-unique-extensions (λ i → (f i ＝ i0) → F i)
-        λ AF@(mk-afmap σ p)
-          → is-single←equiv-to-single
-              (  fibre-precomp-Π≃Ext (F ∘ σ ∘ fst) (λ z → i0 , z) (p tt)
-              ∙e transpose-ext-exponentials ((_＝ i0) ∘ f) F σ (p tt)  e⁻¹)
-              (has-singleton-fibres←is-equiv
-                 (transpose-●-is-left-anodyne σ (phoa σ) F Fc f (phoa f)) (p tt) )
+    = cov^contrav-is-covariant ((_＝ i0) ∘ f) F (●-is-contravariant phoa f) Fc
 }
 }

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -182,18 +182,18 @@ opaque
 }
 
 \subtree[tot-0556]{
-\title{Contravariance at #{i = 0}}
+\title{Contravariance of the family #{i \mapsto (i = 0)}}
 \date{2026-06-22}
 \taxon{Lemma}
 
 \p{Assuming [quasicoherence](), or more specifically that every endomap on #{Δ^1} is
-monotone, the family #{- = 0} is contravariant }
+monotone, the family #{i \mapsto (i = 0)} is contravariant.}
 
 \proof{
 \p{We want to show the family #{{-} = 0} is orthogonal to #{\{1\} \to \Delta^1}. Since
-this family is a proposition it suffices to show that lifts merely exist. Then for
+this is a family of propositions it suffices to show that lifts merely exist. Then for
 each #{\sigma : Δ^1 \to Δ^1} such that #{\sigma(1) = 0} we need to show that
-#{\sigma(i) = 0} for each #{0}. But this follows from the fact that #{\sigma} is
+#{\sigma(i) = 0} for each #{i}, but this follows from the fact that #{\sigma} is
 monotone.
 }
 }

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -327,19 +327,18 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Latt
     ( (λ x (i , p) → coe-cov Pσ Pσ-cov 0-init (x (map1 i i0 0-init p)))
     , (λ a → funext→ (λ
       where (i , p) → coe-cov Pσ Pσ-cov (0-init {i}) (a (i0 , map1' i p))
-                  ＝⟨⟩
-                     tr-cov-hom Pσ-cov (Δ¹-hom←≤ 0-init) (a (i0 , map1' i p))
-                  ＝⟨ tr-cov-hom-unique Pσ Pσ-cov
-                       (Δ¹-hom←≤ 0-init) (a (i0 , map1' i p))
-                       (a (i , p))
-                       (connection i p a) ⟩
-                     a (i , p) ∎))
-    , (λ a → funext→ (λ p →
-                          coe-cov-id
-                            (P ∘ σ)
-                            (covariant-base-change {P = P} σ P-cov)
-                            0-init (a (map1' i0 p))
-                         ∙ ap a (map1-at-0 0-init p)))) where
+                    ＝⟨⟩
+                      tr-cov-hom Pσ-cov (Δ¹-hom←≤ 0-init) (a (i0 , map1' i p))
+                    ＝⟨ tr-cov-hom-unique Pσ Pσ-cov
+                         (Δ¹-hom←≤ 0-init) (a (i0 , map1' i p))
+                         (a (i , p))
+                         (connection i p a) ⟩
+                      a (i , p) ∎))
+    , (λ a → funext→ (λ p → coe-cov-id
+                              (P ∘ σ)
+                              (covariant-base-change {P = P} σ P-cov)
+                              0-init (a (map1' i0 p))
+                          ∙ ap a (map1-at-0 0-init p)))) where
       Pσ = P ∘ σ
       Pσ-cov = covariant-base-change {P = P} σ P-cov
 
@@ -433,9 +432,9 @@ module _ (phoa : Δ¹-endos-are-mono) where
     = is-covariant←has-unique-extensions (λ i → (f i ＝ i0) → F i)
         λ AF@(mk-afmap σ p)
           → is-single←equiv-to-single
-              ( fibre-precomp-Π≃Ext (F ∘ σ ∘ fst) (λ z → i0 , z) (p tt)
+              (  fibre-precomp-Π≃Ext (F ∘ σ ∘ fst) (λ z → i0 , z) (p tt)
               ∙e transpose-ext-exponentials ((_＝ i0) ∘ f) F σ (p tt)  e⁻¹)
               (has-singleton-fibres←is-equiv
-                   (transpose-●-is-left-anodyne σ (phoa σ) F Fc f (phoa f)) (p tt) )
+                 (transpose-●-is-left-anodyne σ (phoa σ) F Fc f (phoa f)) (p tt) )
 }
 }

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -491,7 +491,7 @@ module _
 \taxon{Example}
 
 \p{For any #{f : A \to Δ^1} and covariant family #{F}, the type family
-#{(a \mapsto (f(a) = 0) \to G(a))} is covariant.}
+#{(a \mapsto (f(a) = 0) \to F(a))} is covariant.}
 
 \agda{
 module _ (phoa : Δ¹-endos-are-mono) where

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -288,23 +288,21 @@ module _
 }
 
 \p{We give a concrete proof of this fact (without the need for the yet unformalised
-assumption) for the case that #{F} is the contravariant family #{i \mapsto (i = 0)}.
-By the above argument it suffices to show that the arrow map from #{(\sigma(0) = 0)
-\to \Sigma_{i} (\sigma(i)=0)} to any left fibration #{G}, where the bottom map is
-given by #{\sigma\pi}, has unique extensions when #{\sigma} is monotone (which it
+assumption) for the case that #{F} is the contravariant family #{i \mapsto (f(i) = 0)}
+for any #{f : \Delta^1 \to \Delta^1}.
+By the above argument it suffices to show that the arrow map from #{(f(\sigma(0)) = 0)
+\to \Sigma_{i} (f(\sigma(i))=0)} to any left fibration #{G}, where the bottom map is
+given by #{\sigma\pi}, has unique extensions when #{f \sigma} is monotone (which it
 always is under the assumption of quasi-coherence).}
 
 \agda{
 module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Lattice.≤-poset I) σ) where
   transpose-●-is-left-anodyne
     : ∀ {𝓥} (P : Δ¹ → Type 𝓥) (P-cov : is-covariant P)
-      → is-equiv (precomp-Π {B = Σ[ i ∶ Δ¹ ] (σ i ＝ i0)} (P ∘ σ ∘ fst) (λ p → (i0 , p)))
-  transpose-●-is-left-anodyne  P P-cov = is-equiv←qinv
-    ( (λ x (i , p) → coe-cov
-                       (P ∘ σ)
-                       (covariant-base-change {P = P} σ P-cov)
-                       0-init
-                       (x (map1' i p)))
+        (f : Δ¹ → Δ¹) (f-mono : is-monotone ≤-poset ≤-poset f)
+      → is-equiv (precomp-Π {B = Σ[ i ∶ Δ¹ ] (f (σ i) ＝ i0)} (P ∘ σ ∘ fst) (λ p → (i0 , p)))
+  transpose-●-is-left-anodyne P P-cov f fm = is-equiv←qinv
+    ( (λ x (i , p) → coe-cov Pσ Pσ-cov 0-init (x (map1 i i0 0-init p)))
     , (λ a → funext→ (λ
       where (i , p)→ coe-cov Pσ Pσ-cov (0-init {i}) (a (i0 , map1' i p))
                   ＝⟨⟩
@@ -322,8 +320,9 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Latt
       Pσ-cov = covariant-base-change {P = P} σ P-cov
 
       opaque
-        map1 : ∀ i j → j ≤ i → σ i ＝ i0 → σ j ＝ i0
-        map1 i j l p = ≤-antisym (≤-trans (σ-mono l) (≤←＝ p)) 0-init
+        map1 : ∀ i j → j ≤ i → f (σ i) ＝ i0 → f (σ j) ＝ i0
+        map1 i j l p = ≤-antisym
+          (≤-trans (∘-is-monotone ≤-poset ≤-poset ≤-poset f σ fm σ-mono l) (≤←＝ p)) 0-init
 
         map1-at-0 : ∀ p → map1 i0 i0 p ~ id
         map1-at-0 _ p = carrier-is-set _ _ _ p
@@ -332,7 +331,7 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Latt
 
       opaque
         connection
-          : ∀ i (p : σ i ＝ i0) (a : (∀ (x : Σ[ i ∶ Δ¹ ] (σ i ＝ i0)) → P (σ (fst x))))
+          : ∀ i (p : f (σ i) ＝ i0) (a : (∀ (x : Σ[ i ∶ Δ¹ ] (f (σ i) ＝ i0)) → P (σ (fst x))))
             → Hom-over {B = P ∘ σ} (Δ¹-hom←≤ 0-init) (a (i0 , map1 i i0 0-init p)) (a (i , p))
         connection i p a .Homᵈ.hom j
           = a ( (j ∨ i0) ∧ (i0 ∨ i)
@@ -348,7 +347,7 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Latt
                      ∙ refl)
             ∙ ap (_∧_ i0) (sym (∨-comm ∙ 0-bottom)) ∙ ∧-∨-abs ∙ refl)
 
-          lemma3 : Id (Σ[ i ∶ Δ¹ ] (σ i ＝ i0))
+          lemma3 : Id (Σ[ i ∶ Δ¹ ] (f (σ i) ＝ i0))
                       (i0 , map1' i p)
                       ( (i0 ∨ i0) ∧ (i0 ∨ i)
                       , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
@@ -373,7 +372,7 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Latt
           path : i ＝ (i1 ∨ i0) ∧ (i0 ∨ i)
           path = sym (ap₂ _∧_ (∨-comm ∙ 1-coinit) (≤-max 0-init) ∙ ∧-comm ∙ 1-top)
 
-          Σpath : Id (Σ[ i ∶ Δ¹ ] (σ i ＝ i0))
+          Σpath : Id (Σ[ i ∶ Δ¹ ] (f (σ i) ＝ i0))
                      (i , p)
                      ( (i1 ∨ i0) ∧ (i0 ∨ i)
                      , map1 i ((i1 ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
@@ -391,14 +390,15 @@ module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone (Lattice.≤-poset I) (Latt
 module _ (phoa : Δ¹-endos-are-mono) where
   exp-●-is-covariant
     : ∀ {𝓤} (F : Δ¹ → Type 𝓤) (F-cov : is-covariant F)
-      → is-covariant (λ i → (i ＝ i0) → F i)
-  exp-●-is-covariant F Fc
-    = is-covariant←has-unique-extensions (λ i → (i ＝ i0) → F i)
+      → (f : Δ¹ → Δ¹)
+      → is-covariant (λ i → (f i ＝ i0) → F i)
+  exp-●-is-covariant F Fc f
+    = is-covariant←has-unique-extensions (λ i → (f i ＝ i0) → F i)
         λ AF@(mk-afmap σ p)
           → is-single←equiv-to-single
-              (fibre-precomp-Π≃Ext (F ∘ σ ∘ fst) (λ z → i0 , z) (p tt)
-              ∙e transpose-ext-exponentials (_＝ i0) F σ (p tt) e⁻¹)
-              (has-singleton-fibres←is-equiv
-                (transpose-●-is-left-anodyne σ (phoa σ) F Fc) (p tt))
+              ( fibre-precomp-Π≃Ext (F ∘ σ ∘ fst) (λ z → i0 , z) (p tt)
+              ∙e transpose-ext-exponentials ((_＝ i0) ∘ f) F σ (p tt)  e⁻¹)
+              ( has-singleton-fibres←is-equiv
+                   (transpose-●-is-left-anodyne σ (phoa σ) F Fc f (phoa f)) (p tt) )
 }
 }

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -223,17 +223,13 @@ module _ (Δ¹-mono : Δ¹-endos-are-mono) where
 }
 }
 
-\subtree[stt-00OM]{
-\title{Exponentiating covariant families}
+\subtree[tot-CEIY]{
 \taxon{Lemma}
 
-\p{We show that given a [contravariant type family](stt-00OD) #{F},
-and a [covariant type family](stt-00AY) #{G}, the type family given by
-#{x \mapsto F(x) \to G(x)} is also covariant.}
-
-\proof{
-\p{First notice that solutions to the left lifting problem are in bijection with
-solutions to the right lifting problem.}
+\p{Given type families #{F} and #{G}, solutions of the left lifting problem are
+equivalent to solutions of the right lifting problem depicted below. This can be seen
+as transporting a lifting problem across the adjunction between base change and
+exponentiation.}
 
 \quiver{
 \begin{tikzcd}[cramped]
@@ -250,6 +246,94 @@ solutions to the right lifting problem.}
 	\arrow["{f\pi_1}"', from=3-5, to=3-7]
 \end{tikzcd}
 }
+
+\agda{
+module _
+  {𝓤 𝓥 𝓦}
+  {A : Type 𝓤} {B : Type 𝓥}
+  (p : A → B)
+  (F : B → Type 𝓦)
+  where
+
+  base-change-fst
+    : Σ A (F ∘ p) → Σ B F
+  base-change-fst = total-map-fst p
+
+  base-change-fst-is-base-change
+    : Arrow-equiv
+        base-change-fst
+        (base-change-arrow (fst: F) p)
+  base-change-fst-is-base-change .fst .Arrow-Π.top a
+    = (total-map-fst p a , a .fst , refl)
+  base-change-fst-is-base-change .fst .Arrow-Π.bot = id
+  base-change-fst-is-base-change .fst .Arrow-Π.comm = ~refl
+  base-change-fst-is-base-change .snd .fst
+    = is-equiv←qinv
+        ( (λ {((.(p a) , f) , a , refl) → (a , f)})
+        , ~refl
+        , λ {(_ , _ , refl) → refl})
+  base-change-fst-is-base-change .snd .snd = id-is-equiv
+
+module _
+  {𝓤 𝓥 𝓦 𝓜 𝓝} {A : Type 𝓤} {B : Type 𝓥} (p : A → B)
+  {C : Type 𝓝} (F : C → Type 𝓦) (G : C → Type 𝓜)
+  (let G^F b = F b → G b)
+  where
+
+  module _ (σ : B → C) where
+    transpose-ext-exponentials'
+      : ∀ (h : (a : A) → F (σ (p a)) → G (σ (p a)))
+        → Extᵈ p (G^F ∘ σ) h
+        ≃ Extᵈ (base-change-fst p (F ∘ σ)) (G ∘ σ ∘ fst) (uncurry h)
+    transpose-ext-exponentials' h
+      = Σ-≃
+          uncurry≃
+          (λ h
+           →  postcomp-Π-≃ (λ c → funext≃)
+           ∙e uncurry≃)
+
+
+module _
+  {𝓤 𝓥 𝓦} {B : Type 𝓤}
+  (F : B → Type 𝓥) (G : B → Type 𝓦)
+  (let G^F b = F b → G b)
+  (let
+    transposed-left-map : ∀ σ → F (σ i0) → Σ Δ¹ (F ∘ σ)
+    transposed-left-map σ x = (i0 , x))
+  where
+
+  module _ (σ : Δ¹ → B) where
+    transpose-ext-exponentials-at-point-i0
+      : ∀ (h : F (σ i0) → G (σ i0))
+        → Extᵈ (point i0) (G^F ∘ σ) (point h)
+        ≃ Extᵈ (transposed-left-map σ) (G ∘ σ ∘ fst) h
+    transpose-ext-exponentials-at-point-i0 h = Σ-≃ uncurry≃ λ f → unit-UP≃ ∙e funext≃
+
+    transposed-left-map-is-pb
+      : Arrow-equiv
+          (transposed-left-map σ)
+          (base-change-arrow (fst: (F ∘ σ)) (point i0))
+    transposed-left-map-is-pb .fst .Arrow-Π.top a = ((_ , a) , tt , refl)
+    transposed-left-map-is-pb .fst .Arrow-Π.bot = id
+    transposed-left-map-is-pb .fst .Arrow-Π.comm = ~refl
+    transposed-left-map-is-pb .snd .fst
+      = is-equiv←qinv
+          ( (λ {((_ , a) , _ , refl) → a})
+          , ~refl
+          , λ {(_ , _ , refl) → refl})
+    transposed-left-map-is-pb .snd .snd = id-is-equiv
+}
+}
+
+\subtree[stt-00OM]{
+\title{Exponentiating covariant families}
+\taxon{Lemma}
+
+\p{Given a [contravariant type family](stt-00OD) #{F},
+and a [covariant type family](stt-00AY) #{G}, the type family given by
+#{x \mapsto F(x) \to G(x)} is also covariant.}
+
+\proof{
 
 \p{From here we present a pair of proof strategies, the first is
 conceptually simpler, but relies on a yet to be formalised lemma and the second
@@ -269,28 +353,230 @@ lifting problem exist uniquely.}
 \p{We have not yet formalised the fact that left anodyne maps are stable under
 base change by right fibrations.}
 }
+
+\agda{
+module FromBaseChangeLeftAnodyne
+  {𝓤 𝓥 𝓦} {B : Type 𝓤}
+  (F : B → Type 𝓥) (G : B → Type 𝓦)
+  (let G^F b = F b → G b)
+  (let
+    transposed-left-map : ∀ σ → F (σ i0) → Σ Δ¹ (F ∘ σ)
+    transposed-left-map σ x = (i0 , x))
+  (base-change-left-anodyne
+    : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
+        (f : B → A) (p : C → A)
+      → is-left-anodyne p
+      → is-right-fibration f
+      → is-left-anodyne (base-change-arrow f p))
+  where
+
+  transposed-left-map-is-left-anodyne
+    : (σ : Δ¹ → B)
+    → is-contravariant F → is-left-anodyne (transposed-left-map σ)
+  transposed-left-map-is-left-anodyne σ rfib
+    = is-anodyne←equiv
+        (base-change-arrow (fst: (F ∘ σ)) (point i0))
+        (transposed-left-map σ)
+        (inv-Arrow-equiv (transposed-left-map-is-pb F G σ))
+        (point i0)
+        (base-change-left-anodyne
+          (fst: (F ∘ σ)) (point i0) (is-self-anodyne (point i0))
+          (is-right-fibration←is-contravariant (F ∘ σ) (rfib ∘ (σ ∘_))))
+
+  cov^contrav-is-covariant-alternative
+    : is-contravariant F → is-covariant G → is-covariant G^F
+  cov^contrav-is-covariant-alternative Fctr Gcov
+    = is-covariant←has-unique-extensions G^F
+        (λ {(mk-afmap σ h)
+         → is-single←equiv-to-single
+             (transpose-ext-exponentials-at-point-i0 F G σ (h tt) e⁻¹)
+             (unique-extensions←are-orthogonal-fam {P = G}
+               (are-orthogonal-fam←are-orthogonal-fst
+                 (transposed-left-map-is-left-anodyne σ Fctr (fst: G)
+                   (is-covariant↔is-left-fibration G .fst Gcov)))
+               (mk-afmap (σ ∘ fst) (h tt)))})
+}
 }
 
 \subtree[tot-0AAI]{
 \p{Alternatively we can show directly that lifts exist uniquely for lifting problems
 in the shape of the rightmost diagram. In particular we show that for any covariant
-type family #{G}, the natural map
-##{(\Pi_{i} F\sigma(i) \to G\sigma(i)) \to (F\sigma(0) \to G(\sigma(0)))},
-whose fibres are the desired extensions, is an equivalence. For the inverse map, suppose
-that we have a map #{x : F(\sigma(0)) \to G(\sigma(0))}, then to get a map
-#{F\sigma(i) \to G\sigma(i)}, we take the composite
-##{F\sigma(i) \to F\sigma(0) \to G\sigma(0) \to G\sigma(i)}, where the first map
-is induced by contravariant transport, and the last by covariant transport. When
-#{i = 0}, this map is clearly equal to the map we started with, so we have defined
-a left inverse, and all that remains is to show it is a right inverse. To do so, let
-#{x : \Pi_{i} F\sigma(i) \to G\sigma(i)} so that we need to show #{G_* x(0) F^* \sim x}.
+type family #{G}, the natural map ##{(\Pi_{i}\ (F\sigma(i) \to G\sigma(i))) \to
+(F\sigma(0) \to G(\sigma(0)))} (whose fibres are the lifting solutions) is an
+equivalence. For the inverse map, suppose that we have a map #{x : F(\sigma(0)) \to
+G(\sigma(0))}, then to obtain a map #{F\sigma(i) \to G\sigma(i)}, we take the composite
+##{F\sigma(i) \to F\sigma(0) \xrightarrow{x} G\sigma(0) \to G\sigma(i)} where the first map is
+induced by contravariant transport, and the last by covariant transport. When #{i =
+0}, this map is clearly equal to #{x} itself, so we have defined a left
+inverse, and all that remains is to show it is a right inverse. To do so, let #{x :
+\Pi_{i}\ (F\sigma(i) \to G\sigma(i))} so that we need to show #{G_* x(0) F^* \sim x}.
 We may use the uniqueness of covariant transport and give a dependent morphism
-#{\Hom_{Gσ}^{0 \le i}(x(0, F^*(p)), x(i,p))} for all #{i : \Delta^1} and
-#{p : F\sigma(i)}. The morphism can be given by #{j \mapsto x(i \land j, F^*(p))}, and
-this can be shown to have the correct boundary trivially at #{0}, and at #{1} by again
+#{\Hom_{Gσ}^{0 \le i}(x(0, F^*(p)), x(i,p))} for all #{i : \Delta^1} and #{p :
+F\sigma(i)}. The morphism can be given by #{j \mapsto x(i \land j, F^*(p))}, and this
+can be shown to have the correct boundary trivially at #{0}, and at #{1} by again
 applying uniqueness of transport with a similarly constructed dependent morphism.
 }
+
+
+\agda{
+module _
+  {𝓤 𝓥 𝓦} {B : Type 𝓤}
+  (F : B → Type 𝓥) (G : B → Type 𝓦)
+  (let G^F b = F b → G b)
+  (let
+    transposed-left-map : ∀ σ → F (σ i0) → Σ Δ¹ (F ∘ σ)
+    transposed-left-map σ x = (i0 , x))
+  (σ : Δ¹ → B)
+  (Fc : is-contravariant F)
+  (Gc : is-covariant G)
+  (let Gσ = G ∘ σ)
+  (let Gσ-cov = covariant-base-change {P = G} σ Gc)
+  (let Fσ = F ∘ σ)
+  (let Fσ-contrav = contravariant-base-change {P = F} σ Fc)
+  where
+
+  connection
+    : ∀ (i : Δ¹) (p : F (σ i))
+        (a : ∀ (x : Σ[ i ∶ Δ¹ ] F (σ i)) → G (σ (fst x)))
+      → Hom-over {B = Gσ}
+          (0≤i i)
+          (a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p))
+          (a (i , p))
+  connection i p a .Homᵈ.hom j
+    = a ( j ∧ i
+        , tr-contrav-hom
+            Fσ-contrav
+            (Δ¹-hom←≤ {i = j ∧ i} {j = i} (∧-≤-elimr ≤-refl))
+            p)
+
 }
+
+\p{The calculation of the endpoints of this map is somewhat tedious and hence hidden
+in a \em{closed} tree.}
+
+\closedScope{
+\subtree{
+
+\title{Showing the morphism has the correct endpoints}
+
+\agda{
+  connection i p a .Homᵈ.hom0 = sym lemma3 where
+
+    path : i0 ＝ i0 ∧ i
+    path = sym 0-init
+
+    lemma1
+      : Id (Σ Δ¹ Fσ)
+         (i0 , tr-contrav-hom {P = Fσ} Fσ-contrav (0≤i i) p)
+         ( i0 ∧ i
+         , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+    lemma1
+      = Σ-path→
+        ( path
+        , tr∘tr-contrav Fσ Fσ-contrav path (0≤i i) p
+        ∙ ap (λ f → tr-contrav-hom Fσ-contrav f p)
+             (Hom-ext→
+               ( (λ j
+                  → ap₂
+                      (_∧_)
+                      (≤-antisym
+                        (∨-≤-introl auto!)
+                        (∨-UP (auto! , (∧-≤-eliml auto!))))
+                      (sym (∧-∨-abs')))
+               , carrier-is-set _ _ _ _
+               , carrier-is-set _ _ _ _)))
+
+    lemma2
+      : a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p)
+      ＝[ ap (Gσ ∘ fst) lemma1 ]
+        a (i0 ∧ i
+          , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+    lemma2 = apᶠ a lemma1
+
+    lemma3
+      : a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p)
+      ＝[ ap Gσ (sym 0-init) ]
+        a (i0 ∧ i
+          , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+    lemma3 = adjust-Idᵈ (ap-∘ Gσ fst lemma1 ∙ ap (ap Gσ) Σ-path-ap-fst) lemma2
+
+  connection i p a .Homᵈ.hom1 = sym lemma3 where
+
+    lemma1
+      : Id (Σ Δ¹ Fσ)
+         (i , p)
+         ( i1 ∧ i
+         , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+    lemma1 = Σ-path→
+      ( sym (∧-comm ∙ 1-top)
+      , Idᶠ-inr' {B = Fσ} {p = ∧-comm ∙ 1-top}
+          {x = p}
+          {y = tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p}
+          (sym ( tr∘tr-contrav Fσ Fσ-contrav (∧-comm ∙ 1-top) _ p
+               ∙ tr-contrav-hom-unique
+                   Fσ Fσ-contrav
+                   (adjust-hom (∧-comm ∙ 1-top) refl (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))
+                   p p
+                   (tr
+                     (λ f → Hom-over f p p)
+                     {a = idH i}
+                     {b = (adjust-hom
+                            (∧-comm ∙ 1-top)
+                            refl
+                            (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))}
+                     (Hom-ext→
+                       ((λ j
+                         → ≤-antisym
+                             (∧-UP
+                               ( ∨-≤-intror (∧-UP (1-top , ∧-idem))
+                               , ∨-≤-intror ≤-refl))
+                             (∧-≤-elimr
+                               (∨-UP
+                                 ( (∧-≤-elimr ≤-refl)
+                                 , ≤-refl))))
+                       , carrier-is-set _ _ _ _
+                       , carrier-is-set _ _ _ _))
+                     (idH p)))))
+
+    lemma2
+      : a (i , p)
+      ＝[ ap (Gσ ∘ fst) lemma1 ]
+        a ( i1 ∧ i
+          , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+    lemma2 = apᶠ a lemma1
+
+    lemma3
+      : a (i , p)
+      ＝[ ap Gσ (sym (∧-comm ∙ 1-top)) ]
+        a ( i1 ∧ i
+          , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+    lemma3 = adjust-Idᵈ (ap-∘ Gσ fst lemma1 ∙ ap (ap Gσ) Σ-path-ap-fst) lemma2
+}
+}
+}
+
+\p{With this dependent morphism constructed, giving the rest of the quasi-inverse
+follows quite directly:}
+
+\agda{
+  cov^contrav-is-covariant-lemma
+    : is-equiv (precomp-Π {B = Σ[ i ∶ Δ¹ ] F (σ i)} (G ∘ σ ∘ fst) (i0 ,_))
+  cov^contrav-is-covariant-lemma = is-equiv←qinv qinv where
+
+    qinv : quasi-inv (precomp-Π (G ∘ σ ∘ fst) (λ p → i0 , p))
+    qinv .fst x (i , p)
+      = tr-cov-hom Gσ-cov (0≤i i)
+          (x (tr-contrav-hom Fσ-contrav (0≤i i) p))
+    qinv .snd .fst x = funext→
+      (λ (i , p)
+       → tr-cov-hom-unique Gσ Gσ-cov (0≤i i)
+           (x (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p))
+           (x (i , p))
+           (connection i p x))
+    qinv .snd .snd x = funext→
+      (λ p
+       → tr-cov-idH~ Gσ Gσ-cov _ 0≤i-at-0 (x (tr-contrav-hom Fσ-contrav (0≤i i0) p))
+       ∙ ap x (tr-contrav-idH~ Fσ Fσ-contrav _ 0≤i-at-0 p))
 }
 
 \agda{
@@ -303,179 +589,6 @@ module _
     transposed-left-map σ x = (i0 , x))
   where
 
-  module _ (σ : Δ¹ → B) where
-    transpose-ext-exponentials
-      : ∀ (h : F (σ i0) → G (σ i0))
-        → Extᵈ (point i0) (G^F ∘ σ) (point h)
-        ≃ Extᵈ (transposed-left-map σ) (G ∘ σ ∘ fst) h
-    transpose-ext-exponentials h = Σ-≃ uncurry≃ λ f → unit-UP≃ ∙e funext≃
-
-    transposed-left-map-is-pb
-      : Arrow-equiv
-          (transposed-left-map σ)
-          (base-change-arrow (fst: (F ∘ σ)) (point i0))
-    transposed-left-map-is-pb .fst .Arrow-Π.top a = ((_ , a) , tt , refl)
-    transposed-left-map-is-pb .fst .Arrow-Π.bot = id
-    transposed-left-map-is-pb .fst .Arrow-Π.comm = ~refl
-    transposed-left-map-is-pb .snd .fst
-      = is-equiv←qinv
-          ( (λ {((_ , a) , _ , refl) → a})
-          , ~refl
-          , λ {(_ , _ , refl) → refl})
-    transposed-left-map-is-pb .snd .snd = id-is-equiv
-
-    transposed-left-map-is-left-anodyne
-      : (base-change-left-anodyne
-          : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
-              (f : B → A) (p : C → A)
-            → is-left-anodyne p
-            → is-right-fibration f
-            → is-left-anodyne (base-change-arrow f p))
-      → is-contravariant F → is-left-anodyne (transposed-left-map σ)
-    transposed-left-map-is-left-anodyne base-change-left-anodyne rfib
-      = is-anodyne←equiv
-          (base-change-arrow (fst: (F ∘ σ)) (point i0))
-          (transposed-left-map σ)
-          (inv-Arrow-equiv transposed-left-map-is-pb)
-          (point i0)
-          (base-change-left-anodyne
-            (fst: (F ∘ σ)) (point i0) (is-self-anodyne (point i0))
-            (is-right-fibration←is-contravariant (F ∘ σ) (rfib ∘ (σ ∘_))))
-}
-
-\agda{
-    cov^contrav-is-covariant-lemma
-      : ∀ (F-contrav : is-contravariant F) (G-cov : is-covariant G)
-        → is-equiv (precomp-Π {B = Σ[ i ∶ Δ¹ ] F (σ i)} (G ∘ σ ∘ fst) (i0 ,_))
-    cov^contrav-is-covariant-lemma Fc Gc = is-equiv←qinv qinv where
-      Gσ = G ∘ σ
-      Gσ-cov = covariant-base-change {P = G} σ Gc
-      Fσ = F ∘ σ
-      Fσ-contrav = contravariant-base-change {P = F} σ Fc
-
-      connection
-        : ∀ (i : Δ¹) (p : F (σ i))
-            (a : ∀ (x : Σ[ i ∶ Δ¹ ] F (σ i)) → G (σ (fst x)))
-          → Hom-over {B = Gσ}
-              (0≤i i)
-              (a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p))
-              (a (i , p))
-      connection i p a .Homᵈ.hom j
-        = a ( j ∧ i
-            , tr-contrav-hom
-                Fσ-contrav
-                (Δ¹-hom←≤ {i = j ∧ i} {j = i} (∧-≤-elimr ≤-refl))
-                p)
-
-      connection i p a .Homᵈ.hom0 = sym lemma1 where
-
-        path : i0 ＝ i0 ∧ i
-        path = sym 0-init
-
-        lemma3
-          : Id (Σ Δ¹ Fσ)
-             (i0 , tr-contrav-hom {P = Fσ} Fσ-contrav (0≤i i) p)
-             ( i0 ∧ i
-             , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
-        lemma3
-          = Σ-path→
-            ( path
-            , tr∘tr-contrav Fσ Fσ-contrav path (0≤i i) p
-            ∙ ap (λ f → tr-contrav-hom Fσ-contrav f p)
-                 (Hom-ext→
-                   ( (λ j
-                      → ap₂
-                          (_∧_)
-                          (≤-antisym
-                            (∨-≤-introl auto!)
-                            (∨-UP (auto! , (∧-≤-eliml auto!))))
-                          (sym (∧-∨-abs')))
-                   , carrier-is-set _ _ _ _
-                   , carrier-is-set _ _ _ _)))
-
-        lemma2
-          : a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p)
-          ＝[ ap (Gσ ∘ fst) lemma3 ]
-            a (i0 ∧ i
-              , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
-        lemma2 = apᶠ a lemma3
-
-        lemma1
-          : a (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p)
-          ＝[ ap Gσ (sym 0-init) ]
-            a (i0 ∧ i
-              , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
-        lemma1 = adjust-Idᵈ (ap-∘ Gσ fst lemma3 ∙ ap (ap Gσ) Σ-path-ap-fst) lemma2
-
-      connection i p a .Homᵈ.hom1 = sym lemma1 where
-
-        lemma3
-          : Id (Σ Δ¹ Fσ)
-             (i , p)
-             ( i1 ∧ i
-             , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
-        lemma3 = Σ-path→
-          ( sym (∧-comm ∙ 1-top)
-          , Idᶠ-inr' {B = Fσ} {p = ∧-comm ∙ 1-top}
-              {x = p}
-              {y = tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p}
-              (sym ( tr∘tr-contrav Fσ Fσ-contrav (∧-comm ∙ 1-top) _ p
-                   ∙ tr-contrav-hom-unique
-                       Fσ Fσ-contrav
-                       (adjust-hom (∧-comm ∙ 1-top) refl (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))
-                       p p
-                       (tr
-                         (λ f → Hom-over f p p)
-                         {a = idH i}
-                         {b = (adjust-hom
-                                (∧-comm ∙ 1-top)
-                                refl
-                                (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))}
-                         (Hom-ext→
-                           ((λ j
-                             → ≤-antisym
-                                 (∧-UP
-                                   ( ∨-≤-intror (∧-UP (1-top , ∧-idem))
-                                   , ∨-≤-intror ≤-refl))
-                                 (∧-≤-elimr
-                                   (∨-UP
-                                     ( (∧-≤-elimr ≤-refl)
-                                     , ≤-refl))))
-                           , carrier-is-set _ _ _ _
-                           , carrier-is-set _ _ _ _))
-                         (idH p)))))
-
-        lemma2
-          : a (i , p)
-          ＝[ ap (Gσ ∘ fst) lemma3 ]
-            a ( i1 ∧ i
-              , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
-        lemma2 = apᶠ a lemma3
-
-        lemma1
-          : a (i , p)
-          ＝[ ap Gσ (sym (∧-comm ∙ 1-top)) ]
-            a ( i1 ∧ i
-              , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
-        lemma1 = adjust-Idᵈ (ap-∘ Gσ fst lemma3 ∙ ap (ap Gσ) Σ-path-ap-fst) lemma2
-
-      qinv : quasi-inv (precomp-Π (G ∘ σ ∘ fst) (λ p → i0 , p))
-      qinv .fst x (i , p)
-        = tr-cov-hom Gσ-cov (0≤i i)
-            (x (tr-contrav-hom Fσ-contrav (0≤i i) p))
-      qinv .snd .fst x = funext→
-        (λ (i , p)
-         → tr-cov-hom-unique Gσ Gσ-cov (0≤i i)
-             (x (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p))
-             (x (i , p))
-             (connection i p x))
-      qinv .snd .snd x = funext→
-        (λ p
-         → tr-cov-idH~ Gσ Gσ-cov _ 0≤i-at-0 (x (tr-contrav-hom Fσ-contrav (0≤i i0) p))
-         ∙ ap x (tr-contrav-idH~ Fσ Fσ-contrav _ 0≤i-at-0 p))
-}
-
-\agda{
   cov^contrav-is-covariant
     : is-contravariant F → is-covariant G → is-covariant G^F
   cov^contrav-is-covariant Fc Gc
@@ -483,34 +596,18 @@ module _
         (λ {(mk-afmap σ h)
          → is-single←equiv-to-single
              (  fibre-precomp-Π≃Ext (G ∘ σ ∘ fst) (i0 ,_) (h tt)
-             ∙e transpose-ext-exponentials σ (h tt) e⁻¹)
+             ∙e transpose-ext-exponentials-at-point-i0 F G σ (h tt) e⁻¹)
              (has-singleton-fibres←is-equiv
-               (cov^contrav-is-covariant-lemma σ Fc Gc)
+               (cov^contrav-is-covariant-lemma F G σ Fc Gc)
                (h tt))})
 
-  cov^contrav-is-covariant-alternative
-    : (base-change-left-anodyne
-          : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
-              (f : B → A) (p : C → A)
-            → is-left-anodyne p
-            → is-right-fibration f
-            → is-left-anodyne (base-change-arrow f p))
-    → is-contravariant F → is-covariant G → is-covariant G^F
-  cov^contrav-is-covariant-alternative bcla Fctr Gcov
-    = is-covariant←has-unique-extensions G^F
-        (λ {(mk-afmap σ h)
-         → is-single←equiv-to-single
-             (transpose-ext-exponentials σ (h tt) e⁻¹)
-             (unique-extensions←are-orthogonal-fam {P = G}
-               (are-orthogonal-fam←are-orthogonal-fst
-                 (transposed-left-map-is-left-anodyne σ bcla Fctr (fst: G)
-                   (is-covariant↔is-left-fibration G .fst Gcov)))
-               (mk-afmap (σ ∘ fst) (h tt)))})
+}
+}
 }
 }
 
 \subtree[tot-0AGU]{
-\taxon{Example}
+\taxon{Corollary}
 
 \p{For any #{f : A \to Δ^1} and covariant family #{F}, the type family
 #{(a \mapsto (f(a) = 0) \to F(a))} is covariant.}

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -201,11 +201,11 @@ monotone.
 }
 
 \agda{
-module _ (phoa : Δ¹-endos-are-mono) where
+module _ (Δ¹-mono : Δ¹-endos-are-mono) where
 
   ●-unique-extensions : has-unique-extensions (point i1) (_＝ i0)
   ●-unique-extensions (mk-afmap σ p) .centre .fst a
-    = ≤-antisym (≤-trans (phoa σ auto!) (≤←＝ (p tt))) auto!
+    = ≤-antisym (≤-trans (Δ¹-mono σ auto!) (≤←＝ (p tt))) auto!
   ●-unique-extensions (mk-afmap σ p) .centre .snd a = prop!
   ●-unique-extensions F .central
     = Extᵈ-Subtype-is-prop
@@ -374,8 +374,9 @@ module _
 
         lemma3
           : Id (Σ Δ¹ Fσ)
-               (i0 , tr-contrav-hom {P = Fσ} Fσ-contrav (0≤i i) p)
-               (i0 ∧ i , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
+             (i0 , tr-contrav-hom {P = Fσ} Fσ-contrav (0≤i i) p)
+             ( i0 ∧ i
+             , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
         lemma3
           = Σ-path→
             ( path
@@ -383,7 +384,8 @@ module _
             ∙ ap (λ f → tr-contrav-hom Fσ-contrav f p)
                  (Hom-ext→
                    ( (λ j
-                      → ap₂ _∧_
+                      → ap₂
+                          (_∧_)
                           (≤-antisym
                             (∨-≤-introl auto!)
                             (∨-UP (auto! , (∧-≤-eliml auto!))))
@@ -415,33 +417,33 @@ module _
         lemma3 = Σ-path→
           ( sym (∧-comm ∙ 1-top)
           , Idᶠ-inr' {B = Fσ} {p = ∧-comm ∙ 1-top}
-               {x = p}
-               {y = tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p}
-               (sym ( tr∘tr-contrav Fσ Fσ-contrav (∧-comm ∙ 1-top) _ p
-                    ∙ tr-contrav-hom-unique
-                        Fσ Fσ-contrav
-                        (adjust-hom (∧-comm ∙ 1-top) refl (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))
-                        p p
-                        (tr
-                          (λ f → Hom-over f p p)
-                          {a = idH i}
-                          {b = (adjust-hom
-                                 (∧-comm ∙ 1-top)
-                                 refl
-                                 (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))}
-                          (Hom-ext→
-                            ((λ j
-                              → ≤-antisym
-                                  (∧-UP
-                                    ( ∨-≤-intror (∧-UP (1-top , ∧-idem))
-                                    , ∨-≤-intror ≤-refl))
-                                  (∧-≤-elimr
-                                    (∨-UP
-                                      ( (∧-≤-elimr ≤-refl)
-                                      , ≤-refl))))
-                            , carrier-is-set _ _ _ _
-                            , carrier-is-set _ _ _ _))
-                          (idH p)))))
+              {x = p}
+              {y = tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p}
+              (sym ( tr∘tr-contrav Fσ Fσ-contrav (∧-comm ∙ 1-top) _ p
+                   ∙ tr-contrav-hom-unique
+                       Fσ Fσ-contrav
+                       (adjust-hom (∧-comm ∙ 1-top) refl (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))
+                       p p
+                       (tr
+                         (λ f → Hom-over f p p)
+                         {a = idH i}
+                         {b = (adjust-hom
+                                (∧-comm ∙ 1-top)
+                                refl
+                                (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)))}
+                         (Hom-ext→
+                           ((λ j
+                             → ≤-antisym
+                                 (∧-UP
+                                   ( ∨-≤-intror (∧-UP (1-top , ∧-idem))
+                                   , ∨-≤-intror ≤-refl))
+                                 (∧-≤-elimr
+                                   (∨-UP
+                                     ( (∧-≤-elimr ≤-refl)
+                                     , ≤-refl))))
+                           , carrier-is-set _ _ _ _
+                           , carrier-is-set _ _ _ _))
+                         (idH p)))))
 
         lemma2
           : a (i , p)
@@ -462,14 +464,15 @@ module _
         = tr-cov-hom Gσ-cov (0≤i i)
             (x (tr-contrav-hom Fσ-contrav (0≤i i) p))
       qinv .snd .fst x = funext→
-        (λ {(i , p)
+        (λ (i , p)
          → tr-cov-hom-unique Gσ Gσ-cov (0≤i i)
              (x (i0 , tr-contrav-hom Fσ-contrav (0≤i i) p))
              (x (i , p))
-             (connection i p x)})
+             (connection i p x))
       qinv .snd .snd x = funext→
-        (λ p → tr-cov-idH~ Gσ Gσ-cov _ 0≤i-at-0 (x (tr-contrav-hom Fσ-contrav (0≤i i0) p))
-             ∙ ap x (tr-contrav-idH~ Fσ Fσ-contrav _ 0≤i-at-0 p))
+        (λ p
+         → tr-cov-idH~ Gσ Gσ-cov _ 0≤i-at-0 (x (tr-contrav-hom Fσ-contrav (0≤i i0) p))
+         ∙ ap x (tr-contrav-idH~ Fσ Fσ-contrav _ 0≤i-at-0 p))
 }
 
 \agda{
@@ -513,13 +516,13 @@ module _
 #{(a \mapsto (f(a) = 0) \to F(a))} is covariant.}
 
 \agda{
-module _ (phoa : Δ¹-endos-are-mono) where
+module _ (Δ¹-mono : Δ¹-endos-are-mono) where
 
   exp-●-is-covariant
     : ∀ {𝓤 𝓥} {A : Type 𝓥} (F : A → Type 𝓤) (F-cov : is-covariant F)
       → (f : A → Δ¹)
       → is-covariant (λ i → (f i ＝ i0) → F i)
   exp-●-is-covariant F Fc f
-    = cov^contrav-is-covariant ((_＝ i0) ∘ f) F (●-is-contravariant phoa f) Fc
+    = cov^contrav-is-covariant ((_＝ i0) ∘ f) F (●-is-contravariant Δ¹-mono f) Fc
 }
 }

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -191,7 +191,7 @@ monotone, the family #{i \mapsto (i = 0)} is contravariant.}
 
 \proof{
 \p{We want to show the family #{{-} = 0} is orthogonal to #{\{1\} \to \Delta^1}. Since
-this is a family of propositions it suffices to show that lifts merely exist. Then for
+this is a family of propositions it suffices to construct some lift. Then for
 each #{\sigma : Δ^1 \to Δ^1} such that #{\sigma(1) = 0} we need to show that
 #{\sigma(i) = 0} for each #{i}, but this follows from the fact that #{\sigma} is
 monotone.
@@ -233,7 +233,7 @@ module _ (phoa : Δ¹-endos-are-mono) where
 
 \p{We show that given a [contravariant type family](stt-00OD) #{F},
 and a [covariant type family](stt-00AY) #{G}, the type family given by
-#{x \mapsto F(x) \to G(x)} is also covariant.}
+#{x \mapsto F(x) \to G(x)} is also covariant. }
 
 \proof{
 \p{First notice that solutions to the left lifting problem are in bijection with
@@ -255,17 +255,46 @@ solutions to the right lifting problem.}
 \end{tikzcd}
 }
 
-\p{Now we may see that the leftmost map of the second diagram is obtained
-as the pullback of #{\{0\} \to \Delta^1} by the projection
-#{\Sigma_{i} F_{f(i)} \to \Delta^1}. Hence we have a lifting problem where the
-left map is a pullback of a left anodyne map by a right fibration and hence
-is a left anodyne map. Since the right family is covariant by assumption, this
-means solutions to the lifting problem exist uniquely.}
-}
+\p{From here we present a pair of proof strategies, the first is
+conceptually simpler, but relies on a yet to be formalised lemma and the second
+takes a somewhat more bruteforce approach, but is completely formalised within the
+library.}
+
+\subtree[tot-56BA]{
+\p{
+We may see that the leftmost map of the second of the [above diagrams](stt-00OM) is
+obtained as the pullback of #{\{0\} \to \Delta^1} by the projection #{\Sigma_{i}
+F_{f(i)} \to \Delta^1}. Hence we have a lifting problem where the left map is a
+pullback of a left anodyne map by a right fibration and hence is a left anodyne
+map. Since the right family is covariant by assumption, this means solutions to the
+lifting problem exist uniquely.}
 
 \remark{
 \p{We have not yet formalised the fact that left-anodyne maps are stable under
 base change by right fibrations.}
+}
+}
+
+\subtree[tot-0AAI]{
+\p{Alternatively we can show directly that lifts exist uniquely for lifting problems
+in the shape of the rightmost diagram. In particular we show that for any covariant
+type family #{G}, the natural map
+##{(\Pi_{i} F\sigma(i) \to G\sigma(i)) \to (F\sigma(0) \to G(\sigma(0)))},
+whose fibres are the desired extensions, is an equivalence. For the inverse map, suppose
+that we have a map #{x : F(\sigma(0)) \to G(\sigma(0))}, then to get a map
+#{F\sigma(i) \to G\sigma(i)}, we take the composite
+##{F\sigma(i) \to F\sigma(0) \to G\sigma(0) \to G\sigma(i)}, where the first map
+is induced by contravariant transport, and the last by covariant transport. When
+#{i = 0}, this map is clearly equal to the map we started with, so we have defined
+a left inverse, and all that remains is to show it is a right inverse. To do so, let
+#{x : \Pi_{i} F\sigma(i) \to G\sigma(i)} so that we need to show #{G_* x(0) F^* \sim x}.
+We may use the uniqueness of covariant transport and give a dependent morphism
+#{\Hom_{Gσ}^{0 \le i}(x(0, F^*(p)), x(i,p))} for all #{i : \Delta^1} and
+#{p : F\sigma(i)}. The morphism can be given by #{j \mapsto x(i \land j, F^*(p))}, and
+this can be shown to have the correct boundary trivially at #{0}, and at #{1} by again
+applying uniqueness of transport with a similarly constructed dependent morphism.
+}
+}
 }
 
 \agda{
@@ -321,7 +350,9 @@ module _
           (base-change-left-anodyne
                 (fst: (F ∘ σ)) (point i0) (is-self-anodyne (point i0))
                 (is-right-fibration←is-contravariant (F ∘ σ) (rfib ∘ (σ ∘_))))
+}
 
+\agda{
     cov^contrav-is-covariant-lemma
       : ∀ (F-contrav : is-contravariant F) (G-cov : is-covariant G)
         → is-equiv (precomp-Π {B = Σ[ i ∶ Δ¹ ] F (σ i)} (G ∘ σ ∘ fst) (λ p → (i0 , p)))
@@ -435,7 +466,9 @@ module _
       qinv .snd .snd x = funext→
         (λ p → tr-cov-idH~ Gσ Gσ-cov _ 0≤i-at-0 (x (tr-contrav-hom Fσ-contrav (0≤i i0) p))
              ∙ ap x (tr-contrav-idH~ Fσ Fσ-contrav _ 0≤i-at-0 p))
+}
 
+\agda{
   cov^contrav-is-covariant
     : is-contravariant F → is-covariant G → is-covariant G^F
   cov^contrav-is-covariant Fc Gc = is-covariant←has-unique-extensions G^F
@@ -464,40 +497,13 @@ module _
                       (is-covariant↔is-left-fibration G .fst Gcov)))
                   (mk-afmap (σ ∘ fst) (h tt)))})
 }
-
-\p{We give a concrete proof for a specific instance of this fact (without the need
-for the yet unformalised assumption) for the case that #{F} is the contravariant
-family #{i \mapsto (f(i) = 0)} for any #{f : \Delta^1 \to \Delta^1}.  By the above
-argument it suffices to show that any arrow map from #{(f(\sigma(0)) = 0) \to
-\Sigma_{i} (f(\sigma(i))=0)} to any left fibration #{G}, where the bottom map is
-given by #{\sigma\pi}, has unique extensions when #{f \sigma} is monotone (which it
-always is under the assumption of quasi-coherence).}
-
-
-\proof{
-\p{We give an explicit inverse to the map ##{(\Pi_{(i , p) : \Sigma_{i} f(\sigma(i))
-= 0} P(\sigma(i))) \to (\Pi_{(p : f(\sigma(0)) = 0) P(\sigma(0))} )} Namely we need
-take a function #{x : (f(\sigma(0)) = 0) \to P(0)} and a pair #{i : \Delta^1}, #{p :
-f(\sigma(i)) = 0} to #{P(\sigma(i))}. By the monotonicity of #{f\sigma} we have a map
-#{h : (f(\sigma(i)) = 0) \to (f(\sigma(0)) = 0)}, which is the identity when #{i =
-0}, and by covariance of #{P} we have a map #{P(\sigma(0)) \to P(\sigma(i))}, which
-is also the identity when #{i} is #{0}. Consequently, we may construct a map which is
-clearly a left inverse. To show it is also a right inverse, we require that for any
-#{a : \Pi_{(i , p) : \Sigma_{i} (f(\sigma(i)) = 0)} P(\sigma(i))} and #{(i,p) :
-\Sigma_{i} (f(\sigma(i)) = 0)} that #{P_*(a(0, h_i(p)))} is equal to #{a (i, p)}. By
-the uniqueness of covariant transport, we may give a morphism #{\Hom_{Pσ}^{0 \le
-i}(a(0 , h_i(p)), a (i , p))}. The mapping #{j \mapsto a(i \land j, h'_{j \land i \le
-i}(p))} does the job, where #{h'} generalises #{h} by replacing #{i} and #{0} with
-any pair #{i \ge j}.}
-
-\p{Note that for technical reasons due to the construction of the
-map from #{i \le j \to \Hom(i,j)}, in the formalisation, we have to use the mapping
-#{j \mapsto a((j \lor 0) \land (i \lor 0), ...)}.}
-}
 }
 
 \subtree[tot-0AGU]{
 \taxon{Example}
+
+\p{For any #{f : A \to Δ^1} and covariant family #{F}, the type family
+#{(a \mapsto (f(a) = 0) \to G(a))} is covariant.}
 
 \agda{
 module _ (phoa : Δ¹-endos-are-mono) where

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -228,10 +228,6 @@ module _
   (let
     transposed-left-map : ∀ σ → F (σ i0) → Σ Δ¹ (F ∘ σ)
     transposed-left-map σ x = (i0 , x))
-  (base-change-left-anodyne
-    : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} (f : B → A) {C : Type 𝓦}
-        (p : C → A) → is-left-anodyne p → is-right-fibration f
-      → is-left-anodyne (base-change-arrow f p))
   where
 
   module _ (σ : Δ¹ → B) where
@@ -255,8 +251,12 @@ module _
     transposed-left-map-is-pb .snd .snd = id-is-equiv
 
     transposed-left-map-is-left-anodyne
-      : is-contravariant F → is-left-anodyne (transposed-left-map σ)
-    transposed-left-map-is-left-anodyne rfib
+      : (base-change-left-anodyne
+          : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} (f : B → A) {C : Type 𝓦}
+              (p : C → A) → is-left-anodyne p → is-right-fibration f
+            → is-left-anodyne (base-change-arrow f p))
+      → is-contravariant F → is-left-anodyne (transposed-left-map σ)
+    transposed-left-map-is-left-anodyne base-change-left-anodyne rfib
       = is-anodyne←equiv
           (base-change-arrow (fst: (F ∘ σ)) (point i0))
           (transposed-left-map σ)
@@ -267,16 +267,137 @@ module _
                 (is-right-fibration←is-contravariant (F ∘ σ) (rfib ∘ (σ ∘_))))
 
   cov^contrav-is-covariant
-    : is-contravariant F → is-covariant G → is-covariant G^F
-  cov^contrav-is-covariant Fctr Gcov
+    : (base-change-left-anodyne
+          : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} (f : B → A) {C : Type 𝓦}
+              (p : C → A) → is-left-anodyne p → is-right-fibration f
+            → is-left-anodyne (base-change-arrow f p))
+    → is-contravariant F → is-covariant G → is-covariant G^F
+  cov^contrav-is-covariant bcla Fctr Gcov
     = is-covariant←has-unique-extensions G^F (λ
         {(mk-afmap σ h)
             → is-single←equiv-to-single
                 (transpose-ext-exponentials σ (h tt) e⁻¹)
                 (unique-extensions←are-orthogonal-fam {P = G}
                   (are-orthogonal-fam←are-orthogonal-fst
-                    (transposed-left-map-is-left-anodyne σ Fctr (fst: G)
+                    (transposed-left-map-is-left-anodyne σ bcla Fctr (fst: G)
                       (is-covariant↔is-left-fibration G .fst Gcov)))
                   (mk-afmap (σ ∘ fst) (h tt)))})
+}
+
+\p{We give a concrete proof of this fact (without the need for the yet unformalised
+assumption) for the case that #{F} is the contravariant family #{i \mapsto (i = 0)}.
+In particular we show that the map #{(\sigma(0) = 0) \to \Sigma_{i} (\sigma(i)=0)} is
+left-anodyne when #{\sigma} is monotone (which it always is under the assumption of
+quasi-coherence).}
+
+\agda{
+is-monotone : (Δ¹ → Δ¹) → Type 𝓘
+is-monotone σ = ∀ {i j} → i ≤ j → σ i ≤ σ j
+
+module _ (σ : Δ¹ → Δ¹) (σ-mono : is-monotone σ) where
+  transpose-●-is-left-anodyne
+    : ∀ {𝓥} (P : Δ¹ → Type 𝓥) (P-cov : is-covariant P)
+      → is-equiv (precomp-Π {B = Σ[ i ∶ Δ¹ ] (σ i ＝ i0)} (P ∘ σ ∘ fst) (λ p → (i0 , p)))
+  transpose-●-is-left-anodyne  P P-cov = is-equiv←qinv
+    ( (λ x (i , p) → coe-cov
+                       (P ∘ σ)
+                       (covariant-base-change {P = P} σ P-cov)
+                       0-init
+                       (x (map1' i p)))
+    , (λ a → funext→ (λ
+      where (i , p)→ coe-cov Pσ Pσ-cov (0-init {i}) (a (i0 , map1' i p))
+                  ＝⟨⟩
+                     tr-cov-hom {P = P ∘ σ} Pσ-cov (Δ¹-hom←≤ 0-init) (a (i0 , map1' i p))
+                  ＝⟨ tr-cov-hom-unique Pσ Pσ-cov (Δ¹-hom←≤ 0-init) (a (i0 , map1' i p))
+                        (a (i , p)) (connection i p a) ⟩
+                      a (i , p) ∎))
+    , (λ a → funext→ (λ p →
+                          coe-cov-id
+                            (P ∘ σ)
+                            (covariant-base-change {P = P} σ P-cov)
+                            0-init (a (map1' i0 p))
+                         ∙ ap a (map1-at-0 0-init p)))) where
+      Pσ = P ∘ σ
+      Pσ-cov = covariant-base-change {P = P} σ P-cov
+
+      opaque
+        map1 : ∀ i j → j ≤ i → σ i ＝ i0 → σ j ＝ i0
+        map1 i j l p = ≤-antisym (≤-trans (σ-mono l) (≤←＝ p)) 0-init
+
+        map1-at-0 : ∀ p → map1 i0 i0 p ~ id
+        map1-at-0 _ p = carrier-is-set _ _ _ p
+
+      map1' = λ i → map1 i i0 0-init
+
+      opaque
+        connection
+          : ∀ i (p : σ i ＝ i0) (a : (∀ (x : Σ[ i ∶ Δ¹ ] (σ i ＝ i0)) → P (σ (fst x))))
+            → Hom-over {B = P ∘ σ} (Δ¹-hom←≤ 0-init) (a (i0 , map1 i i0 0-init p)) (a (i , p))
+        connection i p a .Homᵈ.hom j
+          = a ( (j ∨ i0) ∧ (i0 ∨ i)
+              , map1 i ((j ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
+        connection i p a .Homᵈ.hom0 = sym lemma1 where
+          -- it is important to chose this path in particular
+          path : i0 ＝ (i0 ∨ i0) ∧ (i0 ∨ i)
+          path = sym
+            (ap₂ _∧_ (∨-comm ∙ 0-bottom)
+                     ( ap (_∨ i)
+                          (sym (ap (_∧_ i0) (sym (∨-comm ∙ 0-bottom)) ∙ ∧-∨-abs ∙ refl))
+                     ∙ (ap (_∨ i) ∧-comm ∙ ∨-comm ∙ ∨-∧-abs)
+                     ∙ refl)
+            ∙ ap (_∧_ i0) (sym (∨-comm ∙ 0-bottom)) ∙ ∧-∨-abs ∙ refl)
+
+          lemma3 : Id (Σ[ i ∶ Δ¹ ] (σ i ＝ i0))
+                      (i0 , map1' i p)
+                      ( (i0 ∨ i0) ∧ (i0 ∨ i)
+                      , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
+          lemma3 = Σ-path→ (path , carrier-is-set _ _ _ _)
+
+          lemma2 : a (i0 , map1' i p)
+                 ＝[ ap (P ∘ σ ∘ fst) lemma3 ]
+                   a ( (i0 ∨ i0) ∧ (i0 ∨ i)
+                     , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
+          lemma2 = apᶠ a lemma3
+
+          lemma1 : a (i0 , map1' i p)
+                 ＝[ ap (P ∘ σ) path ]
+                   a ( (i0 ∨ i0) ∧ (i0 ∨ i)
+                     , map1 i ((i0 ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
+          lemma1 = adjust-idᵈ
+                     {P = ap (P ∘ σ ∘ fst) lemma3} {Q = ap (P ∘ σ) path}
+                     (ap-∘ (P ∘ σ) fst lemma3 ∙ ap (ap (P ∘ σ)) Σ-path-ap-fst)
+                     lemma2
+
+        connection i p a .Homᵈ.hom1 = sym lemma1 where
+          path : i ＝ (i1 ∨ i0) ∧ (i0 ∨ i)
+          path = sym (ap₂ _∧_ (∨-comm ∙ 1-coinit) (≤-max 0-init) ∙ ∧-comm ∙ 1-top)
+
+          Σpath : Id (Σ[ i ∶ Δ¹ ] (σ i ＝ i0))
+                     (i , p)
+                     ( (i1 ∨ i0) ∧ (i0 ∨ i)
+                     , map1 i ((i1 ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
+          Σpath = Σ-path→ (path , (carrier-is-set _ _ _ _))
+
+          lemma1
+            : a (i , p)
+            ＝[ ap (P ∘ σ) path ]
+              a ( (i1 ∨ i0) ∧ (i0 ∨ i)
+                , map1 i ((i1 ∨ i0) ∧ (i0 ∨ i)) (∧-≤-elimr (∨-UP (0-init , ≤-refl))) p)
+          lemma1 = adjust-idᵈ {P = ap (P ∘ σ ∘ fst) Σpath} {Q = ap (P ∘ σ) path}
+                     (ap-∘ (P ∘ σ) fst Σpath ∙ ap (ap (P ∘ σ)) Σ-path-ap-fst)
+                     (apᶠ a Σpath)
+
+module _ (phoa : ∀ (σ : Δ¹ → Δ¹) → is-monotone σ) where
+  exp-●-is-covariant
+    : ∀ {𝓤} (F : Δ¹ → Type 𝓤) (F-cov : is-covariant F)
+      → is-covariant (λ i → (i ＝ i0) → F i)
+  exp-●-is-covariant F Fc
+    = is-covariant←has-unique-extensions (λ i → (i ＝ i0) → F i)
+        λ AF@(mk-afmap σ p)
+          → is-single←equiv-to-single
+              (fibre-precomp-Π≃Ext (F ∘ σ ∘ fst) (λ z → i0 , z) (p tt)
+              ∙e transpose-ext-exponentials (_＝ i0) F σ (p tt) e⁻¹)
+              (has-singleton-fibres←is-equiv
+                (transpose-●-is-left-anodyne σ (phoa σ) F Fc) (p tt))
 }
 }

--- a/src/Synthetic/Categories/CovariantClosure.lagda.tree
+++ b/src/Synthetic/Categories/CovariantClosure.lagda.tree
@@ -191,8 +191,8 @@ opaque
 monotone, the family #{i \mapsto (i = 0)} is contravariant.}
 
 \proof{
-\p{We want to show the family #{{-} = 0} is orthogonal to #{\{1\} \to \Delta^1}. Since
-this is a family of propositions it suffices to construct some lift. Then for
+\p{We want to show the family #{({-}) = 0} is orthogonal to the point inclusion #{\{1\} \to \Delta^1}. Since
+this is a family of propositions it suffices to construct some lift. In other words, for
 each #{\sigma : Δ^1 \to Δ^1} such that #{\sigma(1) = 0} we need to show that
 #{\sigma(i) = 0} for each #{i}, but this follows from the fact that #{\sigma} is
 monotone.
@@ -216,7 +216,7 @@ module _ (phoa : Δ¹-endos-are-mono) where
     : ∀ {𝓤} {A : Type 𝓤} (f : A → Δ¹)
       → is-contravariant ((_＝ i0) ∘ f)
   ●-is-contravariant f
-    = contravariant-base-change {P = _＝ i0} f
+    = contravariant-base-change {P = (_＝ i0)} f
         (is-right-family↔is-contravariant (_＝ i0) .fst
           (are-orthogonal-fam←unique-extensions ●-unique-extensions))
 }
@@ -228,7 +228,7 @@ module _ (phoa : Δ¹-endos-are-mono) where
 
 \p{We show that given a [contravariant type family](stt-00OD) #{F},
 and a [covariant type family](stt-00AY) #{G}, the type family given by
-#{x \mapsto F(x) \to G(x)} is also covariant. }
+#{x \mapsto F(x) \to G(x)} is also covariant.}
 
 \proof{
 \p{First notice that solutions to the left lifting problem are in bijection with
@@ -265,7 +265,7 @@ map. Since the right family is covariant by assumption, this means solutions to 
 lifting problem exist uniquely.}
 
 \remark{
-\p{We have not yet formalised the fact that left-anodyne maps are stable under
+\p{We have not yet formalised the fact that left anodyne maps are stable under
 base change by right fibrations.}
 }
 }
@@ -324,8 +324,10 @@ module _
 
     transposed-left-map-is-left-anodyne
       : (base-change-left-anodyne
-          : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} (f : B → A) {C : Type 𝓦}
-              (p : C → A) → is-left-anodyne p → is-right-fibration f
+          : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
+              (f : B → A) (p : C → A) 
+            → is-left-anodyne p 
+            → is-right-fibration f
             → is-left-anodyne (base-change-arrow f p))
       → is-contravariant F → is-left-anodyne (transposed-left-map σ)
     transposed-left-map-is-left-anodyne base-change-left-anodyne rfib
@@ -342,7 +344,7 @@ module _
 \agda{
     cov^contrav-is-covariant-lemma
       : ∀ (F-contrav : is-contravariant F) (G-cov : is-covariant G)
-        → is-equiv (precomp-Π {B = Σ[ i ∶ Δ¹ ] F (σ i)} (G ∘ σ ∘ fst) (λ p → (i0 , p)))
+        → is-equiv (precomp-Π {B = Σ[ i ∶ Δ¹ ] F (σ i)} (G ∘ σ ∘ fst) (i0 ,_))
     cov^contrav-is-covariant-lemma Fc Gc = is-equiv←qinv qinv where
       Gσ = G ∘ σ
       Gσ-cov = covariant-base-change {P = G} σ Gc
@@ -350,7 +352,7 @@ module _
       Fσ-contrav = contravariant-base-change {P = F} σ Fc
 
       connection
-        : ∀ i (p : F (σ i))
+        : ∀ (i : Δ¹) (p : F (σ i))
             (a : ∀ (x : Σ[ i ∶ Δ¹ ] F (σ i)) → G (σ (fst x)))
           → Hom-over {B = Gσ}
               (0≤i i)
@@ -442,7 +444,7 @@ module _
                    , tr-contrav-hom {P = Fσ} Fσ-contrav (Δ¹-hom←≤ (∧-≤-elimr ≤-refl)) p)
         lemma1 = adjust-idᵈ (ap-∘ Gσ fst lemma3 ∙ ap (ap Gσ) Σ-path-ap-fst) lemma2
 
-      qinv : quasi-inv (precomp-Π (G ∘ σ ∘ fst) (λ p → i0 , p))
+      qinv : quasi-inv (precomp-Π (G ∘ σ ∘ fst) (i0 ,_))
       qinv .fst x (i , p) = tr-cov-hom Gσ-cov (0≤i i)
                                (x (tr-contrav-hom Fσ-contrav (0≤i i) p))
       qinv .snd .fst x = funext→

--- a/src/Synthetic/Categories/CovariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/CovariantFamilies.lagda.tree
@@ -515,14 +515,14 @@ module _ {𝓤} (B : Δ¹ → Type 𝓤) (bc : is-covariant B) where
 \agda{
 opaque
   unfolding tr-cov-hom
-  tr-naturality
+  tr-cov-naturality
     : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {F : A → Type 𝓥} {G : A → Type 𝓦}
         (Fc : is-covariant F)
         (Gc : is-covariant G)
         (α : ∀ a → F a → G a)
         {x y} (f : Hom A x y)
       → tr-cov-hom Gc f ∘ α x ~ α y ∘ tr-cov-hom Fc f
-  tr-naturality Fc Gc α f x'
+  tr-cov-naturality Fc Gc α f x'
     = ap fst
         (is-covariant-hom←is-covariant _ Gc f (α _ x') .central
           ( α _ (tr-cov-hom Fc f x')

--- a/src/Synthetic/Categories/CovariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/CovariantFamilies.lagda.tree
@@ -59,6 +59,7 @@ open import Synthetic.Cubes Δ¹ i0 i1
 open import Synthetic.Categories.Groupoids Δ¹ I
 open import Synthetic.Horns Δ¹ I
 open import Synthetic.Boundaries Δ¹ I
+open import Synthetic.Categories.WalkingHom Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I
 open import Synthetic.Categories.Comma Δ¹ I
 }
@@ -485,19 +486,6 @@ same as covariant transport over the canonical morphisms from #{0} to #{1} given
 by #{id : \Delta^1 \to \Delta^1}.}
 
 \agda{
-Δ¹-hom←≤  : ∀ {i j} → i ≤ j → Hom Δ¹ i j
-Δ¹-hom←≤ {i} {j} p .Homᵈ.hom l = (l ∨ i) ∧ (i ∨ j)
-Δ¹-hom←≤ p .Homᵈ.hom0 = ap₂ (_∧_) (∨-comm ∙ 0-bottom) (≤-max p) ∙ p
-Δ¹-hom←≤ p .Homᵈ.hom1 = ap₂ (_∧_) (∨-comm ∙ 1-coinit) (≤-max p) ∙ ∧-comm ∙ 1-top
-
-Δ¹-hom-≤-refl : ∀ {i} (p : i ≤ i) → Δ¹-hom←≤ p ＝ idH i
-Δ¹-hom-≤-refl {i} p
-  = Hom-ext→ ( (λ a → ap ((a ∨ i) ∧_) ∨-idem ∙ ∨-∧-abs') , prop! , prop!)
-
-Δ¹-hom-0≤1 : (p : i0 ≤ i1) → Δ¹-hom←≤ p ＝ 0≤1
-Δ¹-hom-0≤1 p
-  = Hom-ext→ ( (λ a → ap₂ (_∧_) 0-bottom 1-coinit ∙ 1-top) , prop! , prop!)
-
 module _ {𝓤} (B : Δ¹ → Type 𝓤) (bc : is-covariant B) where
 
   coe-cov : {i j : Δ¹} → i ≤ j → B i → B j

--- a/src/Synthetic/Categories/CovariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/CovariantFamilies.lagda.tree
@@ -125,17 +125,18 @@ tr-cov-filler
     → ∀ p → Homᵈ (P ∘ h) p (tr-cov {P = P} Pc h p)
 tr-cov-filler cov h = snd ∘ centre ∘ cov h
 
-tr-cov-hom
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥}
-    → is-covariant P
-    → ∀ {x y} (h : Hom A x y) → P x → P y
-tr-cov-hom cov h = fst ∘ centre ∘ is-covariant-hom←is-covariant _ cov h
+opaque
+  tr-cov-hom
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥}
+      → is-covariant P
+      → ∀ {x y} (h : Hom A x y) → P x → P y
+  tr-cov-hom cov h = fst ∘ centre ∘ is-covariant-hom←is-covariant _ cov h
 
-tr-cov-over
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥}
-    → (cov : is-covariant P)
-    → ∀ {x y} (h : Hom A x y) → (x' : P x) → Hom-over h x' (tr-cov-hom cov h x')
-tr-cov-over cov h = snd ∘ centre ∘ is-covariant-hom←is-covariant _ cov h
+  tr-cov-over
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥}
+      → (cov : is-covariant P)
+      → ∀ {x y} (h : Hom A x y) → (x' : P x) → Hom-over h x' (tr-cov-hom cov h x')
+  tr-cov-over cov h = snd ∘ centre ∘ is-covariant-hom←is-covariant _ cov h
 }
 }
 
@@ -392,12 +393,14 @@ Hom-cov-is-equiv
     → is-equiv (Hom-cov P cov f x' y')
 Hom-cov-is-equiv P Pc f x' = fundamental-Id _ (Pc f x') (Hom-cov P Pc f x')
 
-Hom-cov'
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (cov : is-covariant P)
-      {x y} (f : Hom A x y) x' y'
-    → tr-cov-hom {P = P} cov f x' ＝ y' → Hom-over f x' y'
-Hom-cov' P cov f x' y' refl
-  = is-covariant-hom←is-covariant _ cov f x' .centre .snd
+opaque
+  unfolding tr-cov-hom
+  Hom-cov'
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (cov : is-covariant P)
+        {x y} (f : Hom A x y) x' y'
+      → tr-cov-hom {P = P} cov f x' ＝ y' → Hom-over f x' y'
+  Hom-cov' P cov f x' y' refl
+    = is-covariant-hom←is-covariant _ cov f x' .centre .snd
 
 Hom-cov'-is-equiv
   : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (cov : is-covariant P)
@@ -415,6 +418,12 @@ Hom-cov'≃
     → (tr-cov-hom {P = P} cov f x' ＝ y') ≃ (Hom-over f x' y')
 Hom-cov'≃  P Pc f x' y'
   = mk≃ (Hom-cov' P Pc f x' y') (Hom-cov'-is-equiv P Pc f x' y')
+
+tr-cov-hom-unique
+  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (cov : is-covariant P)
+      {x y} (f : Hom A x y) x' y'
+    → (Hom-over f x' y') → tr-cov-hom {P = P} cov f x' ＝ y'
+tr-cov-hom-unique P Pc f x' y' = _≃_.bwd (Hom-cov'≃ P Pc f x' y')
 }
 }
 
@@ -434,24 +443,26 @@ tr-cov-id
     → tr-cov {P = P} cov (λ _ → x) ~ id
 tr-cov-id P cov {x} x' = ap fst (cov (λ _ → x) x' .central (x' , idH x'))
 
-tr-cov-idH
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (cov : is-covariant P) {x}
-    → tr-cov-hom {P = P} cov (idH x) ~ id
-tr-cov-idH P cov {x} x' = ap fst
-  (is-covariant-hom←is-covariant _ cov (idH x) x' .central (x' , idH x'))
+opaque
+  unfolding tr-cov-hom
+  tr-cov-idH
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (cov : is-covariant P) {x}
+      → tr-cov-hom {P = P} cov (idH x) ~ id
+  tr-cov-idH P cov {x} x' = ap fst
+    (is-covariant-hom←is-covariant _ cov (idH x) x' .central (x' , idH x'))
 
-tr-cov-∘
-  : ∀ {𝓤 𝓥} {A : Type 𝓤} (Apc : is-segal A) (P : A → Type 𝓥)
-      (cov : is-covariant P) {x y z} (g : Hom A y z) (f : Hom A x y)
-      (x' : P x)
-    → tr-cov-hom cov (g ∘[ Apc ] f) x'
-    ＝ tr-cov-hom cov g (tr-cov-hom cov f x')
-tr-cov-∘ apc P cov g f x'
-  = ap fst
-      (is-covariant-hom←is-covariant _ cov (g ∘[ apc ] f) x' .central
-        ( tr-cov-hom cov g (tr-cov-hom cov f x')
-        , Compᵈ apc P (is-inner-family←is-covariant cov) g f
-                (tr-cov-over cov g _) (tr-cov-over cov f _)))
+  tr-cov-∘
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} (Apc : is-segal A) (P : A → Type 𝓥)
+        (cov : is-covariant P) {x y z} (g : Hom A y z) (f : Hom A x y)
+        (x' : P x)
+      → tr-cov-hom cov (g ∘[ Apc ] f) x'
+      ＝ tr-cov-hom cov g (tr-cov-hom cov f x')
+  tr-cov-∘ apc P cov g f x'
+    = ap fst
+        (is-covariant-hom←is-covariant _ cov (g ∘[ apc ] f) x' .central
+          ( tr-cov-hom cov g (tr-cov-hom cov f x')
+          , Compᵈ apc P (is-inner-family←is-covariant cov) g f
+                  (tr-cov-over cov g _) (tr-cov-over cov f _)))
 }
 }
 
@@ -486,6 +497,7 @@ module _ {𝓤} (B : Δ¹ → Type 𝓤) (bc : is-covariant B) where
   coe-cov p = tr-cov-hom bc (Δ¹-hom←≤ p)
 
   opaque
+    unfolding tr-cov-hom
     coe-cov-id : {i  : Δ¹} (p : i ≤ i) → coe-cov p ~ id
     coe-cov-id {i} p
       =  happly (ap (tr-cov-hom bc) (Δ¹-hom-≤-refl p))
@@ -500,62 +512,32 @@ module _ {𝓤} (B : Δ¹ → Type 𝓤) (bc : is-covariant B) where
 }
 
 \subtree[stt-00FR]{
-\title{Natural transformations are natural w.r.t. covariant transport}
-\taxon{Lemma}
-\author{samueltoth}
-\date{2025-12-09}
-
-\citet{Proposition 8.17}{RS17}
-
-\agda{
-tr-cov-hom-naturality
-  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {F : A → Type 𝓥} {G : A → Type 𝓦}
-      (Fc : is-covariant F)
-      (Gc : is-covariant G)
-      (α : ∀ a → F a → G a)
-      {x y : A} (f : Hom A x y)
-    → tr-cov-hom Gc f ∘ α x ~ α y ∘ tr-cov-hom Fc f
-tr-cov-hom-naturality {A = A} {F} Fc Gc α f x'
-  = ap fst
-      (is-covariant-hom←is-covariant _ Gc f (α _ x') .central
-        ( α _ (tr-cov-hom Fc f x')
-        , help f x')) where
-  help
-    : {x y : A} (f : Hom A x y) (x' : F x)
-    → Hom-over f (α x x') (α y (tr-cov-hom Fc f x'))
-  help (mk-hom f refl refl) x'
-    = mk-hom (λ i → α (f i) ((Fc f x') .centre .snd .Homᵈ.hom i))
-             (ap (α (f i0)) ((Fc f x') .centre .snd .Homᵈ.hom0))
-             (ap (α (f i1)) ((Fc f x') .centre .snd .Homᵈ.hom1))
-}
-}
-
-
-\subtree[stt-00FR]{
 \title{Natural transformations are natural with respect to covariant transport}
 \taxon{Lemma}
 
 \citet{Proposition 8.17}{RS17}
 
 \agda{
-tr-naturality
-  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {F : A → Type 𝓥} {G : A → Type 𝓦}
-      (Fc : is-covariant F)
-      (Gc : is-covariant G)
-      (α : ∀ a → F a → G a)
-      {x y} (f : Hom A x y)
-    → tr-cov-hom Gc f ∘ α x ~ α y ∘ tr-cov-hom Fc f
-tr-naturality Fc Gc α f x'
-  = ap fst
-      (is-covariant-hom←is-covariant _ Gc f (α _ x') .central
-        ( α _ (tr-cov-hom Fc f x')
-        , help f x')) where
-  help
-    : ∀ {x y} (f : Hom _ x y) x'
-      → Hom-over f (α x x') (α y (tr-cov-hom Fc f x'))
-  help (mk-hom f refl refl) x'
-    = mk-hom (λ i → α (f i) ((Fc f x') .centre .snd .Homᵈ.hom i))
-             (ap (α (f i0)) ((Fc f x') .centre .snd .Homᵈ.hom0))
-             (ap (α (f i1)) ((Fc f x') .centre .snd .Homᵈ.hom1))
+opaque
+  unfolding tr-cov-hom
+  tr-naturality
+    : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {F : A → Type 𝓥} {G : A → Type 𝓦}
+        (Fc : is-covariant F)
+        (Gc : is-covariant G)
+        (α : ∀ a → F a → G a)
+        {x y} (f : Hom A x y)
+      → tr-cov-hom Gc f ∘ α x ~ α y ∘ tr-cov-hom Fc f
+  tr-naturality Fc Gc α f x'
+    = ap fst
+        (is-covariant-hom←is-covariant _ Gc f (α _ x') .central
+          ( α _ (tr-cov-hom Fc f x')
+          , help f x')) where
+    help
+      : ∀ {x y} (f : Hom _ x y) x'
+        → Hom-over f (α x x') (α y (tr-cov-hom Fc f x'))
+    help (mk-hom f refl refl) x'
+      = mk-hom (λ i → α (f i) ((Fc f x') .centre .snd .Homᵈ.hom i))
+               (ap (α (f i0)) ((Fc f x') .centre .snd .Homᵈ.hom0))
+               (ap (α (f i1)) ((Fc f x') .centre .snd .Homᵈ.hom1))
 }
 }

--- a/src/Synthetic/Categories/CovariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/CovariantFamilies.lagda.tree
@@ -526,11 +526,11 @@ opaque
     = ap fst
         (is-covariant-hom←is-covariant _ Gc f (α _ x') .central
           ( α _ (tr-cov-hom Fc f x')
-          , help f x')) where
-    help
+          , filler f x')) where
+    filler
       : ∀ {x y} (f : Hom _ x y) x'
         → Hom-over f (α x x') (α y (tr-cov-hom Fc f x'))
-    help (mk-hom f refl refl) x'
+    filler (mk-hom f refl refl) x'
       = mk-hom (λ i → α (f i) ((Fc f x') .centre .snd .Homᵈ.hom i))
                (ap (α (f i0)) ((Fc f x') .centre .snd .Homᵈ.hom0))
                (ap (α (f i1)) ((Fc f x') .centre .snd .Homᵈ.hom1))

--- a/src/Synthetic/Categories/CovariantFamilies.lagda.tree
+++ b/src/Synthetic/Categories/CovariantFamilies.lagda.tree
@@ -451,6 +451,13 @@ opaque
   tr-cov-idH P cov {x} x' = ap fst
     (is-covariant-hom←is-covariant _ cov (idH x) x' .central (x' , idH x'))
 
+  tr-cov-idH~
+    : ∀ {𝓤 𝓥} {A : Type 𝓤} (P : A → Type 𝓥) (cov : is-covariant P) {x}
+        (f : Hom A x x)
+      → f ＝ idH x
+      → tr-cov-hom {P = P} cov f ~ id
+  tr-cov-idH~ P cov _ refl = tr-cov-idH P cov
+
   tr-cov-∘
     : ∀ {𝓤 𝓥} {A : Type 𝓤} (Apc : is-segal A) (P : A → Type 𝓥)
         (cov : is-covariant P) {x y z} (g : Hom A y z) (f : Hom A x y)

--- a/src/Synthetic/Categories/CovariantHomFamily.lagda.tree
+++ b/src/Synthetic/Categories/CovariantHomFamily.lagda.tree
@@ -274,7 +274,11 @@ module CovariantActionPostcomp
     → tr-cov-hom (hom-fam-cov 𝐴ₗ _) g f
     ＝ g ∘[ 𝐴 ] f
   tr-cov-hom-is-comp {a} (mk-hom gh refl refl) f@(mk-hom fh refl fh1)
-    = ap fst (hom-fam-cov 𝐴ₗ a gh f .central (gf , comp-hov))
+    = tr-cov-hom-unique
+        (Homᵈ (λ _ → A) (fh i0))
+        (hom-fam-cov 𝐴ₗ a)
+        g f gf
+        comp-hov
     where
     g = mk-hom gh refl refl
     gf = g ∘[ 𝐴 ] f

--- a/src/Synthetic/Categories/Spaces.lagda.tree
+++ b/src/Synthetic/Categories/Spaces.lagda.tree
@@ -71,7 +71,7 @@ open import Core.UniversalFibrations
 open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Boundaries Δ¹ I
 open import Synthetic.Categories.CovariantFamilies Δ¹ I
-open import Synthetic.Categories.CovariantClosure Δ¹ I
+open import Synthetic.Categories.CovariantClosure Δ¹ I I-distr
 }
 }
 

--- a/src/Synthetic/Categories/Spaces.lagda.tree
+++ b/src/Synthetic/Categories/Spaces.lagda.tree
@@ -22,6 +22,7 @@ open import Modalities.Cohesion.Connectivity
 open import Modalities.Cohesion.Continuity
 
 import Synthetic.Cubes
+import Synthetic.Quasicoherence
 }
 
 \agda{
@@ -29,6 +30,8 @@ module Synthetic.Categories.Spaces
   {@♭ 𝓘} (@♭ Δ¹ : Type 𝓘) (@♭ I : Lattice Δ¹) (@♭ I-distr : is-distributive I)
   (open Lattice I renaming (0l to i0; 1l to i1))
   (open Synthetic.Cubes Δ¹ i0 i1)
+  (open Synthetic.Quasicoherence Δ¹ I I-distr)
+  (@♭ qc : SQCP)
   (@♭ √ : ∀ {@♭ 𝓤} → @♭ Type 𝓤 → Type 𝓤)
   (@♭ √ε : ∀ {@♭ 𝓤} {@♭ A : Type 𝓤} → (Δ¹ → √ A) → A)
   (@♭ is-tiny-str : ∀ {@♭ 𝓤} {@♭ A : Type 𝓤}
@@ -290,6 +293,40 @@ instance
     : ∀ {@♭ 𝓤} {A : Type 𝓤} {a b : A} ⦃ _ : is-acov A ⦄
       → is-acov (a ＝ b)
   ＝-is-Acov = ＝-is-acov auto!
+
+opaque
+  exp-●-is-acov
+   : ∀ {@♭ 𝓤} {A : Type 𝓤}
+     → is-acov A
+     → (∀ {i} → is-acov (i ＝ i0 → A))
+  exp-●-is-acov {𝓤}{A} ac {i}
+    = √ᵈ-naturality← _ _ _ (ϕ̂ (mk-ufib A ac , i)) where
+    open Space
+    @♭ Γ : Type (lsuc (𝓘 ⊔ 𝓤))
+    Γ = Space 𝓤 × Δ¹
+
+    @♭ σ : Γ → Type (𝓘 ⊔ 𝓤)
+    σ (A , i) = (i ＝ i0) → Carrier A
+
+    @♭ ϕ : Π (Δ¹ → Γ) (is-covariant ∘ postcomp Δ¹ σ)
+    ϕ g = exp-●-is-covariant (Δ¹-endos-are-mono←SQPC qc) A' A'-is-cov f where
+      A' : Δ¹ → Type 𝓤
+      A' = Carrier ∘ fst ∘ g
+
+      A'-is-cov : is-covariant A'
+      A'-is-cov = UFib-is-fib (fst ∘ g)
+
+      f : Δ¹ → Δ¹
+      f = snd ∘ g
+
+    @♭ ϕ̂ : Π Γ (√ᵈ (is-covariant ∘ postcomp Δ¹ σ))
+    ϕ̂ = ε♭ (rintro (mod♭ ϕ))
+
+instance
+  exp-●-is-Acov
+    : ∀ {@♭ 𝓤} {A : Type 𝓤} ⦃ _ : is-acov A ⦄
+      → (∀ {i} → is-acov (i ＝ i0 → A))
+  exp-●-is-Acov = exp-●-is-acov auto!
 }
 }
 
@@ -567,7 +604,6 @@ dua→ h = (h i0 , h i1 , tr-𝓢 h)
 
 \agda{
 module DUA
-  ⦃ _ : ∀ {@♭ 𝓤} {A : Type 𝓤} ⦃ _ : is-acov A ⦄ → (∀ {i} → is-acov (i ＝ i0 → A)) ⦄
   (non-triv : i1 ＝ i0 → ∅)
   (@♭ √ᵈ-is-prop : ∀ {@♭ 𝓤 𝓥} {@♭ Γ : Type 𝓤} (@♭ A : (Δ¹ → Γ) → Type 𝓥)
                    → (∀ g → is-prop (A g)) → ∀ g → is-prop (√ᵈ A g))

--- a/src/Synthetic/Categories/Spaces.lagda.tree
+++ b/src/Synthetic/Categories/Spaces.lagda.tree
@@ -31,13 +31,12 @@ module Synthetic.Categories.Spaces
   (open Lattice I renaming (0l to i0; 1l to i1))
   (open Synthetic.Cubes Δ¹ i0 i1)
   (open Synthetic.Quasicoherence Δ¹ I I-distr)
-  (@♭ qc : SQCP)
+  (@♭ Δ¹-endos-mono : Δ¹-endos-are-mono)
   (@♭ √ : ∀ {@♭ 𝓤} → @♭ Type 𝓤 → Type 𝓤)
   (@♭ √ε : ∀ {@♭ 𝓤} {@♭ A : Type 𝓤} → (Δ¹ → √ A) → A)
   (@♭ is-tiny-str : ∀ {@♭ 𝓤} {@♭ A : Type 𝓤}
                     → is-tiny-structure Δ¹ A (√ A) √ε)
   (@♭ cubes-detect-cont : detects-continuity {I = ℕ} □^_)
-  (@♭ simplicial-conn : detects-connectivity (point Δ¹))
   (@♭ ♭Δ¹-ind : ∀ {𝓤} (P : @♭ Δ¹ → Type 𝓤) → P i0 → P i1 → (@♭ x : Δ¹) → P x)
   where
 
@@ -309,7 +308,7 @@ opaque
     σ (A , i) = (i ＝ i0) → Carrier A
 
     @♭ ϕ : Π (Δ¹ → Γ) (is-covariant ∘ postcomp Δ¹ σ)
-    ϕ g = exp-●-is-covariant (Δ¹-endos-are-mono←SQPC qc) A' A'-is-cov f where
+    ϕ g = exp-●-is-covariant (Δ¹-endos-mono) A' A'-is-cov f where
       A' : Δ¹ → Type 𝓤
       A' = Carrier ∘ fst ∘ g
 

--- a/src/Synthetic/Categories/Spaces.lagda.tree
+++ b/src/Synthetic/Categories/Spaces.lagda.tree
@@ -308,7 +308,7 @@ opaque
     σ (A , i) = (i ＝ i0) → Carrier A
 
     @♭ ϕ : Π (Δ¹ → Γ) (is-covariant ∘ postcomp Δ¹ σ)
-    ϕ g = exp-●-is-covariant (Δ¹-endos-mono) A' A'-is-cov f where
+    ϕ g = ^●-is-covariant (Δ¹-endos-mono) A' A'-is-cov f where
       A' : Δ¹ → Type 𝓤
       A' = Carrier ∘ fst ∘ g
 

--- a/src/Synthetic/Categories/Strictification.lagda.tree
+++ b/src/Synthetic/Categories/Strictification.lagda.tree
@@ -9,7 +9,7 @@ open import Foundations.Universes
 open import Algebra.Lattice
 
 module Synthetic.Categories.Strictification
-  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹)
+  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹) (I-distr : is-distributive I)
   where
 
 open Lattice I renaming (0l to i0; 1l to i1)
@@ -27,7 +27,7 @@ open import Synthetic.Categories.CovariantFamilies Δ¹ I
 open import Synthetic.Categories.LeftSegal Δ¹ I
 open import Synthetic.Categories.CovariantHomFamily Δ¹ I
 open import Synthetic.Categories.AlgebraicLaws Δ¹ I
-open import Synthetic.Categories.Yoneda Δ¹ I
+open import Synthetic.Categories.Yoneda Δ¹ I I-distr
 
 open import Wild.Categories.Structure
 open CompPrestructure using (Homʷ ; idʷ: ; compʷ:)

--- a/src/Synthetic/Categories/UniversalElements.lagda.tree
+++ b/src/Synthetic/Categories/UniversalElements.lagda.tree
@@ -10,7 +10,7 @@ open import Foundations.Universes
 open import Algebra.Lattice
 
 module Synthetic.Categories.UniversalElements
-  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹)
+  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹) (I-distr : is-distributive I)
   where
 
 open Lattice I renaming (0l to i0; 1l to i1)
@@ -43,7 +43,7 @@ open import Synthetic.Horns Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I
 open import Synthetic.Categories.Homotopy Δ¹ I
 open import Synthetic.Categories.CovariantFamilies Δ¹ I
-open import Synthetic.Categories.CovariantClosure Δ¹ I
+open import Synthetic.Categories.CovariantClosure Δ¹ I I-distr
 open import Synthetic.Categories.LeftSegal Δ¹ I
 open import Synthetic.Categories.CovariantHomFamily Δ¹ I
 open import Synthetic.Categories.Comma Δ¹ I

--- a/src/Synthetic/Categories/WalkingHom.lagda.tree
+++ b/src/Synthetic/Categories/WalkingHom.lagda.tree
@@ -3,6 +3,8 @@
 \author{samueltoth}
 \import{stt-macros}
 
+\p{This module is about the properties of the interval (#{Δ¹}) as a category and
+as a representing object for morphisms in a category.}
 
 \agda{
 open import Foundations.Universes

--- a/src/Synthetic/Categories/WalkingHom.lagda.tree
+++ b/src/Synthetic/Categories/WalkingHom.lagda.tree
@@ -29,7 +29,7 @@ open import Synthetic.Hom Δ¹ i0 i1
 }
 }
 
-\subtree[tot-X56P]{
+\subtree[stt-00UK]{
 \title{Morphisms in #{Δ¹}}
 \taxon{Construction}
 
@@ -78,11 +78,11 @@ by #{0 \le i}.}
 }
 }
 
-\subtree[tot-AAEE]{
+\subtree[stt-00UH]{
 \title{Characterising all morphisms of #{Δ¹}}
 \taxon{Lemma}
 
-\p{Under the assumption that #{I[x]} is [quasicoherent](stt-00TA), the [map](tot-X56P)
+\p{Under the assumption that #{I[x]} is [quasicoherent](stt-00TA), the [map](stt-00UK)
 #{(i \le j) \to \Hom(i,j)} is an equivalence for all #{i} and #{j}.}
 
 \todo{

--- a/src/Synthetic/Categories/WalkingHom.lagda.tree
+++ b/src/Synthetic/Categories/WalkingHom.lagda.tree
@@ -1,0 +1,89 @@
+\title{The walking morphism}
+\taxon{Module}
+\author{samueltoth}
+\import{stt-macros}
+
+
+\agda{
+open import Foundations.Universes
+open import Algebra.Lattice
+
+module Synthetic.Categories.WalkingHom
+  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹)
+  where
+
+open Lattice I renaming (0l to i0; 1l to i1)
+
+open import Axioms.UF
+}
+
+\agda-imports{
+\agda{
+open import Foundations.Prelude
+
+open import Modalities.Instances.Truncation
+
+open import Synthetic.Hom Δ¹ i0 i1
+}
+}
+
+\subtree[tot-X56P]{
+\title{Morphisms in #{Δ^1}}
+\taxon{Construction}
+
+\p{There is a canonical morphism #{\Hom_{\Delta^1}(0,1)} given by the identity
+function.}
+
+\agda{
+0≤1 : Hom Δ¹ i0 i1
+0≤1 .Homᵈ.hom = id
+0≤1 .Homᵈ.hom0 = refl
+0≤1 .Homᵈ.hom1 = refl
+}
+
+\p{More generally, for any #{i \le j}, we may construct a morphism #{\Hom(i,j)}. This
+morphism is the identity when #{i = j} and agrees with the canonical morphism when
+#{i = 0} and #{j = 1}. }
+
+\agda{
+Δ¹-hom←≤  : ∀ {i j} → i ≤ j → Hom Δ¹ i j
+Δ¹-hom←≤ {i} {j} p .Homᵈ.hom l = (l ∨ i) ∧ (i ∨ j)
+Δ¹-hom←≤ p .Homᵈ.hom0 = ap₂ (_∧_) (∨-comm ∙ 0-bottom) (≤-max p) ∙ p
+Δ¹-hom←≤ p .Homᵈ.hom1 = ap₂ (_∧_) (∨-comm ∙ 1-coinit) (≤-max p) ∙ ∧-comm ∙ 1-top
+
+Δ¹-hom-≤-refl : ∀ {i} (p : i ≤ i) → Δ¹-hom←≤ p ＝ idH i
+Δ¹-hom-≤-refl {i} p
+  = Hom-ext→ ( (λ a → ap ((a ∨ i) ∧_) ∨-idem ∙ ∨-∧-abs') , prop! , prop!)
+
+Δ¹-hom-0≤1 : (p : i0 ≤ i1) → Δ¹-hom←≤ p ＝ 0≤1
+Δ¹-hom-0≤1 p
+  = Hom-ext→ ( (λ a → ap₂ (_∧_) 0-bottom 1-coinit ∙ 1-top) , prop! , prop!)
+
+}
+
+\p{We also give a bespoke morphism #{\Hom(0,i)} for any #{i} which is given by a
+simpler underlying map. This morphism is (propositionally) equal to the one induced
+by #{0 \le i}.}
+
+\agda{
+0≤i : ∀ i → Hom Δ¹ i0 i
+0≤i i .Homᵈ.hom j = j ∧ i
+0≤i i .Homᵈ.hom0 = 0-init
+0≤i i .Homᵈ.hom1 = ∧-comm ∙ 1-top
+
+0≤i-at-0 : 0≤i i0 ＝ idH i0
+0≤i-at-0 = Hom-ext→ ((λ a → ∧-comm ∙ 0-init) , prop! , prop!)
+}
+}
+
+\subtree[tot-AAEE]{
+\title{Characterising all morphisms of #{Δ^1}}
+\taxon{Lemma}
+
+\p{Under the assumption that #{I[x]} is [quasicoherent](stt-00TA), the [maps](tot-X56P)
+#{i \le j \to \Hom(i,j)} are equivalences.}
+
+\todo{
+This remains to be formalised.
+}
+}

--- a/src/Synthetic/Categories/WalkingHom.lagda.tree
+++ b/src/Synthetic/Categories/WalkingHom.lagda.tree
@@ -3,7 +3,7 @@
 \author{samueltoth}
 \import{stt-macros}
 
-\p{This module is about the properties of the interval (#{Δ¹}) as a category and
+\p{This module is about the properties of the interval #{Δ¹} as a category and
 as a representing object for morphisms in a category.}
 
 \agda{

--- a/src/Synthetic/Categories/WalkingHom.lagda.tree
+++ b/src/Synthetic/Categories/WalkingHom.lagda.tree
@@ -80,8 +80,8 @@ by #{0 \le i}.}
 \title{Characterising all morphisms of #{Δ¹}}
 \taxon{Lemma}
 
-\p{Under the assumption that #{I[x]} is [quasicoherent](stt-00TA), the [maps](tot-X56P)
-#{i \le j \to \Hom(i,j)} are equivalences.}
+\p{Under the assumption that #{I[x]} is [quasicoherent](stt-00TA), the [map](tot-X56P)
+#{(i \le j) \to \Hom(i,j)} is an equivalence for all #{i} and #{j}.}
 
 \todo{
 This remains to be formalised.

--- a/src/Synthetic/Categories/WalkingHom.lagda.tree
+++ b/src/Synthetic/Categories/WalkingHom.lagda.tree
@@ -28,7 +28,7 @@ open import Synthetic.Hom Δ¹ i0 i1
 }
 
 \subtree[tot-X56P]{
-\title{Morphisms in #{Δ^1}}
+\title{Morphisms in #{Δ¹}}
 \taxon{Construction}
 
 \p{There is a canonical morphism #{\Hom_{\Delta^1}(0,1)} given by the identity
@@ -42,8 +42,8 @@ function.}
 }
 
 \p{More generally, for any #{i \le j}, we may construct a morphism #{\Hom(i,j)}. This
-morphism is the identity when #{i = j} and agrees with the canonical morphism when
-#{i = 0} and #{j = 1}. }
+morphism is the identity/constant morphism when #{i = j}, and agrees with the
+canonical morphism when #{i = 0} and #{j = 1}.}
 
 \agda{
 Δ¹-hom←≤  : ∀ {i j} → i ≤ j → Hom Δ¹ i j
@@ -77,7 +77,7 @@ by #{0 \le i}.}
 }
 
 \subtree[tot-AAEE]{
-\title{Characterising all morphisms of #{Δ^1}}
+\title{Characterising all morphisms of #{Δ¹}}
 \taxon{Lemma}
 
 \p{Under the assumption that #{I[x]} is [quasicoherent](stt-00TA), the [maps](tot-X56P)

--- a/src/Synthetic/Categories/Yoneda.lagda.tree
+++ b/src/Synthetic/Categories/Yoneda.lagda.tree
@@ -61,12 +61,17 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥} {a : A} where
     → is-equiv (evᵈ: P a)
   ev-init-is-equiv Pc ai = is-equiv←qinv
     ( (λ x' a' → tr-cov-hom Pc (ai a' .centre) x')
-    , (λ x' → funext→ λ a' → ap fst (is-covariant-hom←is-covariant _ Pc
-                                      (ai a' .centre) (x' a) .central
-                                      (x' a' , ap-hom-over x' (ai a' .centre))))
-    , λ a' → ap fst (is-covariant-hom←is-covariant _ Pc (ai a .centre) a' .central
-              (a' ,  tr (λ p → Hom-over p a' a') (sym (ai a .central (idH a)))
-                        (idH _))))
+    , (λ x' → funext→ λ a' → tr-cov-hom-unique
+                               P Pc
+                               (ai a' .centre) (x' a) (x' a')
+                               (ap-hom-over x' (ai a' .centre)))
+    , λ a' → tr-cov-hom-unique
+               P Pc
+               (ai a .centre) a' a'
+               (tr
+                 (λ p → Hom-over p a' a')
+                 (sym (ai a .central (idH a)))
+                 (idH _)) )
 
   opaque
     rec-init

--- a/src/Synthetic/Categories/Yoneda.lagda.tree
+++ b/src/Synthetic/Categories/Yoneda.lagda.tree
@@ -61,17 +61,21 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥} {a : A} where
     → is-equiv (evᵈ: P a)
   ev-init-is-equiv Pc ai = is-equiv←qinv
     ( (λ x' a' → tr-cov-hom Pc (ai a' .centre) x')
-    , (λ x' → funext→ λ a' → tr-cov-hom-unique
-                               P Pc
-                               (ai a' .centre) (x' a) (x' a')
-                               (ap-hom-over x' (ai a' .centre)))
-    , λ a' → tr-cov-hom-unique
+    , (λ x'
+       → funext→
+           λ a'
+           → tr-cov-hom-unique
                P Pc
-               (ai a .centre) a' a'
-               (tr
-                 (λ p → Hom-over p a' a')
-                 (sym (ai a .central (idH a)))
-                 (idH _)) )
+               (ai a' .centre) (x' a) (x' a')
+               (ap-hom-over x' (ai a' .centre)))
+    , (λ a'
+       → tr-cov-hom-unique
+           P Pc
+           (ai a .centre) a' a'
+           (tr
+             (λ p → Hom-over p a' a')
+             (sym (ai a .central (idH a)))
+             (idH _))))
 
   opaque
     rec-init

--- a/src/Synthetic/Categories/Yoneda.lagda.tree
+++ b/src/Synthetic/Categories/Yoneda.lagda.tree
@@ -61,13 +61,11 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {P : A → Type 𝓥} {a : A} where
     → is-equiv (evᵈ: P a)
   ev-init-is-equiv Pc ai = is-equiv←qinv
     ( (λ x' a' → tr-cov-hom Pc (ai a' .centre) x')
-    , (λ x'
-       → funext→
-           λ a'
-           → tr-cov-hom-unique
-               P Pc
-               (ai a' .centre) (x' a) (x' a')
-               (ap-hom-over x' (ai a' .centre)))
+    , (λ x' → funext→ λ a'
+       → tr-cov-hom-unique
+           P Pc
+           (ai a' .centre) (x' a) (x' a')
+           (ap-hom-over x' (ai a' .centre)))
     , (λ a'
        → tr-cov-hom-unique
            P Pc

--- a/src/Synthetic/Categories/Yoneda.lagda.tree
+++ b/src/Synthetic/Categories/Yoneda.lagda.tree
@@ -9,7 +9,7 @@ open import Foundations.Universes
 open import Algebra.Lattice
 
 module Synthetic.Categories.Yoneda
-  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹)
+  {𝓘} (Δ¹ : Type 𝓘) (I : Lattice Δ¹) (I-distr : is-distributive I)
   where
 
 open Lattice I renaming (0l to i0; 1l to i1)
@@ -25,7 +25,7 @@ open import Synthetic.Hom Δ¹ i0 i1
 open import Synthetic.Simplicial Δ¹ I
 open import Synthetic.Categories.Precategories Δ¹ I
 open import Synthetic.Categories.CovariantFamilies Δ¹ I
-open import Synthetic.Categories.CovariantClosure Δ¹ I
+open import Synthetic.Categories.CovariantClosure Δ¹ I I-distr
 open import Synthetic.Categories.LeftSegal Δ¹ I
 open import Synthetic.Categories.CovariantHomFamily Δ¹ I
 open import Synthetic.Categories.Initial Δ¹ I

--- a/src/Synthetic/Hom.lagda.tree
+++ b/src/Synthetic/Hom.lagda.tree
@@ -74,12 +74,6 @@ Hom-over {A = A} {B} f x' y'
          (tr B (sym (f .Homᵈ.hom0)) x')
          (tr B (sym (f .Homᵈ.hom1)) y')
 
-
-0≤1 : Hom I i0 i1
-0≤1 .Homᵈ.hom = id
-0≤1 .Homᵈ.hom0 = refl
-0≤1 .Homᵈ.hom1 = refl
-
 total-hom : ∀ {𝓤} {A : Type 𝓤} → (I → A) ≃ (Σ[ x y ∶ A ] Hom A x y)
 total-hom {A = A} = equiv←qequiv
   (mk≊


### PR DESCRIPTION
 - [x] Proves lemma #192 (with brute force as opposed to the method via left anodyne maps being stable under base change by right fibrations).
 - [x] Proves more generally that a covariant family exponentiated by any contravariant family is covariant
 - [x] Updates Spaces to use this proof

Also makes tr-cov-hom and related lemmas opaque to improve goal display (and maybe performance)

extracted from #206 
