### PR TITLE
chore: rename horizontal concat and whiskering of homotopies

### DIFF
--- a/src/Algebra/Lattice.lagda.tree
+++ b/src/Algebra/Lattice.lagda.tree
@@ -524,7 +524,7 @@ module _
 
   is-LatticeAlgHom-equiv-bwd : LatticeAlgHom A2 A1
   is-LatticeAlgHom-equiv-bwd .fst .fst = bwd
-  is-LatticeAlgHom-equiv-bwd .fst .snd = bwd ◂ (H h⁻¹) ∙h η ▸ A1.ι
+  is-LatticeAlgHom-equiv-bwd .fst .snd = bwd ◂h (H h⁻¹) ∙h η ▸h A1.ι
   is-LatticeAlgHom-equiv-bwd .snd = mk-is-lattice-alg-hom lhom
     where
       lhom : is-lattice-hom A2.str-Lattice A1.str-Lattice bwd

--- a/src/Algebra/Lattice.lagda.tree
+++ b/src/Algebra/Lattice.lagda.tree
@@ -524,7 +524,7 @@ module _
 
   is-LatticeAlgHom-equiv-bwd : LatticeAlgHom A2 A1
   is-LatticeAlgHom-equiv-bwd .fst .fst = bwd
-  is-LatticeAlgHom-equiv-bwd .fst .snd = bwd ◂h (H h⁻¹) ∙h η ▸h A1.ι
+  is-LatticeAlgHom-equiv-bwd .fst .snd = bwd ◃h (H h⁻¹) ∙h η ▸h A1.ι
   is-LatticeAlgHom-equiv-bwd .snd = mk-is-lattice-alg-hom lhom
     where
       lhom : is-lattice-hom A2.str-Lattice A1.str-Lattice bwd

--- a/src/Algebra/Lattice.lagda.tree
+++ b/src/Algebra/Lattice.lagda.tree
@@ -524,7 +524,7 @@ module _
 
   is-LatticeAlgHom-equiv-bwd : LatticeAlgHom A2 A1
   is-LatticeAlgHom-equiv-bwd .fst .fst = bwd
-  is-LatticeAlgHom-equiv-bwd .fst .snd = bwd ◃h (H h⁻¹) ∙h η ▸h A1.ι
+  is-LatticeAlgHom-equiv-bwd .fst .snd = bwd ◃h (H h⁻¹) ∙h η ▹h A1.ι
   is-LatticeAlgHom-equiv-bwd .snd = mk-is-lattice-alg-hom lhom
     where
       lhom : is-lattice-hom A2.str-Lattice A1.str-Lattice bwd

--- a/src/Axioms/FreeAlgebraicInjectives.lagda.tree
+++ b/src/Axioms/FreeAlgebraicInjectives.lagda.tree
@@ -353,8 +353,8 @@ record Algebraic-injective-map
         ~ lift-alg-inj Y-alg i (α ∘ p)
     ext-comm-coh
       : ∀ i
-        → (postcomp (A i) α ◂ X-alg i .snd)
-        ~ (λ a → funext→ (ext-comm i a ∘ f i)) ∙h Y-alg i .snd ▸ postcomp (A i) α
+        → (postcomp (A i) α ◂h X-alg i .snd)
+        ~ (λ a → funext→ (ext-comm i a ∘ f i)) ∙h Y-alg i .snd ▸h postcomp (A i) α
 }
 }
 

--- a/src/Axioms/FreeAlgebraicInjectives.lagda.tree
+++ b/src/Axioms/FreeAlgebraicInjectives.lagda.tree
@@ -353,7 +353,7 @@ record Algebraic-injective-map
         ~ lift-alg-inj Y-alg i (α ∘ p)
     ext-comm-coh
       : ∀ i
-        → (postcomp (A i) α ◂h X-alg i .snd)
+        → (postcomp (A i) α ◃h X-alg i .snd)
         ~ (λ a → funext→ (ext-comm i a ∘ f i)) ∙h Y-alg i .snd ▸h postcomp (A i) α
 }
 }

--- a/src/Axioms/FreeAlgebraicInjectives.lagda.tree
+++ b/src/Axioms/FreeAlgebraicInjectives.lagda.tree
@@ -354,7 +354,7 @@ record Algebraic-injective-map
     ext-comm-coh
       : ∀ i
         → (postcomp (A i) α ◃h X-alg i .snd)
-        ~ (λ a → funext→ (ext-comm i a ∘ f i)) ∙h Y-alg i .snd ▸h postcomp (A i) α
+        ~ (λ a → funext→ (ext-comm i a ∘ f i)) ∙h Y-alg i .snd ▹h postcomp (A i) α
 }
 }
 

--- a/src/Core/ArrowEquiv.lagda.tree
+++ b/src/Core/ArrowEquiv.lagda.tree
@@ -85,7 +85,7 @@ Arrow⁻¹←is-Arrow-equiv {f = f} {g} (mk-amap top bot comm) (teq , beq)
   K : bot ∘ bot.bwd ∘ g ∘ top ~ bot ∘ f ∘ top.bwd ∘ top
   K =   bot.ε ▸h g ▸h top
      ∙h (comm h⁻¹)
-     ∙h (bot ◂h f ◂h top.η h⁻¹)
+     ∙h (bot ◃h f ◃h top.η h⁻¹)
 
   H : (bot.bwd ∘ g) ~ (f ∘ top.bwd)
   H = beq ◂e⁻¹ K ▸e⁻¹ teq
@@ -236,14 +236,14 @@ section←Arrow-equiv {f = f} {g} {F = F} eq (secf , p) .fst
   module bot = is-equiv (eq .snd)
 section←Arrow-equiv {f = f} {g} {F} eq (secf , p) .snd
   =  H ▸h top ▸h secf ▸h bot.bwd
-  ∙h bot ◂h f ◂h top.η ▸h secf ▸h bot.bwd
-  ∙h bot ◂h p ▸h bot.bwd
+  ∙h bot ◃h f ◃h top.η ▸h secf ▸h bot.bwd
+  ∙h bot ◃h p ▸h bot.bwd
   ∙h bot.ε where
   open Arrow-map F
   module top = is-equiv (eq .fst)
   module bot = is-equiv (eq .snd)
   H : g ~ bot ∘ f ∘ top.bwd
-  H = ((g ◂h top.ε) h⁻¹) ∙h (comm h⁻¹ ▸h top.bwd)
+  H = ((g ◃h top.ε) h⁻¹) ∙h (comm h⁻¹ ▸h top.bwd)
 
 section←Arrow-equiv⁻¹
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {X : Type 𝓦}
@@ -292,7 +292,7 @@ precomp-Arrow-map
     → (Q : Type 𝓠)
     → Arrow-map f g
     → Arrow-map (precomp Q g) (precomp Q f)
-precomp-Arrow-map Q F = mk-amap (_∘ bot) (_∘ top) (funext→ ∘ (_◂h (comm h⁻¹))) where
+precomp-Arrow-map Q F = mk-amap (_∘ bot) (_∘ top) (funext→ ∘ (_◃h (comm h⁻¹))) where
   open Arrow-map F
 
 precomp-square-is-equiv

--- a/src/Core/ArrowEquiv.lagda.tree
+++ b/src/Core/ArrowEquiv.lagda.tree
@@ -83,7 +83,7 @@ Arrow⁻¹←is-Arrow-equiv {f = f} {g} (mk-amap top bot comm) (teq , beq)
   module bot = is-equiv beq
 
   K : bot ∘ bot.bwd ∘ g ∘ top ~ bot ∘ f ∘ top.bwd ∘ top
-  K =   bot.ε ▸h g ▸h top
+  K =   bot.ε ▹h g ▹h top
      ∙h (comm h⁻¹)
      ∙h (bot ◃h f ◃h top.η h⁻¹)
 
@@ -235,15 +235,15 @@ section←Arrow-equiv {f = f} {g} {F = F} eq (secf , p) .fst
   module top = is-equiv (eq .fst)
   module bot = is-equiv (eq .snd)
 section←Arrow-equiv {f = f} {g} {F} eq (secf , p) .snd
-  =  H ▸h top ▸h secf ▸h bot.bwd
-  ∙h bot ◃h f ◃h top.η ▸h secf ▸h bot.bwd
-  ∙h bot ◃h p ▸h bot.bwd
+  =  H ▹h top ▹h secf ▹h bot.bwd
+  ∙h bot ◃h f ◃h top.η ▹h secf ▹h bot.bwd
+  ∙h bot ◃h p ▹h bot.bwd
   ∙h bot.ε where
   open Arrow-map F
   module top = is-equiv (eq .fst)
   module bot = is-equiv (eq .snd)
   H : g ~ bot ∘ f ∘ top.bwd
-  H = ((g ◃h top.ε) h⁻¹) ∙h (comm h⁻¹ ▸h top.bwd)
+  H = ((g ◃h top.ε) h⁻¹) ∙h (comm h⁻¹ ▹h top.bwd)
 
 section←Arrow-equiv⁻¹
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {X : Type 𝓦}
@@ -270,7 +270,7 @@ postcomp-Arrow-map
     → (Q : Type 𝓠)
     → Arrow-map f g
     → Arrow-map (postcomp Q f) (postcomp Q g)
-postcomp-Arrow-map Q F = mk-amap (top ∘_) (bot ∘_) (funext→ ∘ (comm ▸h_)) where
+postcomp-Arrow-map Q F = mk-amap (top ∘_) (bot ∘_) (funext→ ∘ (comm ▹h_)) where
   open Arrow-map F
 
 

--- a/src/Core/ArrowEquiv.lagda.tree
+++ b/src/Core/ArrowEquiv.lagda.tree
@@ -83,9 +83,9 @@ Arrow⁻¹←is-Arrow-equiv {f = f} {g} (mk-amap top bot comm) (teq , beq)
   module bot = is-equiv beq
 
   K : bot ∘ bot.bwd ∘ g ∘ top ~ bot ∘ f ∘ top.bwd ∘ top
-  K =   bot.ε ▸ g ▸ top
+  K =   bot.ε ▸h g ▸h top
      ∙h (comm h⁻¹)
-     ∙h (bot ◂ f ◂ top.η h⁻¹)
+     ∙h (bot ◂h f ◂h top.η h⁻¹)
 
   H : (bot.bwd ∘ g) ~ (f ∘ top.bwd)
   H = beq ◂e⁻¹ K ▸e⁻¹ teq
@@ -235,15 +235,15 @@ section←Arrow-equiv {f = f} {g} {F = F} eq (secf , p) .fst
   module top = is-equiv (eq .fst)
   module bot = is-equiv (eq .snd)
 section←Arrow-equiv {f = f} {g} {F} eq (secf , p) .snd
-  =  H ▸ top ▸ secf ▸ bot.bwd
-  ∙h bot ◂ f ◂ top.η ▸ secf ▸ bot.bwd
-  ∙h bot ◂ p ▸ bot.bwd
+  =  H ▸h top ▸h secf ▸h bot.bwd
+  ∙h bot ◂h f ◂h top.η ▸h secf ▸h bot.bwd
+  ∙h bot ◂h p ▸h bot.bwd
   ∙h bot.ε where
   open Arrow-map F
   module top = is-equiv (eq .fst)
   module bot = is-equiv (eq .snd)
   H : g ~ bot ∘ f ∘ top.bwd
-  H = ((g ◂ top.ε) h⁻¹) ∙h (comm h⁻¹ ▸ top.bwd)
+  H = ((g ◂h top.ε) h⁻¹) ∙h (comm h⁻¹ ▸h top.bwd)
 
 section←Arrow-equiv⁻¹
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {X : Type 𝓦}
@@ -270,7 +270,7 @@ postcomp-Arrow-map
     → (Q : Type 𝓠)
     → Arrow-map f g
     → Arrow-map (postcomp Q f) (postcomp Q g)
-postcomp-Arrow-map Q F = mk-amap (top ∘_) (bot ∘_) (funext→ ∘ (comm ▸_)) where
+postcomp-Arrow-map Q F = mk-amap (top ∘_) (bot ∘_) (funext→ ∘ (comm ▸h_)) where
   open Arrow-map F
 
 
@@ -292,7 +292,7 @@ precomp-Arrow-map
     → (Q : Type 𝓠)
     → Arrow-map f g
     → Arrow-map (precomp Q g) (precomp Q f)
-precomp-Arrow-map Q F = mk-amap (_∘ bot) (_∘ top) (funext→ ∘ (_◂ (comm h⁻¹))) where
+precomp-Arrow-map Q F = mk-amap (_∘ bot) (_∘ top) (funext→ ∘ (_◂h (comm h⁻¹))) where
   open Arrow-map F
 
 precomp-square-is-equiv

--- a/src/Core/ArrowRetracts.lagda.tree
+++ b/src/Core/ArrowRetracts.lagda.tree
@@ -75,8 +75,8 @@ module _
     = Σ[ G ∶ Arrow-map g f ]
       Σ[ lr ∶ retraction-witness (F .Arrow-map.top) (G .Arrow-map.top) ]
         Σ[ rr ∶ retraction-witness (F .Arrow-map.bot) (G .Arrow-map.bot) ]
-          ((bot G) ◂ (comm F) ∙h (comm G) ▸ (top F) ∙h f ◂ lr
-          ~ (rr ▸ f))
+          ((bot G) ◂h (comm F) ∙h (comm G) ▸h (top F) ∙h f ◂h lr
+          ~ (rr ▸h f))
     where open Arrow-map
 
   retraction-arrow-map-is-retraction
@@ -119,14 +119,14 @@ precomp-retraction-square F (G , _) .fst = precomp-square F _
 precomp-retraction-square F (G , tr , br , _) .snd .fst a = ap (a ∘_) (funext→ br)
 precomp-retraction-square F (G , tr , _) .snd .snd .fst a = ap (a ∘_) (funext→ tr)
 precomp-retraction-square {f = f} F (G , lr , rr , coh) .snd .snd .snd j
-  = ap (_∘ _) (funext→ (j ◂ (Arrow-map.comm G h⁻¹)))
-  ∙ funext→ (Arrow-map.top (precomp-square G _) j  ◂ (Arrow-map.comm F h⁻¹))
+  = ap (_∘ _) (funext→ (j ◂h (Arrow-map.comm G h⁻¹)))
+  ∙ funext→ (Arrow-map.top (precomp-square G _) j  ◂h (Arrow-map.comm F h⁻¹))
   ∙ ap (_∘ f) (ap (j ∘_) (funext→ rr))
       ＝⟨ ap₃ (λ p q r → p ∙ q ∙ r) (sym (commutes-prewhisker-funext _)) refl
                       (ap (ap (_∘ f)) (sym (commutes-postwhisker-funext _))
                         ∙ sym (commutes-prewhisker-funext _)) ⟩
-   funext→ (postwhisker j _ _ ((Arrow-map.comm G h⁻¹) ▸ Arrow-map.top F))
- ∙ funext→ ((Arrow-map.top (precomp-square G _) j  ◂ (Arrow-map.comm F h⁻¹)))
+   funext→ (postwhisker j _ _ ((Arrow-map.comm G h⁻¹) ▸h Arrow-map.top F))
+ ∙ funext→ ((Arrow-map.top (precomp-square G _) j  ◂h (Arrow-map.comm F h⁻¹)))
  ∙ funext→ (prewhisker f (j ∘ Arrow-map.bot G ∘ Arrow-map.bot F) j
              (postwhisker j (Arrow-map.bot G ∘ Arrow-map.bot F) id
                rr))
@@ -215,8 +215,8 @@ module _
 
     qinv : quasi-inv f
     qinv .fst = top G ∘ e.bwd ∘ bot F
-    qinv .snd .fst = (top G ∘ e.bwd) ◂ comm F ∙h top G ◂ e.η ▸ top F ∙h tr
-    qinv .snd .snd = (comm G ▸ e.bwd ▸ bot F) h⁻¹ ∙h bot G ◂ e.ε ▸ bot F ∙h br
+    qinv .snd .fst = (top G ∘ e.bwd) ◂h comm F ∙h top G ◂h e.η ▸h top F ∙h tr
+    qinv .snd .snd = (comm G ▸h e.bwd ▸h bot F) h⁻¹ ∙h bot G ◂h e.ε ▸h bot F ∙h br
 
   is-equiv←retraction-equiv
     : (F : Arrow-map f g)

--- a/src/Core/ArrowRetracts.lagda.tree
+++ b/src/Core/ArrowRetracts.lagda.tree
@@ -75,7 +75,7 @@ module _
     = Σ[ G ∶ Arrow-map g f ]
       Σ[ lr ∶ retraction-witness (F .Arrow-map.top) (G .Arrow-map.top) ]
         Σ[ rr ∶ retraction-witness (F .Arrow-map.bot) (G .Arrow-map.bot) ]
-          ((bot G) ◂h (comm F) ∙h (comm G) ▸h (top F) ∙h f ◂h lr
+          ((bot G) ◃h (comm F) ∙h (comm G) ▸h (top F) ∙h f ◃h lr
           ~ (rr ▸h f))
     where open Arrow-map
 
@@ -119,14 +119,14 @@ precomp-retraction-square F (G , _) .fst = precomp-square F _
 precomp-retraction-square F (G , tr , br , _) .snd .fst a = ap (a ∘_) (funext→ br)
 precomp-retraction-square F (G , tr , _) .snd .snd .fst a = ap (a ∘_) (funext→ tr)
 precomp-retraction-square {f = f} F (G , lr , rr , coh) .snd .snd .snd j
-  = ap (_∘ _) (funext→ (j ◂h (Arrow-map.comm G h⁻¹)))
-  ∙ funext→ (Arrow-map.top (precomp-square G _) j  ◂h (Arrow-map.comm F h⁻¹))
+  = ap (_∘ _) (funext→ (j ◃h (Arrow-map.comm G h⁻¹)))
+  ∙ funext→ (Arrow-map.top (precomp-square G _) j  ◃h (Arrow-map.comm F h⁻¹))
   ∙ ap (_∘ f) (ap (j ∘_) (funext→ rr))
       ＝⟨ ap₃ (λ p q r → p ∙ q ∙ r) (sym (commutes-prewhisker-funext _)) refl
                       (ap (ap (_∘ f)) (sym (commutes-postwhisker-funext _))
                         ∙ sym (commutes-prewhisker-funext _)) ⟩
    funext→ (postwhisker j _ _ ((Arrow-map.comm G h⁻¹) ▸h Arrow-map.top F))
- ∙ funext→ ((Arrow-map.top (precomp-square G _) j  ◂h (Arrow-map.comm F h⁻¹)))
+ ∙ funext→ ((Arrow-map.top (precomp-square G _) j  ◃h (Arrow-map.comm F h⁻¹)))
  ∙ funext→ (prewhisker f (j ∘ Arrow-map.bot G ∘ Arrow-map.bot F) j
              (postwhisker j (Arrow-map.bot G ∘ Arrow-map.bot F) id
                rr))
@@ -215,8 +215,8 @@ module _
 
     qinv : quasi-inv f
     qinv .fst = top G ∘ e.bwd ∘ bot F
-    qinv .snd .fst = (top G ∘ e.bwd) ◂h comm F ∙h top G ◂h e.η ▸h top F ∙h tr
-    qinv .snd .snd = (comm G ▸h e.bwd ▸h bot F) h⁻¹ ∙h bot G ◂h e.ε ▸h bot F ∙h br
+    qinv .snd .fst = (top G ∘ e.bwd) ◃h comm F ∙h top G ◃h e.η ▸h top F ∙h tr
+    qinv .snd .snd = (comm G ▸h e.bwd ▸h bot F) h⁻¹ ∙h bot G ◃h e.ε ▸h bot F ∙h br
 
   is-equiv←retraction-equiv
     : (F : Arrow-map f g)

--- a/src/Core/ArrowRetracts.lagda.tree
+++ b/src/Core/ArrowRetracts.lagda.tree
@@ -75,8 +75,8 @@ module _
     = Σ[ G ∶ Arrow-map g f ]
       Σ[ lr ∶ retraction-witness (F .Arrow-map.top) (G .Arrow-map.top) ]
         Σ[ rr ∶ retraction-witness (F .Arrow-map.bot) (G .Arrow-map.bot) ]
-          ((bot G) ◃h (comm F) ∙h (comm G) ▸h (top F) ∙h f ◃h lr
-          ~ (rr ▸h f))
+          ((bot G) ◃h (comm F) ∙h (comm G) ▹h (top F) ∙h f ◃h lr
+          ~ (rr ▹h f))
     where open Arrow-map
 
   retraction-arrow-map-is-retraction
@@ -125,7 +125,7 @@ precomp-retraction-square {f = f} F (G , lr , rr , coh) .snd .snd .snd j
       ＝⟨ ap₃ (λ p q r → p ∙ q ∙ r) (sym (commutes-prewhisker-funext _)) refl
                       (ap (ap (_∘ f)) (sym (commutes-postwhisker-funext _))
                         ∙ sym (commutes-prewhisker-funext _)) ⟩
-   funext→ (postwhisker j _ _ ((Arrow-map.comm G h⁻¹) ▸h Arrow-map.top F))
+   funext→ (postwhisker j _ _ ((Arrow-map.comm G h⁻¹) ▹h Arrow-map.top F))
  ∙ funext→ ((Arrow-map.top (precomp-square G _) j  ◃h (Arrow-map.comm F h⁻¹)))
  ∙ funext→ (prewhisker f (j ∘ Arrow-map.bot G ∘ Arrow-map.bot F) j
              (postwhisker j (Arrow-map.bot G ∘ Arrow-map.bot F) id
@@ -215,8 +215,8 @@ module _
 
     qinv : quasi-inv f
     qinv .fst = top G ∘ e.bwd ∘ bot F
-    qinv .snd .fst = (top G ∘ e.bwd) ◃h comm F ∙h top G ◃h e.η ▸h top F ∙h tr
-    qinv .snd .snd = (comm G ▸h e.bwd ▸h bot F) h⁻¹ ∙h bot G ◃h e.ε ▸h bot F ∙h br
+    qinv .snd .fst = (top G ∘ e.bwd) ◃h comm F ∙h top G ◃h e.η ▹h top F ∙h tr
+    qinv .snd .snd = (comm G ▹h e.bwd ▹h bot F) h⁻¹ ∙h bot G ◃h e.ε ▹h bot F ∙h br
 
   is-equiv←retraction-equiv
     : (F : Arrow-map f g)

--- a/src/Core/Arrows.lagda.tree
+++ b/src/Core/Arrows.lagda.tree
@@ -220,7 +220,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
   Arrow-map-path : ∀ (G H : Arrow-map f f') → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓛)
   Arrow-map-path (mk-amap t b H) (mk-amap t' b' H')
     = Σ[ p ∶ t ~ t' ] Σ[ q ∶ b ~ b' ]
-      (H ∙h (f' ◂h p) ~ q ▸h f ∙h H')
+      (H ∙h (f' ◃h p) ~ q ▸h f ∙h H')
 
   Arrow-map-path-refl : {G : Arrow-map f f'} → Arrow-map-path G G
   Arrow-map-path-refl = ~refl , ~refl , ∙h-reflr _
@@ -285,7 +285,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
     → Arrow-map f f'
     → Arrow-map f f''
   paste-squares (mk-amap g' h' comm') (mk-amap g h comm)
-    = mk-amap (g' ∘ g) (h' ∘ h) (h' ◂h comm ∙h comm' ▸h g)
+    = mk-amap (g' ∘ g) (h' ∘ h) (h' ◃h comm ∙h comm' ▸h g)
 }
 }
 
@@ -461,7 +461,7 @@ precomp-square
       (g : Arrow-map f f')
     → ∀ {𝓛} (C : Type 𝓛) → Arrow-map (precomp C f') (precomp C f)
 precomp-square (mk-amap top bot p) C
- = mk-amap (_∘ bot) (_∘ top) λ f → funext→ (f ◂h (p h⁻¹))
+ = mk-amap (_∘ bot) (_∘ top) λ f → funext→ (f ◃h (p h⁻¹))
 
 postcomp-square
   : ∀ {𝓤 𝓥 𝓦 𝓜}

--- a/src/Core/Arrows.lagda.tree
+++ b/src/Core/Arrows.lagda.tree
@@ -220,7 +220,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
   Arrow-map-path : ∀ (G H : Arrow-map f f') → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓛)
   Arrow-map-path (mk-amap t b H) (mk-amap t' b' H')
     = Σ[ p ∶ t ~ t' ] Σ[ q ∶ b ~ b' ]
-      (H ∙h (f' ◃h p) ~ q ▸h f ∙h H')
+      (H ∙h (f' ◃h p) ~ q ▹h f ∙h H')
 
   Arrow-map-path-refl : {G : Arrow-map f f'} → Arrow-map-path G G
   Arrow-map-path-refl = ~refl , ~refl , ∙h-reflr _
@@ -285,7 +285,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
     → Arrow-map f f'
     → Arrow-map f f''
   paste-squares (mk-amap g' h' comm') (mk-amap g h comm)
-    = mk-amap (g' ∘ g) (h' ∘ h) (h' ◃h comm ∙h comm' ▸h g)
+    = mk-amap (g' ∘ g) (h' ∘ h) (h' ◃h comm ∙h comm' ▹h g)
 }
 }
 
@@ -470,7 +470,7 @@ postcomp-square
       (g : Arrow-map f f')
     → ∀ {𝓛} (C : Type 𝓛) → Arrow-map (postcomp C f) (postcomp C f')
 postcomp-square (mk-amap top bot p) C
-  = mk-amap (top ∘_) (bot ∘_) λ f → funext→ (p ▸h f)
+  = mk-amap (top ∘_) (bot ∘_) λ f → funext→ (p ▹h f)
 }
 }
 

--- a/src/Core/Arrows.lagda.tree
+++ b/src/Core/Arrows.lagda.tree
@@ -220,7 +220,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
   Arrow-map-path : ∀ (G H : Arrow-map f f') → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓛)
   Arrow-map-path (mk-amap t b H) (mk-amap t' b' H')
     = Σ[ p ∶ t ~ t' ] Σ[ q ∶ b ~ b' ]
-      (H ∙h (f' ◂ p) ~ q ▸ f ∙h H')
+      (H ∙h (f' ◂h p) ~ q ▸h f ∙h H')
 
   Arrow-map-path-refl : {G : Arrow-map f f'} → Arrow-map-path G G
   Arrow-map-path-refl = ~refl , ~refl , ∙h-reflr _
@@ -285,7 +285,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
     → Arrow-map f f'
     → Arrow-map f f''
   paste-squares (mk-amap g' h' comm') (mk-amap g h comm)
-    = mk-amap (g' ∘ g) (h' ∘ h) (h' ◂ comm ∙h comm' ▸ g)
+    = mk-amap (g' ∘ g) (h' ∘ h) (h' ◂h comm ∙h comm' ▸h g)
 }
 }
 
@@ -461,7 +461,7 @@ precomp-square
       (g : Arrow-map f f')
     → ∀ {𝓛} (C : Type 𝓛) → Arrow-map (precomp C f') (precomp C f)
 precomp-square (mk-amap top bot p) C
- = mk-amap (_∘ bot) (_∘ top) λ f → funext→ (f ◂ (p h⁻¹))
+ = mk-amap (_∘ bot) (_∘ top) λ f → funext→ (f ◂h (p h⁻¹))
 
 postcomp-square
   : ∀ {𝓤 𝓥 𝓦 𝓜}
@@ -470,7 +470,7 @@ postcomp-square
       (g : Arrow-map f f')
     → ∀ {𝓛} (C : Type 𝓛) → Arrow-map (postcomp C f) (postcomp C f')
 postcomp-square (mk-amap top bot p) C
-  = mk-amap (top ∘_) (bot ∘_) λ f → funext→ (p ▸ f)
+  = mk-amap (top ∘_) (bot ∘_) λ f → funext→ (p ▸h f)
 }
 }
 

--- a/src/Core/CanonicalPushouts.lagda.tree
+++ b/src/Core/CanonicalPushouts.lagda.tree
@@ -61,7 +61,7 @@ module _
       → let open Cocone C
         in (H : F' ∘ ι₁ ~ p)
         →  (K : F' ∘ ι₂ ~ q)
-        →  (M : F' ◂ glue ∙h K ▸ g ~ H ▸ f ∙h filler)
+        →  (M : F' ◂h glue ∙h K ▸h g ~ H ▸h f ∙h filler)
         → F' ~ pushout-rec C
   pushout-rec-unique CC F' H K M
     = pushout-ind _
@@ -293,7 +293,7 @@ precomp-cone
     → Cone (precomp-cospan S Q) (D → Q)
 precomp-cone (mk-cocone p q filler) Q
   = mk-cone  (precomp Q p) (precomp Q q)
-             (λ f → (funext→ (f ◂ filler)))
+             (λ f → (funext→ (f ◂h filler)))
 
 precomp-cone'
   : ∀ {𝓤 𝓥 𝓦} {S : Span 𝓤 𝓥 𝓦}
@@ -303,7 +303,7 @@ precomp-cone'
     → Cone (precomp-cospan' S Q) (D → Q)
 precomp-cone' (mk-cocone p q filler) Q
   = mk-cone  (precomp Q q) (precomp Q p)
-             (λ f → (funext→ (f ◂ sym ∘ filler)))
+             (λ f → (funext→ (f ◂h sym ∘ filler)))
 
 up-pushout←precomp-pullback
   : ∀ {𝓤 𝓥 𝓦 𝓜} {S : Span 𝓤 𝓥 𝓦} {D : Type 𝓜}
@@ -427,12 +427,12 @@ module _
   Pushout-assoc→
     : Pushout f (ι₁ {f = h} {i} ∘ g) → Pushout (ι₂ {f = f} {g} ∘ h) i
   Pushout-assoc→
-    = cogap (mk-cocone (ι₁ ∘ ι₁) (cogap (mk-cocone (ι₁ ∘ ι₂) ι₂ glue)) (ι₁ ◂ glue))
+    = cogap (mk-cocone (ι₁ ∘ ι₁) (cogap (mk-cocone (ι₁ ∘ ι₂) ι₂ glue)) (ι₁ ◂h glue))
 
   Pushout-assoc←
     : Pushout (ι₂ {f = f} {g} ∘ h) i → Pushout f (ι₁ {f = h} {i} ∘ g)
   Pushout-assoc←
-    = cogap (mk-cocone (cogap (mk-cocone ι₁ (ι₂ ∘ ι₁) glue)) (ι₂ ∘ ι₂) (ι₂ ◂ glue))
+    = cogap (mk-cocone (cogap (mk-cocone ι₁ (ι₂ ∘ ι₁) glue)) (ι₂ ∘ ι₂) (ι₂ ◂h glue))
 
   Pushout-assoc→-qinv
     : quasi-inv Pushout-assoc→

--- a/src/Core/CanonicalPushouts.lagda.tree
+++ b/src/Core/CanonicalPushouts.lagda.tree
@@ -61,7 +61,7 @@ module _
       → let open Cocone C
         in (H : F' ∘ ι₁ ~ p)
         →  (K : F' ∘ ι₂ ~ q)
-        →  (M : F' ◃h glue ∙h K ▸h g ~ H ▸h f ∙h filler)
+        →  (M : F' ◃h glue ∙h K ▹h g ~ H ▹h f ∙h filler)
         → F' ~ pushout-rec C
   pushout-rec-unique CC F' H K M
     = pushout-ind _

--- a/src/Core/CanonicalPushouts.lagda.tree
+++ b/src/Core/CanonicalPushouts.lagda.tree
@@ -61,7 +61,7 @@ module _
       → let open Cocone C
         in (H : F' ∘ ι₁ ~ p)
         →  (K : F' ∘ ι₂ ~ q)
-        →  (M : F' ◂h glue ∙h K ▸h g ~ H ▸h f ∙h filler)
+        →  (M : F' ◃h glue ∙h K ▸h g ~ H ▸h f ∙h filler)
         → F' ~ pushout-rec C
   pushout-rec-unique CC F' H K M
     = pushout-ind _
@@ -293,7 +293,7 @@ precomp-cone
     → Cone (precomp-cospan S Q) (D → Q)
 precomp-cone (mk-cocone p q filler) Q
   = mk-cone  (precomp Q p) (precomp Q q)
-             (λ f → (funext→ (f ◂h filler)))
+             (λ f → (funext→ (f ◃h filler)))
 
 precomp-cone'
   : ∀ {𝓤 𝓥 𝓦} {S : Span 𝓤 𝓥 𝓦}
@@ -303,7 +303,7 @@ precomp-cone'
     → Cone (precomp-cospan' S Q) (D → Q)
 precomp-cone' (mk-cocone p q filler) Q
   = mk-cone  (precomp Q q) (precomp Q p)
-             (λ f → (funext→ (f ◂h sym ∘ filler)))
+             (λ f → (funext→ (f ◃h sym ∘ filler)))
 
 up-pushout←precomp-pullback
   : ∀ {𝓤 𝓥 𝓦 𝓜} {S : Span 𝓤 𝓥 𝓦} {D : Type 𝓜}
@@ -427,12 +427,12 @@ module _
   Pushout-assoc→
     : Pushout f (ι₁ {f = h} {i} ∘ g) → Pushout (ι₂ {f = f} {g} ∘ h) i
   Pushout-assoc→
-    = cogap (mk-cocone (ι₁ ∘ ι₁) (cogap (mk-cocone (ι₁ ∘ ι₂) ι₂ glue)) (ι₁ ◂h glue))
+    = cogap (mk-cocone (ι₁ ∘ ι₁) (cogap (mk-cocone (ι₁ ∘ ι₂) ι₂ glue)) (ι₁ ◃h glue))
 
   Pushout-assoc←
     : Pushout (ι₂ {f = f} {g} ∘ h) i → Pushout f (ι₁ {f = h} {i} ∘ g)
   Pushout-assoc←
-    = cogap (mk-cocone (cogap (mk-cocone ι₁ (ι₂ ∘ ι₁) glue)) (ι₂ ∘ ι₂) (ι₂ ◂h glue))
+    = cogap (mk-cocone (cogap (mk-cocone ι₁ (ι₂ ∘ ι₁) glue)) (ι₂ ∘ ι₂) (ι₂ ◃h glue))
 
   Pushout-assoc→-qinv
     : quasi-inv Pushout-assoc→

--- a/src/Core/CanonicalSequentialColimits.lagda.tree
+++ b/src/Core/CanonicalSequentialColimits.lagda.tree
@@ -63,13 +63,13 @@ glue-n
   : ∀ {𝓤} (S : Cotower 𝓤) n
     → ι-cotower S {0} ~ ι-cotower S {n} ∘ Cotower.incrℕ S n
 glue-n S zero = ~refl
-glue-n S (suc n) = glue-n S n ∙h glue-suc S ▸ Cotower.incrℕ S n
+glue-n S (suc n) = glue-n S n ∙h glue-suc S ▸h Cotower.incrℕ S n
 
 glue-+
   : ∀ {𝓤} (S : Cotower 𝓤) {n} m
     → ι-cotower S {n} ~ ι-cotower S {n +ℕ m} ∘ Cotower.incr-+ S m
 glue-+ S zero = ~refl
-glue-+ S (suc m) = glue-+ S m ∙h glue-suc S ▸ Cotower.incr-+ S m
+glue-+ S (suc m) = glue-+ S m ∙h glue-suc S ▸h Cotower.incr-+ S m
 }
 }
 
@@ -191,7 +191,7 @@ seq-colimit-map {S = S} {S'} F = seq-colim-rec cc module seq-colim-map where
 
   cc : Seq-cocone _ (Seq-colimit _)
   cc .Seq-cocone.ι = ι-cotower S' ∘ map
-  cc .Seq-cocone.comm = glue-suc S' ▸ map ∙h ι-cotower S' ◂ comm
+  cc .Seq-cocone.comm = glue-suc S' ▸h map ∙h ι-cotower S' ◂h comm
 
 ap-seq-colimit-map-glue-suc
   : ∀ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
@@ -235,15 +235,15 @@ seq-colimit-map-id {S = S} = seq-colimit-rec~ H where
        (seq-cocone-map _ id)
   H .fst = ~refl
   H .snd {n}
-    = {- (seq-colimit-map id-cotower-map) ◂ (seq-incr S)
-          ∙h ~refl ▸ incr S        ~⟨⟩ -}
-      (seq-colimit-map id-cotower-map) ◂ (glue-suc S) ∙h ~refl
+    = {- (seq-colimit-map id-cotower-map) ◂h (seq-incr S)
+          ∙h ~refl ▸h incr S        ~⟨⟩ -}
+      (seq-colimit-map id-cotower-map) ◂h (glue-suc S) ∙h ~refl
                           ~⟨ ∙h-reflr _ ⟩
-      (seq-colimit-map id-cotower-map) ◂ (glue-suc S)
+      (seq-colimit-map id-cotower-map) ◂h (glue-suc S)
                           ~⟨ ap-seq-colimit-map-glue-suc id-cotower-map ⟩
       glue-suc S ∙h ~refl ~⟨ ∙h-reflr _ ⟩
       glue-suc S          ~⟨ sym ∘ ap-id ∘ glue-suc S ⟩
-      id ◂ glue-suc S     ~∎
+      id ◂h glue-suc S     ~∎
 
 seq-colimit-map∘
   : ∀ {𝓤 𝓥 𝓦} {S : Cotower 𝓤} {S' : Cotower 𝓥}

--- a/src/Core/CanonicalSequentialColimits.lagda.tree
+++ b/src/Core/CanonicalSequentialColimits.lagda.tree
@@ -191,7 +191,7 @@ seq-colimit-map {S = S} {S'} F = seq-colim-rec cc module seq-colim-map where
 
   cc : Seq-cocone _ (Seq-colimit _)
   cc .Seq-cocone.ι = ι-cotower S' ∘ map
-  cc .Seq-cocone.comm = glue-suc S' ▸h map ∙h ι-cotower S' ◂h comm
+  cc .Seq-cocone.comm = glue-suc S' ▸h map ∙h ι-cotower S' ◃h comm
 
 ap-seq-colimit-map-glue-suc
   : ∀ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
@@ -235,15 +235,15 @@ seq-colimit-map-id {S = S} = seq-colimit-rec~ H where
        (seq-cocone-map _ id)
   H .fst = ~refl
   H .snd {n}
-    = {- (seq-colimit-map id-cotower-map) ◂h (seq-incr S)
+    = {- (seq-colimit-map id-cotower-map) ◃h (seq-incr S)
           ∙h ~refl ▸h incr S        ~⟨⟩ -}
-      (seq-colimit-map id-cotower-map) ◂h (glue-suc S) ∙h ~refl
+      (seq-colimit-map id-cotower-map) ◃h (glue-suc S) ∙h ~refl
                           ~⟨ ∙h-reflr _ ⟩
-      (seq-colimit-map id-cotower-map) ◂h (glue-suc S)
+      (seq-colimit-map id-cotower-map) ◃h (glue-suc S)
                           ~⟨ ap-seq-colimit-map-glue-suc id-cotower-map ⟩
       glue-suc S ∙h ~refl ~⟨ ∙h-reflr _ ⟩
       glue-suc S          ~⟨ sym ∘ ap-id ∘ glue-suc S ⟩
-      id ◂h glue-suc S     ~∎
+      id ◃h glue-suc S     ~∎
 
 seq-colimit-map∘
   : ∀ {𝓤 𝓥 𝓦} {S : Cotower 𝓤} {S' : Cotower 𝓥}

--- a/src/Core/CanonicalSequentialColimits.lagda.tree
+++ b/src/Core/CanonicalSequentialColimits.lagda.tree
@@ -63,13 +63,13 @@ glue-n
   : ∀ {𝓤} (S : Cotower 𝓤) n
     → ι-cotower S {0} ~ ι-cotower S {n} ∘ Cotower.incrℕ S n
 glue-n S zero = ~refl
-glue-n S (suc n) = glue-n S n ∙h glue-suc S ▸h Cotower.incrℕ S n
+glue-n S (suc n) = glue-n S n ∙h glue-suc S ▹h Cotower.incrℕ S n
 
 glue-+
   : ∀ {𝓤} (S : Cotower 𝓤) {n} m
     → ι-cotower S {n} ~ ι-cotower S {n +ℕ m} ∘ Cotower.incr-+ S m
 glue-+ S zero = ~refl
-glue-+ S (suc m) = glue-+ S m ∙h glue-suc S ▸h Cotower.incr-+ S m
+glue-+ S (suc m) = glue-+ S m ∙h glue-suc S ▹h Cotower.incr-+ S m
 }
 }
 
@@ -191,7 +191,7 @@ seq-colimit-map {S = S} {S'} F = seq-colim-rec cc module seq-colim-map where
 
   cc : Seq-cocone _ (Seq-colimit _)
   cc .Seq-cocone.ι = ι-cotower S' ∘ map
-  cc .Seq-cocone.comm = glue-suc S' ▸h map ∙h ι-cotower S' ◃h comm
+  cc .Seq-cocone.comm = glue-suc S' ▹h map ∙h ι-cotower S' ◃h comm
 
 ap-seq-colimit-map-glue-suc
   : ∀ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
@@ -236,7 +236,7 @@ seq-colimit-map-id {S = S} = seq-colimit-rec~ H where
   H .fst = ~refl
   H .snd {n}
     = {- (seq-colimit-map id-cotower-map) ◃h (seq-incr S)
-          ∙h ~refl ▸h incr S        ~⟨⟩ -}
+          ∙h ~refl ▹h incr S        ~⟨⟩ -}
       (seq-colimit-map id-cotower-map) ◃h (glue-suc S) ∙h ~refl
                           ~⟨ ∙h-reflr _ ⟩
       (seq-colimit-map id-cotower-map) ◃h (glue-suc S)

--- a/src/Core/CocartesianSquares.lagda.tree
+++ b/src/Core/CocartesianSquares.lagda.tree
@@ -306,23 +306,23 @@ precomp-square-∘ {f = f} {g} {h} F G Q .snd .snd
        ~⟨ ∙h-reflr _ ⟩
    comm (paste-squares (precomp-square G Q) (precomp-square F Q))
        ~⟨⟩
-    (precomp Q (G .top) ◂h precomp-square F Q .comm
+    (precomp Q (G .top) ◃h precomp-square F Q .comm
     ∙h precomp-square G Q .comm ▸h precomp Q (F .bot))
        ~⟨⟩
-    (precomp Q (G .top) ◂h (funext→ ∘ (_◂h (comm F h⁻¹)))
-    ∙h (funext→ ∘ (_◂h (comm G h⁻¹))) ▸h precomp Q (F .bot))
+    (precomp Q (G .top) ◃h (funext→ ∘ (_◃h (comm F h⁻¹)))
+    ∙h (funext→ ∘ (_◃h (comm G h⁻¹))) ▸h precomp Q (F .bot))
        ~⟨ (λ a → ap (_∙ funext→ _)
-         (sym (commutes-prewhisker-funext (a ◂h (comm F h⁻¹))))
+         (sym (commutes-prewhisker-funext (a ◃h (comm F h⁻¹))))
          ∙ sym (funext-∙ _ _)) ⟩
-   funext→ ∘ (λ a → a ◂h (sym ∘ comm F ∘ top G) ∙h (a ∘ F .bot) ◂h (sym ∘ comm G))
+   funext→ ∘ (λ a → a ◃h (sym ∘ comm F ∘ top G) ∙h (a ∘ F .bot) ◃h (sym ∘ comm G))
        ~⟨ (λ a → ap funext→ (funext→ λ x
          → ap (ap a (sym (comm F _)) ∙_)
-             ( ◂h∘  a (bot F) (sym ∘ comm G) x)
+             ( ◃h∘  a (bot F) (sym ∘ comm G) x)
              ∙ sym (ap-∙ a (sym (comm F (top G x))) (ap (bot F) _))
              ∙ ap (ap a) (sym (∙-symsym (ap (bot F) (comm G x)) _
              ∙ ap (sym (comm F (top G x)) ∙_)
                   (sym (ap-sym (bot F) (comm G x))))))) ⟩
-   funext→ ∘ (λ a → a ◂h ((F .bot ◂h comm G ∙h comm F ▸h G .top) h⁻¹))
+   funext→ ∘ (λ a → a ◃h ((F .bot ◃h comm G ∙h comm F ▸h G .top) h⁻¹))
        ~⟨⟩
    comm (precomp-square (paste-squares F G) Q) ~∎ where open Arrow-map
 

--- a/src/Core/CocartesianSquares.lagda.tree
+++ b/src/Core/CocartesianSquares.lagda.tree
@@ -306,23 +306,23 @@ precomp-square-∘ {f = f} {g} {h} F G Q .snd .snd
        ~⟨ ∙h-reflr _ ⟩
    comm (paste-squares (precomp-square G Q) (precomp-square F Q))
        ~⟨⟩
-    (precomp Q (G .top) ◂ precomp-square F Q .comm
-    ∙h precomp-square G Q .comm ▸ precomp Q (F .bot))
+    (precomp Q (G .top) ◂h precomp-square F Q .comm
+    ∙h precomp-square G Q .comm ▸h precomp Q (F .bot))
        ~⟨⟩
-    (precomp Q (G .top) ◂ (funext→ ∘ (_◂ (comm F h⁻¹)))
-    ∙h (funext→ ∘ (_◂ (comm G h⁻¹))) ▸ precomp Q (F .bot))
+    (precomp Q (G .top) ◂h (funext→ ∘ (_◂h (comm F h⁻¹)))
+    ∙h (funext→ ∘ (_◂h (comm G h⁻¹))) ▸h precomp Q (F .bot))
        ~⟨ (λ a → ap (_∙ funext→ _)
-         (sym (commutes-prewhisker-funext (a ◂ (comm F h⁻¹))))
+         (sym (commutes-prewhisker-funext (a ◂h (comm F h⁻¹))))
          ∙ sym (funext-∙ _ _)) ⟩
-   funext→ ∘ (λ a → a ◂ (sym ∘ comm F ∘ top G) ∙h (a ∘ F .bot) ◂ (sym ∘ comm G))
+   funext→ ∘ (λ a → a ◂h (sym ∘ comm F ∘ top G) ∙h (a ∘ F .bot) ◂h (sym ∘ comm G))
        ~⟨ (λ a → ap funext→ (funext→ λ x
          → ap (ap a (sym (comm F _)) ∙_)
-             ( ◂∘  a (bot F) (sym ∘ comm G) x)
+             ( ◂h∘  a (bot F) (sym ∘ comm G) x)
              ∙ sym (ap-∙ a (sym (comm F (top G x))) (ap (bot F) _))
              ∙ ap (ap a) (sym (∙-symsym (ap (bot F) (comm G x)) _
              ∙ ap (sym (comm F (top G x)) ∙_)
                   (sym (ap-sym (bot F) (comm G x))))))) ⟩
-   funext→ ∘ (λ a → a ◂ ((F .bot ◂ comm G ∙h comm F ▸ G .top) h⁻¹))
+   funext→ ∘ (λ a → a ◂h ((F .bot ◂h comm G ∙h comm F ▸h G .top) h⁻¹))
        ~⟨⟩
    comm (precomp-square (paste-squares F G) Q) ~∎ where open Arrow-map
 

--- a/src/Core/CocartesianSquares.lagda.tree
+++ b/src/Core/CocartesianSquares.lagda.tree
@@ -307,10 +307,10 @@ precomp-square-∘ {f = f} {g} {h} F G Q .snd .snd
    comm (paste-squares (precomp-square G Q) (precomp-square F Q))
        ~⟨⟩
     (precomp Q (G .top) ◃h precomp-square F Q .comm
-    ∙h precomp-square G Q .comm ▸h precomp Q (F .bot))
+    ∙h precomp-square G Q .comm ▹h precomp Q (F .bot))
        ~⟨⟩
     (precomp Q (G .top) ◃h (funext→ ∘ (_◃h (comm F h⁻¹)))
-    ∙h (funext→ ∘ (_◃h (comm G h⁻¹))) ▸h precomp Q (F .bot))
+    ∙h (funext→ ∘ (_◃h (comm G h⁻¹))) ▹h precomp Q (F .bot))
        ~⟨ (λ a → ap (_∙ funext→ _)
          (sym (commutes-prewhisker-funext (a ◃h (comm F h⁻¹))))
          ∙ sym (funext-∙ _ _)) ⟩
@@ -322,7 +322,7 @@ precomp-square-∘ {f = f} {g} {h} F G Q .snd .snd
              ∙ ap (ap a) (sym (∙-symsym (ap (bot F) (comm G x)) _
              ∙ ap (sym (comm F (top G x)) ∙_)
                   (sym (ap-sym (bot F) (comm G x))))))) ⟩
-   funext→ ∘ (λ a → a ◃h ((F .bot ◃h comm G ∙h comm F ▸h G .top) h⁻¹))
+   funext→ ∘ (λ a → a ◃h ((F .bot ◃h comm G ∙h comm F ▹h G .top) h⁻¹))
        ~⟨⟩
    comm (precomp-square (paste-squares F G) Q) ~∎ where open Arrow-map
 

--- a/src/Core/Coequalisers.lagda.tree
+++ b/src/Core/Coequalisers.lagda.tree
@@ -44,7 +44,7 @@ cofork-map
     → {f g : A → B} → {C : Type 𝓦}
     → Cofork f g C → ∀ {𝓠} {Q : Type 𝓠}
     → (C → Q) → Cofork f g Q
-cofork-map (p , H) f = (f ∘ p , f ◂ H)
+cofork-map (p , H) f = (f ∘ p , f ◂h H)
 }
 
 \p{We use the abbreviation \code{up} for "universal property".}
@@ -157,7 +157,7 @@ coeq-has-up-coeq {f = f} {g} {Q = Q}
              (Pushout-has-up-pushout) where
   H : cocone←cofork ∘ cofork-map (coeq f g) {Q = Q}
     ~ cocone-map (Coeq.span f g) pushout
-  H k = Cocone-path→ _ _ (funext→ (k ◂ (glue h⁻¹) ▸ inl)) refl λ where
+  H k = Cocone-path→ _ _ (funext→ (k ◂h (glue h⁻¹) ▸h inl)) refl λ where
     (inl x) → sym ( ap (_∙ ap k (glue (inl x))) (ap-sym k (glue (inl x)))
                   ∙ ∙-sym' (ap k (glue _)))
             ∙ ap (_∙ ap k (glue (inl x)))
@@ -277,13 +277,13 @@ cocone≃forkᵈ
 cocone≃forkᵈ {B = B} {f} {g} {C}
   = Coforkᵈ f g C
       ≃⟨⟩
-    (Σ[ p ∶ (Π B (C ∘ ι₂))] ((p ∘ f) ~[ (C ◂ (coeq f g .snd)) ] (p ∘ g)))
+    (Σ[ p ∶ (Π B (C ∘ ι₂))] ((p ∘ f) ~[ (C ◂h (coeq f g .snd)) ] (p ∘ g)))
       ≃⟨ Σ-snd-≃ (λ p → Σ-＝singl') e⁻¹ ⟩
-    (Σ[ p q ∶ (Π B (C ∘ ι₂))] ((p ＝ q) × ((p ∘ f) ~[ C ◂ (coeq f g .snd) ] (q ∘ g))))
+    (Σ[ p q ∶ (Π B (C ∘ ι₂))] ((p ＝ q) × ((p ∘ f) ~[ C ◂h (coeq f g .snd) ] (q ∘ g))))
       ≃⟨ Σ-snd-≃ (λ p → Σ-snd-≃ (λ q → Σ-fst-≃ funext≃)) ⟩
-    (Σ[ p q ∶ Π B (C ∘ ι₂)] ((p ~ q) × ((p ∘ f) ~[ C ◂ (coeq f g .snd) ] (q ∘ g))))
+    (Σ[ p q ∶ Π B (C ∘ ι₂)] ((p ~ q) × ((p ∘ f) ~[ C ◂h (coeq f g .snd) ] (q ∘ g))))
       ≃⟨ Σ-snd-≃ (λ p → Σ-snd-≃ (λ q → ⊎-UP≃ global-funext)) ⟩
-    (Σ[ p q ∶ Π B (C ∘ ι₂)] ((p ∘ Coeq.l f g) ~[ (C ◂ ⊎-ind (~refl , coeq f g .snd)) ] (q ∘ Coeq.r f g)))
+    (Σ[ p q ∶ Π B (C ∘ ι₂)] ((p ∘ Coeq.l f g) ~[ (C ◂h ⊎-ind (~refl , coeq f g .snd)) ] (q ∘ Coeq.r f g)))
       ≃⟨ coconeD-repr≃ e⁻¹ ⟩
     Coconeᵈ (Coeq.span f g) _ C ≃∎
 
@@ -431,7 +431,7 @@ postcomp-cofork
       (h : A' → A) {D : Type 𝓛}
     → Cofork f g D
     → Cofork (f ∘ h) (g ∘ h) D
-postcomp-cofork _ _ h = total-map λ f → _▸ h
+postcomp-cofork _ _ h = total-map λ f → _▸h h
 
 
 postcomp-cofork-is-equiv

--- a/src/Core/Coequalisers.lagda.tree
+++ b/src/Core/Coequalisers.lagda.tree
@@ -157,7 +157,7 @@ coeq-has-up-coeq {f = f} {g} {Q = Q}
              (Pushout-has-up-pushout) where
   H : cocone←cofork ∘ cofork-map (coeq f g) {Q = Q}
     ~ cocone-map (Coeq.span f g) pushout
-  H k = Cocone-path→ _ _ (funext→ (k ◃h (glue h⁻¹) ▸h inl)) refl λ where
+  H k = Cocone-path→ _ _ (funext→ (k ◃h (glue h⁻¹) ▹h inl)) refl λ where
     (inl x) → sym ( ap (_∙ ap k (glue (inl x))) (ap-sym k (glue (inl x)))
                   ∙ ∙-sym' (ap k (glue _)))
             ∙ ap (_∙ ap k (glue (inl x)))
@@ -431,7 +431,7 @@ postcomp-cofork
       (h : A' → A) {D : Type 𝓛}
     → Cofork f g D
     → Cofork (f ∘ h) (g ∘ h) D
-postcomp-cofork _ _ h = total-map λ f → _▸h h
+postcomp-cofork _ _ h = total-map λ f → _▹h h
 
 
 postcomp-cofork-is-equiv

--- a/src/Core/Coequalisers.lagda.tree
+++ b/src/Core/Coequalisers.lagda.tree
@@ -44,7 +44,7 @@ cofork-map
     → {f g : A → B} → {C : Type 𝓦}
     → Cofork f g C → ∀ {𝓠} {Q : Type 𝓠}
     → (C → Q) → Cofork f g Q
-cofork-map (p , H) f = (f ∘ p , f ◂h H)
+cofork-map (p , H) f = (f ∘ p , f ◃h H)
 }
 
 \p{We use the abbreviation \code{up} for "universal property".}
@@ -157,7 +157,7 @@ coeq-has-up-coeq {f = f} {g} {Q = Q}
              (Pushout-has-up-pushout) where
   H : cocone←cofork ∘ cofork-map (coeq f g) {Q = Q}
     ~ cocone-map (Coeq.span f g) pushout
-  H k = Cocone-path→ _ _ (funext→ (k ◂h (glue h⁻¹) ▸h inl)) refl λ where
+  H k = Cocone-path→ _ _ (funext→ (k ◃h (glue h⁻¹) ▸h inl)) refl λ where
     (inl x) → sym ( ap (_∙ ap k (glue (inl x))) (ap-sym k (glue (inl x)))
                   ∙ ∙-sym' (ap k (glue _)))
             ∙ ap (_∙ ap k (glue (inl x)))
@@ -277,13 +277,13 @@ cocone≃forkᵈ
 cocone≃forkᵈ {B = B} {f} {g} {C}
   = Coforkᵈ f g C
       ≃⟨⟩
-    (Σ[ p ∶ (Π B (C ∘ ι₂))] ((p ∘ f) ~[ (C ◂h (coeq f g .snd)) ] (p ∘ g)))
+    (Σ[ p ∶ (Π B (C ∘ ι₂))] ((p ∘ f) ~[ (C ◃h (coeq f g .snd)) ] (p ∘ g)))
       ≃⟨ Σ-snd-≃ (λ p → Σ-＝singl') e⁻¹ ⟩
-    (Σ[ p q ∶ (Π B (C ∘ ι₂))] ((p ＝ q) × ((p ∘ f) ~[ C ◂h (coeq f g .snd) ] (q ∘ g))))
+    (Σ[ p q ∶ (Π B (C ∘ ι₂))] ((p ＝ q) × ((p ∘ f) ~[ C ◃h (coeq f g .snd) ] (q ∘ g))))
       ≃⟨ Σ-snd-≃ (λ p → Σ-snd-≃ (λ q → Σ-fst-≃ funext≃)) ⟩
-    (Σ[ p q ∶ Π B (C ∘ ι₂)] ((p ~ q) × ((p ∘ f) ~[ C ◂h (coeq f g .snd) ] (q ∘ g))))
+    (Σ[ p q ∶ Π B (C ∘ ι₂)] ((p ~ q) × ((p ∘ f) ~[ C ◃h (coeq f g .snd) ] (q ∘ g))))
       ≃⟨ Σ-snd-≃ (λ p → Σ-snd-≃ (λ q → ⊎-UP≃ global-funext)) ⟩
-    (Σ[ p q ∶ Π B (C ∘ ι₂)] ((p ∘ Coeq.l f g) ~[ (C ◂h ⊎-ind (~refl , coeq f g .snd)) ] (q ∘ Coeq.r f g)))
+    (Σ[ p q ∶ Π B (C ∘ ι₂)] ((p ∘ Coeq.l f g) ~[ (C ◃h ⊎-ind (~refl , coeq f g .snd)) ] (q ∘ Coeq.r f g)))
       ≃⟨ coconeD-repr≃ e⁻¹ ⟩
     Coconeᵈ (Coeq.span f g) _ C ≃∎
 

--- a/src/Core/Coslices.lagda.tree
+++ b/src/Core/Coslices.lagda.tree
@@ -65,7 +65,7 @@ Coslice-map-precompose r F G = Coslice-map-∘ _ _ r G F
 Coslice-map-path
  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {X : Type 𝓥} {p : A → X}
      {Y : Type 𝓦} {q : A → Y} → (f g : Coslice-map p q) → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦)
-Coslice-map-path {p = p} (f , H) (g , K) = Σ[ P ∶ f ~ g ] (P ▸h p ∙h K ~ H)
+Coslice-map-path {p = p} (f , H) (g , K) = Σ[ P ∶ f ~ g ] (P ▹h p ∙h K ~ H)
 
 Coslice-map-path-refl
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {X : Type 𝓥} {p : A → X}
@@ -98,7 +98,7 @@ extend-coslice-map
   : ∀ {𝓤 𝓥 𝓦 𝓧} {P : Type 𝓤} {Q : Type 𝓥} {A : Type 𝓦} {B : Type 𝓧}
       (p : A → P) (q : A → Q) (f : B → A)
     → Coslice-map p q → Coslice-map (p ∘ f) (q ∘ f)
-extend-coslice-map p q f = total-map (λ _ → _▸h f)
+extend-coslice-map p q f = total-map (λ _ → _▹h f)
 }
 }
 
@@ -169,7 +169,7 @@ sec←sec-Coslice-equiv
     → section p
     → section q
 sec←sec-Coslice-equiv (f , H) feq (ps , sp)
-  = section←~⁻¹ H ((ps ∘ f.bwd) , f ◃h sp ▸h f.bwd ∙h f.ε) where
+  = section←~⁻¹ H ((ps ∘ f.bwd) , f ◃h sp ▹h f.bwd ∙h f.ε) where
   module f = is-equiv feq
 
 
@@ -185,8 +185,8 @@ sec←sec-Coslice-equiv'
     → section q
     → section p
 sec←sec-Coslice-equiv' {p = p} (f , H) feq (ps , sp)
-  = section←~ (((f.η ▸h p) h⁻¹) ∙h f.bwd ◃h H)
-             ((ps ∘ f) , f.bwd ◃h sp ▸h f ∙h f.η) where
+  = section←~ (((f.η ▹h p) h⁻¹) ∙h f.bwd ◃h H)
+             ((ps ∘ f) , f.bwd ◃h sp ▹h f ∙h f.η) where
   module f = is-equiv feq
 
 equiv←Coslice-equiv

--- a/src/Core/Coslices.lagda.tree
+++ b/src/Core/Coslices.lagda.tree
@@ -48,7 +48,7 @@ Coslice-map-∘
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {X : Type 𝓥} {Y : Type 𝓦} {Z : Type 𝓜}
       (p : A → X) (q : A → Y) (r : A → Z)
     → Coslice-map q r → Coslice-map p q → Coslice-map p r
-Coslice-map-∘ p q r (f , H) (g , K) = (f ∘ g , f ◂ K ∙h H)
+Coslice-map-∘ p q r (f , H) (g , K) = (f ∘ g , f ◂h K ∙h H)
 
 Coslice-map-postcompose
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {X : Type 𝓥} {Y : Type 𝓦} {Z : Type 𝓜}
@@ -65,7 +65,7 @@ Coslice-map-precompose r F G = Coslice-map-∘ _ _ r G F
 Coslice-map-path
  : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {X : Type 𝓥} {p : A → X}
      {Y : Type 𝓦} {q : A → Y} → (f g : Coslice-map p q) → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦)
-Coslice-map-path {p = p} (f , H) (g , K) = Σ[ P ∶ f ~ g ] (P ▸ p ∙h K ~ H)
+Coslice-map-path {p = p} (f , H) (g , K) = Σ[ P ∶ f ~ g ] (P ▸h p ∙h K ~ H)
 
 Coslice-map-path-refl
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {X : Type 𝓥} {p : A → X}
@@ -98,7 +98,7 @@ extend-coslice-map
   : ∀ {𝓤 𝓥 𝓦 𝓧} {P : Type 𝓤} {Q : Type 𝓥} {A : Type 𝓦} {B : Type 𝓧}
       (p : A → P) (q : A → Q) (f : B → A)
     → Coslice-map p q → Coslice-map (p ∘ f) (q ∘ f)
-extend-coslice-map p q f = total-map (λ _ → _▸ f)
+extend-coslice-map p q f = total-map (λ _ → _▸h f)
 }
 }
 
@@ -169,7 +169,7 @@ sec←sec-Coslice-equiv
     → section p
     → section q
 sec←sec-Coslice-equiv (f , H) feq (ps , sp)
-  = section←~⁻¹ H ((ps ∘ f.bwd) , f ◂ sp ▸ f.bwd ∙h f.ε) where
+  = section←~⁻¹ H ((ps ∘ f.bwd) , f ◂h sp ▸h f.bwd ∙h f.ε) where
   module f = is-equiv feq
 
 
@@ -185,8 +185,8 @@ sec←sec-Coslice-equiv'
     → section q
     → section p
 sec←sec-Coslice-equiv' {p = p} (f , H) feq (ps , sp)
-  = section←~ (((f.η ▸ p) h⁻¹) ∙h f.bwd ◂ H)
-             ((ps ∘ f) , f.bwd ◂ sp ▸ f ∙h f.η) where
+  = section←~ (((f.η ▸h p) h⁻¹) ∙h f.bwd ◂h H)
+             ((ps ∘ f) , f.bwd ◂h sp ▸h f ∙h f.η) where
   module f = is-equiv feq
 
 equiv←Coslice-equiv

--- a/src/Core/Coslices.lagda.tree
+++ b/src/Core/Coslices.lagda.tree
@@ -48,7 +48,7 @@ Coslice-map-∘
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {X : Type 𝓥} {Y : Type 𝓦} {Z : Type 𝓜}
       (p : A → X) (q : A → Y) (r : A → Z)
     → Coslice-map q r → Coslice-map p q → Coslice-map p r
-Coslice-map-∘ p q r (f , H) (g , K) = (f ∘ g , f ◂h K ∙h H)
+Coslice-map-∘ p q r (f , H) (g , K) = (f ∘ g , f ◃h K ∙h H)
 
 Coslice-map-postcompose
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {X : Type 𝓥} {Y : Type 𝓦} {Z : Type 𝓜}
@@ -169,7 +169,7 @@ sec←sec-Coslice-equiv
     → section p
     → section q
 sec←sec-Coslice-equiv (f , H) feq (ps , sp)
-  = section←~⁻¹ H ((ps ∘ f.bwd) , f ◂h sp ▸h f.bwd ∙h f.ε) where
+  = section←~⁻¹ H ((ps ∘ f.bwd) , f ◃h sp ▸h f.bwd ∙h f.ε) where
   module f = is-equiv feq
 
 
@@ -185,8 +185,8 @@ sec←sec-Coslice-equiv'
     → section q
     → section p
 sec←sec-Coslice-equiv' {p = p} (f , H) feq (ps , sp)
-  = section←~ (((f.η ▸h p) h⁻¹) ∙h f.bwd ◂h H)
-             ((ps ∘ f) , f.bwd ◂h sp ▸h f ∙h f.η) where
+  = section←~ (((f.η ▸h p) h⁻¹) ∙h f.bwd ◃h H)
+             ((ps ∘ f) , f.bwd ◃h sp ▸h f ∙h f.η) where
   module f = is-equiv feq
 
 equiv←Coslice-equiv

--- a/src/Core/FibredJoin.lagda.tree
+++ b/src/Core/FibredJoin.lagda.tree
@@ -242,7 +242,7 @@ module _ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {A' : Type 𝓦} {B : Type 𝓥}
       map k .fst = pushout-rec (mk-cocone
         (k .fst)
         (φ.bwd  k .fst)
-        (iemb ◂emb (k .snd ▸h π₁ ∙h pbₑ.filler ∙h ((φ.bwd k .snd ▸h π₂) h⁻¹))))
+        (iemb ◂emb (k .snd ▹h π₁ ∙h pbₑ.filler ∙h ((φ.bwd k .snd ▹h π₂) h⁻¹))))
       map k .snd = pushout-ind _ (mk-coconeᵈ
         (k .snd)
         (φ.bwd k .snd)
@@ -568,7 +568,7 @@ we show that the sequence of iterated joins of fibres all factor through
 
       sm' : Slice-map (fst {B = fibre incl}) (fst {B = is-singleton ∘ fibre incl})
       sm' .fst = sm .fst ∘ total←total-fibre _
-      sm' .snd = sm .snd ▸h total←total-fibre incl ∙h (snd ∘ snd)
+      sm' .snd = sm .snd ▹h total←total-fibre incl ∙h (snd ∘ snd)
 
       lem
         : ∀ (b : B) (f : fibre incl b)

--- a/src/Core/FibredJoin.lagda.tree
+++ b/src/Core/FibredJoin.lagda.tree
@@ -242,7 +242,7 @@ module _ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {A' : Type 𝓦} {B : Type 𝓥}
       map k .fst = pushout-rec (mk-cocone
         (k .fst)
         (φ.bwd  k .fst)
-        (iemb ◂emb (k .snd ▸ π₁ ∙h pbₑ.filler ∙h ((φ.bwd k .snd ▸ π₂) h⁻¹))))
+        (iemb ◂emb (k .snd ▸h π₁ ∙h pbₑ.filler ∙h ((φ.bwd k .snd ▸h π₂) h⁻¹))))
       map k .snd = pushout-ind _ (mk-coconeᵈ
         (k .snd)
         (φ.bwd k .snd)
@@ -568,7 +568,7 @@ we show that the sequence of iterated joins of fibres all factor through
 
       sm' : Slice-map (fst {B = fibre incl}) (fst {B = is-singleton ∘ fibre incl})
       sm' .fst = sm .fst ∘ total←total-fibre _
-      sm' .snd = sm .snd ▸ total←total-fibre incl ∙h (snd ∘ snd)
+      sm' .snd = sm .snd ▸h total←total-fibre incl ∙h (snd ∘ snd)
 
       lem
         : ∀ (b : B) (f : fibre incl b)

--- a/src/Core/FunctorialityPullbacks.lagda.tree
+++ b/src/Core/FunctorialityPullbacks.lagda.tree
@@ -65,8 +65,8 @@ cospan-map-compose
 cospan-map-compose F G .h₁ = F .h₁ ∘ G .h₁
 cospan-map-compose F G .h₂ = F .h₂ ∘ G .h₂
 cospan-map-compose F G .h₃ = F .h₃ ∘ G .h₃
-cospan-map-compose F G .H  = F .h₂ ◂ G .H ∙h F .H ▸ G .h₁
-cospan-map-compose F G .K  = F .h₂ ◂ G .K ∙h F .K ▸ G .h₃
+cospan-map-compose F G .H  = F .h₂ ◂h G .H ∙h F .H ▸h G .h₁
+cospan-map-compose F G .K  = F .h₂ ◂h G .K ∙h F .K ▸h G .h₃
 
 id-cospan-map : ∀ {𝓤 𝓥 𝓦} {S : Cospan 𝓤 𝓥 𝓦} → Cospan-map S S
 id-cospan-map .h₁ = id
@@ -91,8 +91,8 @@ Cospan-map-homotopy
       (F G : Cospan-map S T) → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓤' ⊔ 𝓥' ⊔ 𝓦')
 Cospan-map-homotopy F G
   = Σ[ H₁ ∶ F.h₁ ~ G.h₁ ] Σ[ H₂ ∶ F.h₂ ~ G.h₂ ] Σ[ H₃ ∶ F.h₃ ~ G.h₃ ]
-       (((F.H ∙h G.T.left ◂ H₁) ~ (H₂ ▸ G.S.left ∙h G.H))
-       ×  ((F.K ∙h F.T.right ◂ H₃) ~ (H₂ ▸ G.S.right ∙h G.K)))  where
+       (((F.H ∙h G.T.left ◂h H₁) ~ (H₂ ▸h G.S.left ∙h G.H))
+       ×  ((F.K ∙h F.T.right ◂h H₃) ~ (H₂ ▸h G.S.right ∙h G.K)))  where
   module F = Cospan-map F
   module G = Cospan-map G
 
@@ -225,11 +225,11 @@ retraction-witness-cospan {S = S} {T} F G
    = Σ[ r₁ ∶ retraction-witness (F .h₁) (G .h₁) ]
       Σ[ r₂ ∶ retraction-witness (F .h₂) (G .h₂) ]
        Σ[ r₃ ∶ retraction-witness (F .h₃) (G .h₃) ]
-          ((G .h₂ ◂ (F .H) ∙h (G .H) ▸ F .h₁ ∙h F .S.left ◂ r₁
-            ~ r₂ ▸ F .S.left)
+          ((G .h₂ ◂h (F .H) ∙h (G .H) ▸h F .h₁ ∙h F .S.left ◂h r₁
+            ~ r₂ ▸h F .S.left)
           ×
-          (G .h₂ ◂ F .K ∙h G .K ▸ F .h₃ ∙h F .S.right ◂ r₃
-            ~ r₂ ▸ F .S.right)) where
+          (G .h₂ ◂h F .K ∙h G .K ▸h F .h₃ ∙h F .S.right ◂h r₃
+            ~ r₂ ▸h F .S.right)) where
   open Cospan-map
 
 retraction-cospan
@@ -265,9 +265,9 @@ cospan-retraction-is-cospan-retraction F (G , _ , r , _) .snd .fst = r
 cospan-retraction-is-cospan-retraction F (G , _ , _ , r , _) .snd .snd .fst
   = r
 cospan-retraction-is-cospan-retraction F (G , r1 , r2 , r3 , p , _) .snd .snd .snd .fst
-  = ∙h-assoc (G .h₂ ◂ F .H) (G .H ▸ F .h₁) (S.left F ◂ r1) ∙h p ∙h (∙h-reflr _ h⁻¹)
+  = ∙h-assoc (G .h₂ ◂h F .H) (G .H ▸h F .h₁) (S.left F ◂h r1) ∙h p ∙h (∙h-reflr _ h⁻¹)
 cospan-retraction-is-cospan-retraction F (G , r1 , r2 , r3 , _ , q) .snd .snd .snd .snd
-  = ∙h-assoc (G .h₂ ◂ F .K) (G .K ▸ F .h₃) _ ∙h q ∙h (∙h-reflr _ h⁻¹)
+  = ∙h-assoc (G .h₂ ◂h F .K) (G .K ▸h F .h₃) _ ∙h q ∙h (∙h-reflr _ h⁻¹)
 }
 }
 

--- a/src/Core/FunctorialityPullbacks.lagda.tree
+++ b/src/Core/FunctorialityPullbacks.lagda.tree
@@ -65,8 +65,8 @@ cospan-map-compose
 cospan-map-compose F G .h₁ = F .h₁ ∘ G .h₁
 cospan-map-compose F G .h₂ = F .h₂ ∘ G .h₂
 cospan-map-compose F G .h₃ = F .h₃ ∘ G .h₃
-cospan-map-compose F G .H  = F .h₂ ◂h G .H ∙h F .H ▸h G .h₁
-cospan-map-compose F G .K  = F .h₂ ◂h G .K ∙h F .K ▸h G .h₃
+cospan-map-compose F G .H  = F .h₂ ◃h G .H ∙h F .H ▸h G .h₁
+cospan-map-compose F G .K  = F .h₂ ◃h G .K ∙h F .K ▸h G .h₃
 
 id-cospan-map : ∀ {𝓤 𝓥 𝓦} {S : Cospan 𝓤 𝓥 𝓦} → Cospan-map S S
 id-cospan-map .h₁ = id
@@ -91,8 +91,8 @@ Cospan-map-homotopy
       (F G : Cospan-map S T) → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓤' ⊔ 𝓥' ⊔ 𝓦')
 Cospan-map-homotopy F G
   = Σ[ H₁ ∶ F.h₁ ~ G.h₁ ] Σ[ H₂ ∶ F.h₂ ~ G.h₂ ] Σ[ H₃ ∶ F.h₃ ~ G.h₃ ]
-       (((F.H ∙h G.T.left ◂h H₁) ~ (H₂ ▸h G.S.left ∙h G.H))
-       ×  ((F.K ∙h F.T.right ◂h H₃) ~ (H₂ ▸h G.S.right ∙h G.K)))  where
+       (((F.H ∙h G.T.left ◃h H₁) ~ (H₂ ▸h G.S.left ∙h G.H))
+       ×  ((F.K ∙h F.T.right ◃h H₃) ~ (H₂ ▸h G.S.right ∙h G.K)))  where
   module F = Cospan-map F
   module G = Cospan-map G
 
@@ -225,10 +225,10 @@ retraction-witness-cospan {S = S} {T} F G
    = Σ[ r₁ ∶ retraction-witness (F .h₁) (G .h₁) ]
       Σ[ r₂ ∶ retraction-witness (F .h₂) (G .h₂) ]
        Σ[ r₃ ∶ retraction-witness (F .h₃) (G .h₃) ]
-          ((G .h₂ ◂h (F .H) ∙h (G .H) ▸h F .h₁ ∙h F .S.left ◂h r₁
+          ((G .h₂ ◃h (F .H) ∙h (G .H) ▸h F .h₁ ∙h F .S.left ◃h r₁
             ~ r₂ ▸h F .S.left)
           ×
-          (G .h₂ ◂h F .K ∙h G .K ▸h F .h₃ ∙h F .S.right ◂h r₃
+          (G .h₂ ◃h F .K ∙h G .K ▸h F .h₃ ∙h F .S.right ◃h r₃
             ~ r₂ ▸h F .S.right)) where
   open Cospan-map
 
@@ -265,9 +265,9 @@ cospan-retraction-is-cospan-retraction F (G , _ , r , _) .snd .fst = r
 cospan-retraction-is-cospan-retraction F (G , _ , _ , r , _) .snd .snd .fst
   = r
 cospan-retraction-is-cospan-retraction F (G , r1 , r2 , r3 , p , _) .snd .snd .snd .fst
-  = ∙h-assoc (G .h₂ ◂h F .H) (G .H ▸h F .h₁) (S.left F ◂h r1) ∙h p ∙h (∙h-reflr _ h⁻¹)
+  = ∙h-assoc (G .h₂ ◃h F .H) (G .H ▸h F .h₁) (S.left F ◃h r1) ∙h p ∙h (∙h-reflr _ h⁻¹)
 cospan-retraction-is-cospan-retraction F (G , r1 , r2 , r3 , _ , q) .snd .snd .snd .snd
-  = ∙h-assoc (G .h₂ ◂h F .K) (G .K ▸h F .h₃) _ ∙h q ∙h (∙h-reflr _ h⁻¹)
+  = ∙h-assoc (G .h₂ ◃h F .K) (G .K ▸h F .h₃) _ ∙h q ∙h (∙h-reflr _ h⁻¹)
 }
 }
 

--- a/src/Core/FunctorialityPullbacks.lagda.tree
+++ b/src/Core/FunctorialityPullbacks.lagda.tree
@@ -65,8 +65,8 @@ cospan-map-compose
 cospan-map-compose F G .h₁ = F .h₁ ∘ G .h₁
 cospan-map-compose F G .h₂ = F .h₂ ∘ G .h₂
 cospan-map-compose F G .h₃ = F .h₃ ∘ G .h₃
-cospan-map-compose F G .H  = F .h₂ ◃h G .H ∙h F .H ▸h G .h₁
-cospan-map-compose F G .K  = F .h₂ ◃h G .K ∙h F .K ▸h G .h₃
+cospan-map-compose F G .H  = F .h₂ ◃h G .H ∙h F .H ▹h G .h₁
+cospan-map-compose F G .K  = F .h₂ ◃h G .K ∙h F .K ▹h G .h₃
 
 id-cospan-map : ∀ {𝓤 𝓥 𝓦} {S : Cospan 𝓤 𝓥 𝓦} → Cospan-map S S
 id-cospan-map .h₁ = id
@@ -91,8 +91,8 @@ Cospan-map-homotopy
       (F G : Cospan-map S T) → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓤' ⊔ 𝓥' ⊔ 𝓦')
 Cospan-map-homotopy F G
   = Σ[ H₁ ∶ F.h₁ ~ G.h₁ ] Σ[ H₂ ∶ F.h₂ ~ G.h₂ ] Σ[ H₃ ∶ F.h₃ ~ G.h₃ ]
-       (((F.H ∙h G.T.left ◃h H₁) ~ (H₂ ▸h G.S.left ∙h G.H))
-       ×  ((F.K ∙h F.T.right ◃h H₃) ~ (H₂ ▸h G.S.right ∙h G.K)))  where
+       (((F.H ∙h G.T.left ◃h H₁) ~ (H₂ ▹h G.S.left ∙h G.H))
+       ×  ((F.K ∙h F.T.right ◃h H₃) ~ (H₂ ▹h G.S.right ∙h G.K)))  where
   module F = Cospan-map F
   module G = Cospan-map G
 
@@ -225,11 +225,11 @@ retraction-witness-cospan {S = S} {T} F G
    = Σ[ r₁ ∶ retraction-witness (F .h₁) (G .h₁) ]
       Σ[ r₂ ∶ retraction-witness (F .h₂) (G .h₂) ]
        Σ[ r₃ ∶ retraction-witness (F .h₃) (G .h₃) ]
-          ((G .h₂ ◃h (F .H) ∙h (G .H) ▸h F .h₁ ∙h F .S.left ◃h r₁
-            ~ r₂ ▸h F .S.left)
+          ((G .h₂ ◃h (F .H) ∙h (G .H) ▹h F .h₁ ∙h F .S.left ◃h r₁
+            ~ r₂ ▹h F .S.left)
           ×
-          (G .h₂ ◃h F .K ∙h G .K ▸h F .h₃ ∙h F .S.right ◃h r₃
-            ~ r₂ ▸h F .S.right)) where
+          (G .h₂ ◃h F .K ∙h G .K ▹h F .h₃ ∙h F .S.right ◃h r₃
+            ~ r₂ ▹h F .S.right)) where
   open Cospan-map
 
 retraction-cospan
@@ -265,9 +265,9 @@ cospan-retraction-is-cospan-retraction F (G , _ , r , _) .snd .fst = r
 cospan-retraction-is-cospan-retraction F (G , _ , _ , r , _) .snd .snd .fst
   = r
 cospan-retraction-is-cospan-retraction F (G , r1 , r2 , r3 , p , _) .snd .snd .snd .fst
-  = ∙h-assoc (G .h₂ ◃h F .H) (G .H ▸h F .h₁) (S.left F ◃h r1) ∙h p ∙h (∙h-reflr _ h⁻¹)
+  = ∙h-assoc (G .h₂ ◃h F .H) (G .H ▹h F .h₁) (S.left F ◃h r1) ∙h p ∙h (∙h-reflr _ h⁻¹)
 cospan-retraction-is-cospan-retraction F (G , r1 , r2 , r3 , _ , q) .snd .snd .snd .snd
-  = ∙h-assoc (G .h₂ ◃h F .K) (G .K ▸h F .h₃) _ ∙h q ∙h (∙h-reflr _ h⁻¹)
+  = ∙h-assoc (G .h₂ ◃h F .K) (G .K ▹h F .h₃) _ ∙h q ∙h (∙h-reflr _ h⁻¹)
 }
 }
 

--- a/src/Core/FunctorialityPushouts.lagda.tree
+++ b/src/Core/FunctorialityPushouts.lagda.tree
@@ -35,7 +35,7 @@ Cocone₁
 Cocone₁ F Pc'
   = mk-cocone (Pc'.p ∘ F.h₁) (Pc'.q ∘ F.h₃)
               (  Pc'.p ◃h F.H
-              ∙h Pc'.filler ▸h F.h₂
+              ∙h Pc'.filler ▹h F.h₂
               ∙h Pc'.q ◃h (F.K h⁻¹)) where
   module Pc' = Cocone Pc'
   module F = Span-map F

--- a/src/Core/FunctorialityPushouts.lagda.tree
+++ b/src/Core/FunctorialityPushouts.lagda.tree
@@ -34,9 +34,9 @@ Cocone₁
       → Cocone S P'
 Cocone₁ F Pc'
   = mk-cocone (Pc'.p ∘ F.h₁) (Pc'.q ∘ F.h₃)
-              (  Pc'.p ◂h F.H
+              (  Pc'.p ◃h F.H
               ∙h Pc'.filler ▸h F.h₂
-              ∙h Pc'.q ◂h (F.K h⁻¹)) where
+              ∙h Pc'.q ◃h (F.K h⁻¹)) where
   module Pc' = Cocone Pc'
   module F = Span-map F
 

--- a/src/Core/FunctorialityPushouts.lagda.tree
+++ b/src/Core/FunctorialityPushouts.lagda.tree
@@ -34,9 +34,9 @@ Cocone₁
       → Cocone S P'
 Cocone₁ F Pc'
   = mk-cocone (Pc'.p ∘ F.h₁) (Pc'.q ∘ F.h₃)
-              (  Pc'.p ◂ F.H
-              ∙h Pc'.filler ▸ F.h₂
-              ∙h Pc'.q ◂ (F.K h⁻¹)) where
+              (  Pc'.p ◂h F.H
+              ∙h Pc'.filler ▸h F.h₂
+              ∙h Pc'.q ◂h (F.K h⁻¹)) where
   module Pc' = Cocone Pc'
   module F = Span-map F
 

--- a/src/Core/Images.lagda.tree
+++ b/src/Core/Images.lagda.tree
@@ -40,7 +40,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} (f : A → B) where
       → Slice-map i i' → Slice-map f i'
   postcomp-slice {i = i} K {I'} {i'} sm
     = ( sm .fst ∘ K .fst
-      , sm .snd ▸ K .fst ∙h K .snd)
+      , sm .snd ▸h K .fst ∙h K .snd)
 
   is-universal-embedding
     : ∀ {𝓘} {I : Type 𝓘}
@@ -171,13 +171,13 @@ module _
     ret : from .fst ∘ to .fst ~ id
     ret = happly (ap fst
       (slice-embedding-is-prop (is-image.map-is-emb Ii)
-        (from .fst ∘ to .fst , from .snd ▸ to .fst ∙h to .snd)
+        (from .fst ∘ to .fst , from .snd ▸h to .fst ∙h to .snd)
         (Slice-id i)))
 
     sec : to .fst ∘ from .fst ~ id
     sec = happly (ap fst
       (slice-embedding-is-prop (is-image.map-is-emb Ij)
-        (to .fst ∘ from .fst , to .snd ▸ from .fst ∙h from .snd)
+        (to .fst ∘ from .fst , to .snd ▸h from .fst ∙h from .snd)
         (Slice-id j)))
 }
 }
@@ -202,13 +202,13 @@ module _
   is-image←equiv-domain e {f = f} {i = i} im = mk-is-image
     (is-image.map-is-emb im)
     (is-image.factors im .fst ∘ _≃_.fwd e
-    , is-image.factors im .snd ▸ _≃_.fwd e ∙h f ◂ _≃_.η e)
+    , is-image.factors im .snd ▸h _≃_.fwd e ∙h f ◂h _≃_.η e)
     (is-universal-embedding←logical f i
       ( is-image.factors im .fst ∘ _≃_.fwd e
-      , is-image.factors im .snd ▸ _≃_.fwd e ∙h f ◂ _≃_.η e)
+      , is-image.factors im .snd ▸h _≃_.fwd e ∙h f ◂h _≃_.η e)
       ( λ i' i'emb fi' →
         is-equiv.bwd (is-image.factors-is-universal-embedding im i' i'emb)
           ( fi' .fst ∘ _≃_.bwd e
-          , fi' .snd ▸ _≃_.bwd e)))
+          , fi' .snd ▸h _≃_.bwd e)))
 }
 }

--- a/src/Core/Images.lagda.tree
+++ b/src/Core/Images.lagda.tree
@@ -202,10 +202,10 @@ module _
   is-image←equiv-domain e {f = f} {i = i} im = mk-is-image
     (is-image.map-is-emb im)
     (is-image.factors im .fst ∘ _≃_.fwd e
-    , is-image.factors im .snd ▸h _≃_.fwd e ∙h f ◂h _≃_.η e)
+    , is-image.factors im .snd ▸h _≃_.fwd e ∙h f ◃h _≃_.η e)
     (is-universal-embedding←logical f i
       ( is-image.factors im .fst ∘ _≃_.fwd e
-      , is-image.factors im .snd ▸h _≃_.fwd e ∙h f ◂h _≃_.η e)
+      , is-image.factors im .snd ▸h _≃_.fwd e ∙h f ◃h _≃_.η e)
       ( λ i' i'emb fi' →
         is-equiv.bwd (is-image.factors-is-universal-embedding im i' i'emb)
           ( fi' .fst ∘ _≃_.bwd e

--- a/src/Core/Images.lagda.tree
+++ b/src/Core/Images.lagda.tree
@@ -40,7 +40,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} (f : A → B) where
       → Slice-map i i' → Slice-map f i'
   postcomp-slice {i = i} K {I'} {i'} sm
     = ( sm .fst ∘ K .fst
-      , sm .snd ▸h K .fst ∙h K .snd)
+      , sm .snd ▹h K .fst ∙h K .snd)
 
   is-universal-embedding
     : ∀ {𝓘} {I : Type 𝓘}
@@ -171,13 +171,13 @@ module _
     ret : from .fst ∘ to .fst ~ id
     ret = happly (ap fst
       (slice-embedding-is-prop (is-image.map-is-emb Ii)
-        (from .fst ∘ to .fst , from .snd ▸h to .fst ∙h to .snd)
+        (from .fst ∘ to .fst , from .snd ▹h to .fst ∙h to .snd)
         (Slice-id i)))
 
     sec : to .fst ∘ from .fst ~ id
     sec = happly (ap fst
       (slice-embedding-is-prop (is-image.map-is-emb Ij)
-        (to .fst ∘ from .fst , to .snd ▸h from .fst ∙h from .snd)
+        (to .fst ∘ from .fst , to .snd ▹h from .fst ∙h from .snd)
         (Slice-id j)))
 }
 }
@@ -202,13 +202,13 @@ module _
   is-image←equiv-domain e {f = f} {i = i} im = mk-is-image
     (is-image.map-is-emb im)
     (is-image.factors im .fst ∘ _≃_.fwd e
-    , is-image.factors im .snd ▸h _≃_.fwd e ∙h f ◃h _≃_.η e)
+    , is-image.factors im .snd ▹h _≃_.fwd e ∙h f ◃h _≃_.η e)
     (is-universal-embedding←logical f i
       ( is-image.factors im .fst ∘ _≃_.fwd e
-      , is-image.factors im .snd ▸h _≃_.fwd e ∙h f ◃h _≃_.η e)
+      , is-image.factors im .snd ▹h _≃_.fwd e ∙h f ◃h _≃_.η e)
       ( λ i' i'emb fi' →
         is-equiv.bwd (is-image.factors-is-universal-embedding im i' i'emb)
           ( fi' .fst ∘ _≃_.bwd e
-          , fi' .snd ▸h _≃_.bwd e)))
+          , fi' .snd ▹h _≃_.bwd e)))
 }
 }

--- a/src/Core/Joins.lagda.tree
+++ b/src/Core/Joins.lagda.tree
@@ -208,23 +208,23 @@ f *₁ g = pushout-rec (mk-cocone (ι₁ ∘ f) (ι₂ ∘ g) (glue ∘ (f ⊗ g
     sec : ∀ a →
         Square (ap ((f *₁ g) ∘ (f.bwd *₁ g.bwd)) (glue a))
                (ap id (glue a))
-               (((ι₁ ◂h f.ε) ∘ fst) a)
-               (((ι₂ ◂h g.ε) ∘ snd) a)
+               (((ι₁ ◃h f.ε) ∘ fst) a)
+               (((ι₂ ◃h g.ε) ∘ snd) a)
     sec p@(a , b) = mk-square (
-      ⌜ ap ((f *₁ g) ∘ (f.bwd *₁ g.bwd)) (glue p) ⌝ ∙ ((ι₂ ◂h g.ε) b)
+      ⌜ ap ((f *₁ g) ∘ (f.bwd *₁ g.bwd)) (glue p) ⌝ ∙ ((ι₂ ◃h g.ε) b)
                                     ＝⟨ ap! (ap-∘ _ _ (glue p)) ⟩
-      ap (f *₁ g) ⌜ ap (f.bwd *₁ g.bwd) (glue p) ⌝ ∙ ((ι₂ ◂h g.ε) b)
+      ap (f *₁ g) ⌜ ap (f.bwd *₁ g.bwd) (glue p) ⌝ ∙ ((ι₂ ◃h g.ε) b)
                                     ＝⟨ ap! (pushout-rec-apβ p) ⟩
-      ⌜ ap (f *₁ g) (glue (f.bwd a , g.bwd b)) ⌝ ∙ ((ι₂ ◂h g.ε) b)
+      ⌜ ap (f *₁ g) (glue (f.bwd a , g.bwd b)) ⌝ ∙ ((ι₂ ◃h g.ε) b)
                                     ＝⟨ ap! (pushout-rec-apβ ((f.bwd ⊗ g.bwd) p)) ⟩
-      (glue ∘ (f ⊗ g) ∘ (f.bwd ⊗ g.bwd)) p ∙ (⌜ ι₂ ◂h g.ε ▸h snd ⌝) p
+      (glue ∘ (f ⊗ g) ∘ (f.bwd ⊗ g.bwd)) p ∙ (⌜ ι₂ ◃h g.ε ▸h snd ⌝) p
                                     ＝⟨ ap! ( sym (ap-∘ ι₂ snd (×-path→ (f.ε a , g.ε b))
                                             ∙ ap (ap ι₂) ×-path-ap-snd)) ⟩
-      ((glue ∘ (f ⊗ g) ∘ (f.bwd ⊗ g.bwd)) ∙h ((ι₂ ∘ snd) ◂h ×~ (f.ε , g.ε))) p
+      ((glue ∘ (f ⊗ g) ∘ (f.bwd ⊗ g.bwd)) ∙h ((ι₂ ∘ snd) ◃h ×~ (f.ε , g.ε))) p
                                     ＝⟨⟩
       (glue ◾h (×~ (f.ε , g.ε))) p   ＝⟨ switch-◾h glue (×~ (f.ε , g.ε)) p ⟩
       (glue ◾h' (×~ (f.ε , g.ε))) p  ＝⟨ ap (_∙ glue p) (ap-∘ ι₁ fst (×~ (f.ε , g.ε) p)) ⟩
-       ((ι₁ ◂h fst ◂h ×~ (f.ε , g.ε)) ∙h glue) p
+       ((ι₁ ◃h fst ◃h ×~ (f.ε , g.ε)) ∙h glue) p
                                     ＝⟨ ap (λ x → (ap ι₁ x) ∙ glue p) ×-path-ap-fst ⟩
       ap ι₁ (f.ε a) ∙ ⌜ glue p ⌝    ＝⟨ ap! (sym (ap-id (glue p))) ⟩
       ap ι₁ (f.ε a) ∙ ap id (glue p) ∎)
@@ -235,36 +235,36 @@ f *₁ g = pushout-rec (mk-cocone (ι₁ ∘ f) (ι₂ ∘ g) (glue ∘ (f ⊗ g
     ret : ∀ a →
         Square (ap ((f.bwd *₁ g.bwd) ∘ (f *₁ g)) (glue a))
                (ap id (glue a))
-               (((ι₁ ◂h f.η) ∘ fst) a)
-               (((ι₂ ◂h g.η) ∘ snd) a)
+               (((ι₁ ◃h f.η) ∘ fst) a)
+               (((ι₂ ◃h g.η) ∘ snd) a)
     ret p@(a , b) = mk-square (
-        ⌜ ap ((f.bwd *₁ g.bwd) ∘ (f *₁ g)) (glue p) ⌝ ∙ ((ι₂ ◂h g.η) b)
+        ⌜ ap ((f.bwd *₁ g.bwd) ∘ (f *₁ g)) (glue p) ⌝ ∙ ((ι₂ ◃h g.η) b)
                                       ＝⟨ ap! (ap-∘ _ _ (glue p)) ⟩
-        ap (f.bwd *₁ g.bwd) ⌜ ap (f *₁ g) (glue p) ⌝ ∙ ((ι₂ ◂h g.η) b)
+        ap (f.bwd *₁ g.bwd) ⌜ ap (f *₁ g) (glue p) ⌝ ∙ ((ι₂ ◃h g.η) b)
                                       ＝⟨ ap! (pushout-rec-apβ p) ⟩
-        ⌜ ap (f.bwd *₁ g.bwd) (glue (f a , g b)) ⌝ ∙ ((ι₂ ◂h g.η) b)
+        ⌜ ap (f.bwd *₁ g.bwd) (glue (f a , g b)) ⌝ ∙ ((ι₂ ◃h g.η) b)
                                       ＝⟨ ap! (pushout-rec-apβ ((f ⊗ g) p)) ⟩
-        (glue ∘ (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)) p ∙ (⌜ ι₂ ◂h g.η ▸h snd ⌝) p
+        (glue ∘ (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)) p ∙ (⌜ ι₂ ◃h g.η ▸h snd ⌝) p
                                       ＝⟨ ap! ( sym (ap-∘ ι₂ snd (×-path→ (f.η a , g.η b))
                                               ∙ ap (ap ι₂) ×-path-ap-snd)) ⟩
-        ((glue ∘ (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)) ∙h ((ι₂ ∘ snd) ◂h ×~ (f.η , g.η))) p
+        ((glue ∘ (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)) ∙h ((ι₂ ∘ snd) ◃h ×~ (f.η , g.η))) p
                                       ＝⟨ refl ⟩
         (glue ◾h (×~ (f.η , g.η))) p   ＝⟨ switch-◾h glue {h = (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)} (×~ (f.η , g.η)) p ⟩
         (glue ◾h' (×~ (f.η , g.η))) p  ＝⟨ ap (_∙ glue p) (ap-∘ ι₁ fst (×~ (f.η , g.η) p)) ⟩
-         ((ι₁ ◂h fst ◂h ×~ (f.η , g.η)) ∙h glue) p
+         ((ι₁ ◃h fst ◃h ×~ (f.η , g.η)) ∙h glue) p
                                       ＝⟨ ap (λ x → (ap ι₁ x) ∙ glue p) ×-path-ap-fst ⟩
         ap ι₁ (f.η a) ∙ ⌜ glue p ⌝    ＝⟨ ap! (sym (ap-id (glue p))) ⟩
         ap ι₁ (f.η a) ∙ ap id (glue p) ∎)
 
   qinv : quasi-inv (f *₁ g)
   qinv .fst = f.bwd *₁ g.bwd
-  qinv .snd .fst = pushout-ind _ (mk-coconeᵈ (ι₁ ◂h f.η) (ι₂ ◂h g.η)
+  qinv .snd .fst = pushout-ind _ (mk-coconeᵈ (ι₁ ◃h f.η) (ι₂ ◃h g.η)
                     λ a → Idᵈ-func←Square
                            {f = (f.bwd *₁ g.bwd) ∘ (f *₁ g)}
                            {id} (glue a)
-                           (ap ι₁ (f.η (fst a))) ((ι₂ ◂h g.η) (snd a))
+                           (ap ι₁ (f.η (fst a))) ((ι₂ ◃h g.η) (snd a))
                            (ret a))
-  qinv .snd .snd = pushout-ind _ (mk-coconeᵈ (ι₁ ◂h f.ε) (ι₂ ◂h g.ε)
+  qinv .snd .snd = pushout-ind _ (mk-coconeᵈ (ι₁ ◃h f.ε) (ι₂ ◃h g.ε)
                    (λ a → Idᵈ-func←Square {f = (f *₁ g) ∘ (f.bwd *₁ g.bwd)} {id}
                                (glue a) _ _
                                (sec a)))

--- a/src/Core/Joins.lagda.tree
+++ b/src/Core/Joins.lagda.tree
@@ -217,7 +217,7 @@ f *₁ g = pushout-rec (mk-cocone (ι₁ ∘ f) (ι₂ ∘ g) (glue ∘ (f ⊗ g
                                     ＝⟨ ap! (pushout-rec-apβ p) ⟩
       ⌜ ap (f *₁ g) (glue (f.bwd a , g.bwd b)) ⌝ ∙ ((ι₂ ◃h g.ε) b)
                                     ＝⟨ ap! (pushout-rec-apβ ((f.bwd ⊗ g.bwd) p)) ⟩
-      (glue ∘ (f ⊗ g) ∘ (f.bwd ⊗ g.bwd)) p ∙ (⌜ ι₂ ◃h g.ε ▸h snd ⌝) p
+      (glue ∘ (f ⊗ g) ∘ (f.bwd ⊗ g.bwd)) p ∙ (⌜ ι₂ ◃h g.ε ▹h snd ⌝) p
                                     ＝⟨ ap! ( sym (ap-∘ ι₂ snd (×-path→ (f.ε a , g.ε b))
                                             ∙ ap (ap ι₂) ×-path-ap-snd)) ⟩
       ((glue ∘ (f ⊗ g) ∘ (f.bwd ⊗ g.bwd)) ∙h ((ι₂ ∘ snd) ◃h ×~ (f.ε , g.ε))) p
@@ -244,7 +244,7 @@ f *₁ g = pushout-rec (mk-cocone (ι₁ ∘ f) (ι₂ ∘ g) (glue ∘ (f ⊗ g
                                       ＝⟨ ap! (pushout-rec-apβ p) ⟩
         ⌜ ap (f.bwd *₁ g.bwd) (glue (f a , g b)) ⌝ ∙ ((ι₂ ◃h g.η) b)
                                       ＝⟨ ap! (pushout-rec-apβ ((f ⊗ g) p)) ⟩
-        (glue ∘ (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)) p ∙ (⌜ ι₂ ◃h g.η ▸h snd ⌝) p
+        (glue ∘ (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)) p ∙ (⌜ ι₂ ◃h g.η ▹h snd ⌝) p
                                       ＝⟨ ap! ( sym (ap-∘ ι₂ snd (×-path→ (f.η a , g.η b))
                                               ∙ ap (ap ι₂) ×-path-ap-snd)) ⟩
         ((glue ∘ (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)) ∙h ((ι₂ ∘ snd) ◃h ×~ (f.η , g.η))) p

--- a/src/Core/Joins.lagda.tree
+++ b/src/Core/Joins.lagda.tree
@@ -222,8 +222,8 @@ f *₁ g = pushout-rec (mk-cocone (ι₁ ∘ f) (ι₂ ∘ g) (glue ∘ (f ⊗ g
                                             ∙ ap (ap ι₂) ×-path-ap-snd)) ⟩
       ((glue ∘ (f ⊗ g) ∘ (f.bwd ⊗ g.bwd)) ∙h ((ι₂ ∘ snd) ◃h ×~ (f.ε , g.ε))) p
                                     ＝⟨⟩
-      (glue ◾h (×~ (f.ε , g.ε))) p   ＝⟨ switch-◾h glue (×~ (f.ε , g.ε)) p ⟩
-      (glue ◾h' (×~ (f.ε , g.ε))) p  ＝⟨ ap (_∙ glue p) (ap-∘ ι₁ fst (×~ (f.ε , g.ε) p)) ⟩
+      (glue ◽h (×~ (f.ε , g.ε))) p   ＝⟨ switch-◽h glue (×~ (f.ε , g.ε)) p ⟩
+      (glue ◽h' (×~ (f.ε , g.ε))) p  ＝⟨ ap (_∙ glue p) (ap-∘ ι₁ fst (×~ (f.ε , g.ε) p)) ⟩
        ((ι₁ ◃h fst ◃h ×~ (f.ε , g.ε)) ∙h glue) p
                                     ＝⟨ ap (λ x → (ap ι₁ x) ∙ glue p) ×-path-ap-fst ⟩
       ap ι₁ (f.ε a) ∙ ⌜ glue p ⌝    ＝⟨ ap! (sym (ap-id (glue p))) ⟩
@@ -249,8 +249,8 @@ f *₁ g = pushout-rec (mk-cocone (ι₁ ∘ f) (ι₂ ∘ g) (glue ∘ (f ⊗ g
                                               ∙ ap (ap ι₂) ×-path-ap-snd)) ⟩
         ((glue ∘ (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)) ∙h ((ι₂ ∘ snd) ◃h ×~ (f.η , g.η))) p
                                       ＝⟨ refl ⟩
-        (glue ◾h (×~ (f.η , g.η))) p   ＝⟨ switch-◾h glue {h = (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)} (×~ (f.η , g.η)) p ⟩
-        (glue ◾h' (×~ (f.η , g.η))) p  ＝⟨ ap (_∙ glue p) (ap-∘ ι₁ fst (×~ (f.η , g.η) p)) ⟩
+        (glue ◽h (×~ (f.η , g.η))) p   ＝⟨ switch-◽h glue {h = (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)} (×~ (f.η , g.η)) p ⟩
+        (glue ◽h' (×~ (f.η , g.η))) p  ＝⟨ ap (_∙ glue p) (ap-∘ ι₁ fst (×~ (f.η , g.η) p)) ⟩
          ((ι₁ ◃h fst ◃h ×~ (f.η , g.η)) ∙h glue) p
                                       ＝⟨ ap (λ x → (ap ι₁ x) ∙ glue p) ×-path-ap-fst ⟩
         ap ι₁ (f.η a) ∙ ⌜ glue p ⌝    ＝⟨ ap! (sym (ap-id (glue p))) ⟩

--- a/src/Core/Joins.lagda.tree
+++ b/src/Core/Joins.lagda.tree
@@ -208,23 +208,23 @@ f *₁ g = pushout-rec (mk-cocone (ι₁ ∘ f) (ι₂ ∘ g) (glue ∘ (f ⊗ g
     sec : ∀ a →
         Square (ap ((f *₁ g) ∘ (f.bwd *₁ g.bwd)) (glue a))
                (ap id (glue a))
-               (((ι₁ ◂ f.ε) ∘ fst) a)
-               (((ι₂ ◂ g.ε) ∘ snd) a)
+               (((ι₁ ◂h f.ε) ∘ fst) a)
+               (((ι₂ ◂h g.ε) ∘ snd) a)
     sec p@(a , b) = mk-square (
-      ⌜ ap ((f *₁ g) ∘ (f.bwd *₁ g.bwd)) (glue p) ⌝ ∙ ((ι₂ ◂ g.ε) b)
+      ⌜ ap ((f *₁ g) ∘ (f.bwd *₁ g.bwd)) (glue p) ⌝ ∙ ((ι₂ ◂h g.ε) b)
                                     ＝⟨ ap! (ap-∘ _ _ (glue p)) ⟩
-      ap (f *₁ g) ⌜ ap (f.bwd *₁ g.bwd) (glue p) ⌝ ∙ ((ι₂ ◂ g.ε) b)
+      ap (f *₁ g) ⌜ ap (f.bwd *₁ g.bwd) (glue p) ⌝ ∙ ((ι₂ ◂h g.ε) b)
                                     ＝⟨ ap! (pushout-rec-apβ p) ⟩
-      ⌜ ap (f *₁ g) (glue (f.bwd a , g.bwd b)) ⌝ ∙ ((ι₂ ◂ g.ε) b)
+      ⌜ ap (f *₁ g) (glue (f.bwd a , g.bwd b)) ⌝ ∙ ((ι₂ ◂h g.ε) b)
                                     ＝⟨ ap! (pushout-rec-apβ ((f.bwd ⊗ g.bwd) p)) ⟩
-      (glue ∘ (f ⊗ g) ∘ (f.bwd ⊗ g.bwd)) p ∙ (⌜ ι₂ ◂ g.ε ▸ snd ⌝) p
+      (glue ∘ (f ⊗ g) ∘ (f.bwd ⊗ g.bwd)) p ∙ (⌜ ι₂ ◂h g.ε ▸h snd ⌝) p
                                     ＝⟨ ap! ( sym (ap-∘ ι₂ snd (×-path→ (f.ε a , g.ε b))
                                             ∙ ap (ap ι₂) ×-path-ap-snd)) ⟩
-      ((glue ∘ (f ⊗ g) ∘ (f.bwd ⊗ g.bwd)) ∙h ((ι₂ ∘ snd) ◂ ×~ (f.ε , g.ε))) p
+      ((glue ∘ (f ⊗ g) ∘ (f.bwd ⊗ g.bwd)) ∙h ((ι₂ ∘ snd) ◂h ×~ (f.ε , g.ε))) p
                                     ＝⟨⟩
-      (glue ◾ (×~ (f.ε , g.ε))) p   ＝⟨ switch-◾ glue (×~ (f.ε , g.ε)) p ⟩
-      (glue ◾' (×~ (f.ε , g.ε))) p  ＝⟨ ap (_∙ glue p) (ap-∘ ι₁ fst (×~ (f.ε , g.ε) p)) ⟩
-       ((ι₁ ◂ fst ◂ ×~ (f.ε , g.ε)) ∙h glue) p
+      (glue ◾h (×~ (f.ε , g.ε))) p   ＝⟨ switch-◾h glue (×~ (f.ε , g.ε)) p ⟩
+      (glue ◾h' (×~ (f.ε , g.ε))) p  ＝⟨ ap (_∙ glue p) (ap-∘ ι₁ fst (×~ (f.ε , g.ε) p)) ⟩
+       ((ι₁ ◂h fst ◂h ×~ (f.ε , g.ε)) ∙h glue) p
                                     ＝⟨ ap (λ x → (ap ι₁ x) ∙ glue p) ×-path-ap-fst ⟩
       ap ι₁ (f.ε a) ∙ ⌜ glue p ⌝    ＝⟨ ap! (sym (ap-id (glue p))) ⟩
       ap ι₁ (f.ε a) ∙ ap id (glue p) ∎)
@@ -235,36 +235,36 @@ f *₁ g = pushout-rec (mk-cocone (ι₁ ∘ f) (ι₂ ∘ g) (glue ∘ (f ⊗ g
     ret : ∀ a →
         Square (ap ((f.bwd *₁ g.bwd) ∘ (f *₁ g)) (glue a))
                (ap id (glue a))
-               (((ι₁ ◂ f.η) ∘ fst) a)
-               (((ι₂ ◂ g.η) ∘ snd) a)
+               (((ι₁ ◂h f.η) ∘ fst) a)
+               (((ι₂ ◂h g.η) ∘ snd) a)
     ret p@(a , b) = mk-square (
-        ⌜ ap ((f.bwd *₁ g.bwd) ∘ (f *₁ g)) (glue p) ⌝ ∙ ((ι₂ ◂ g.η) b)
+        ⌜ ap ((f.bwd *₁ g.bwd) ∘ (f *₁ g)) (glue p) ⌝ ∙ ((ι₂ ◂h g.η) b)
                                       ＝⟨ ap! (ap-∘ _ _ (glue p)) ⟩
-        ap (f.bwd *₁ g.bwd) ⌜ ap (f *₁ g) (glue p) ⌝ ∙ ((ι₂ ◂ g.η) b)
+        ap (f.bwd *₁ g.bwd) ⌜ ap (f *₁ g) (glue p) ⌝ ∙ ((ι₂ ◂h g.η) b)
                                       ＝⟨ ap! (pushout-rec-apβ p) ⟩
-        ⌜ ap (f.bwd *₁ g.bwd) (glue (f a , g b)) ⌝ ∙ ((ι₂ ◂ g.η) b)
+        ⌜ ap (f.bwd *₁ g.bwd) (glue (f a , g b)) ⌝ ∙ ((ι₂ ◂h g.η) b)
                                       ＝⟨ ap! (pushout-rec-apβ ((f ⊗ g) p)) ⟩
-        (glue ∘ (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)) p ∙ (⌜ ι₂ ◂ g.η ▸ snd ⌝) p
+        (glue ∘ (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)) p ∙ (⌜ ι₂ ◂h g.η ▸h snd ⌝) p
                                       ＝⟨ ap! ( sym (ap-∘ ι₂ snd (×-path→ (f.η a , g.η b))
                                               ∙ ap (ap ι₂) ×-path-ap-snd)) ⟩
-        ((glue ∘ (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)) ∙h ((ι₂ ∘ snd) ◂ ×~ (f.η , g.η))) p
+        ((glue ∘ (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)) ∙h ((ι₂ ∘ snd) ◂h ×~ (f.η , g.η))) p
                                       ＝⟨ refl ⟩
-        (glue ◾ (×~ (f.η , g.η))) p   ＝⟨ switch-◾ glue {h = (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)} (×~ (f.η , g.η)) p ⟩
-        (glue ◾' (×~ (f.η , g.η))) p  ＝⟨ ap (_∙ glue p) (ap-∘ ι₁ fst (×~ (f.η , g.η) p)) ⟩
-         ((ι₁ ◂ fst ◂ ×~ (f.η , g.η)) ∙h glue) p
+        (glue ◾h (×~ (f.η , g.η))) p   ＝⟨ switch-◾h glue {h = (f.bwd ⊗ g.bwd) ∘ (f ⊗ g)} (×~ (f.η , g.η)) p ⟩
+        (glue ◾h' (×~ (f.η , g.η))) p  ＝⟨ ap (_∙ glue p) (ap-∘ ι₁ fst (×~ (f.η , g.η) p)) ⟩
+         ((ι₁ ◂h fst ◂h ×~ (f.η , g.η)) ∙h glue) p
                                       ＝⟨ ap (λ x → (ap ι₁ x) ∙ glue p) ×-path-ap-fst ⟩
         ap ι₁ (f.η a) ∙ ⌜ glue p ⌝    ＝⟨ ap! (sym (ap-id (glue p))) ⟩
         ap ι₁ (f.η a) ∙ ap id (glue p) ∎)
 
   qinv : quasi-inv (f *₁ g)
   qinv .fst = f.bwd *₁ g.bwd
-  qinv .snd .fst = pushout-ind _ (mk-coconeᵈ (ι₁ ◂ f.η) (ι₂ ◂ g.η)
+  qinv .snd .fst = pushout-ind _ (mk-coconeᵈ (ι₁ ◂h f.η) (ι₂ ◂h g.η)
                     λ a → Idᵈ-func←Square
                            {f = (f.bwd *₁ g.bwd) ∘ (f *₁ g)}
                            {id} (glue a)
-                           (ap ι₁ (f.η (fst a))) ((ι₂ ◂ g.η) (snd a))
+                           (ap ι₁ (f.η (fst a))) ((ι₂ ◂h g.η) (snd a))
                            (ret a))
-  qinv .snd .snd = pushout-ind _ (mk-coconeᵈ (ι₁ ◂ f.ε) (ι₂ ◂ g.ε)
+  qinv .snd .snd = pushout-ind _ (mk-coconeᵈ (ι₁ ◂h f.ε) (ι₂ ◂h g.ε)
                    (λ a → Idᵈ-func←Square {f = (f *₁ g) ∘ (f.bwd *₁ g.bwd)} {id}
                                (glue a) _ _
                                (sec a)))

--- a/src/Core/LiftingSquares.lagda.tree
+++ b/src/Core/LiftingSquares.lagda.tree
@@ -44,7 +44,7 @@ module _ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥}
       lift : B → C
       L : lift ∘ f ~ g
       K : f' ∘ lift ~ g'
-      pastes : f' ◂ L ~ K ▸ f ∙h H {- H ~ K ▸ f ∙h f' ◂ L -}
+      pastes : f' ◂h L ~ K ▸h f ∙h H {- H ~ K ▸h f ∙h f' ◂h L -}
 
   unquoteDecl Lift-repr≊ Lift-repr≃
     = make-record-repr Lift-repr≊ Lift-repr≃ (quote Lift)

--- a/src/Core/LiftingSquares.lagda.tree
+++ b/src/Core/LiftingSquares.lagda.tree
@@ -44,7 +44,7 @@ module _ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥}
       lift : B → C
       L : lift ∘ f ~ g
       K : f' ∘ lift ~ g'
-      pastes : f' ◂h L ~ K ▸h f ∙h H {- H ~ K ▸h f ∙h f' ◂h L -}
+      pastes : f' ◃h L ~ K ▸h f ∙h H {- H ~ K ▸h f ∙h f' ◃h L -}
 
   unquoteDecl Lift-repr≊ Lift-repr≃
     = make-record-repr Lift-repr≊ Lift-repr≃ (quote Lift)

--- a/src/Core/LiftingSquares.lagda.tree
+++ b/src/Core/LiftingSquares.lagda.tree
@@ -44,7 +44,7 @@ module _ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥}
       lift : B → C
       L : lift ∘ f ~ g
       K : f' ∘ lift ~ g'
-      pastes : f' ◃h L ~ K ▸h f ∙h H {- H ~ K ▸h f ∙h f' ◃h L -}
+      pastes : f' ◃h L ~ K ▹h f ∙h H {- H ~ K ▹h f ∙h f' ◃h L -}
 
   unquoteDecl Lift-repr≊ Lift-repr≃
     = make-record-repr Lift-repr≊ Lift-repr≃ (quote Lift)

--- a/src/Core/OrthogonalClosure.lagda.tree
+++ b/src/Core/OrthogonalClosure.lagda.tree
@@ -332,7 +332,7 @@ power-hom-cube←arrow-map f f' F g .Cube.comm .snd .fst = ~refl
 power-hom-cube←arrow-map f f' F g .Cube.comm .snd .snd k
   = ∙-reflr _ ∙ ∙-reflr _
   ∙ sym (commutes-postwhisker-funext {h = g} _)
-  ∙ ap funext→ (funext→ (◂h∘ g k _ h⁻¹))
+  ∙ ap funext→ (funext→ (◃h∘ g k _ h⁻¹))
 
 left-orthogonal-retraction
   : ∀ {𝓤 𝓥 𝓦 𝓜 𝓝 𝓛} {A : Type 𝓤} {B : Type 𝓥} (f : A → B)
@@ -350,7 +350,7 @@ left-orthogonal-retraction {A = A} {B} f f' F ret {C} {D} h f'h
 
   cube-ret : 1-coherent-retraction-cube cube
   cube-ret .fst = power-hom-cube←arrow-map _ _ F h
-  cube-ret .snd .fst x = funext→ (x ◂h ret .snd .snd .fst)
+  cube-ret .snd .fst x = funext→ (x ◃h ret .snd .snd .fst)
   cube-ret .snd .snd
     = (ret-left .snd .fst
     ,  ret-right .snd .fst
@@ -358,9 +358,9 @@ left-orthogonal-retraction {A = A} {B} f f' F ret {C} {D} h f'h
     ,  (λ f → sym (ap-∘  (h ∘_) (f ∘_) (funext→ (ret .snd .fst))))
     ,  λ a → sym
               (∙-assoc
-                (ap (_∘ Arrow-map.top F) (funext→ (a ◂h _)))
-                (funext→ ((a ∘ Arrow-map.bot (ret .fst)) ◂h (Arrow-map.comm F h⁻¹)))
-                ((precomp D f ◂h ret-right .fst) a))
+                (ap (_∘ Arrow-map.top F) (funext→ (a ◃h _)))
+                (funext→ ((a ∘ Arrow-map.bot (ret .fst)) ◃h (Arrow-map.comm F h⁻¹)))
+                ((precomp D f ◃h ret-right .fst) a))
               ∙ ret-right .snd .snd a ∙ ∙-reflr _) where
     ret-left : Arrow-map-path
                 (paste-squares (precomp-retraction-square F ret .fst)

--- a/src/Core/OrthogonalClosure.lagda.tree
+++ b/src/Core/OrthogonalClosure.lagda.tree
@@ -332,7 +332,7 @@ power-hom-cube←arrow-map f f' F g .Cube.comm .snd .fst = ~refl
 power-hom-cube←arrow-map f f' F g .Cube.comm .snd .snd k
   = ∙-reflr _ ∙ ∙-reflr _
   ∙ sym (commutes-postwhisker-funext {h = g} _)
-  ∙ ap funext→ (funext→ (◂∘ g k _ h⁻¹))
+  ∙ ap funext→ (funext→ (◂h∘ g k _ h⁻¹))
 
 left-orthogonal-retraction
   : ∀ {𝓤 𝓥 𝓦 𝓜 𝓝 𝓛} {A : Type 𝓤} {B : Type 𝓥} (f : A → B)
@@ -350,7 +350,7 @@ left-orthogonal-retraction {A = A} {B} f f' F ret {C} {D} h f'h
 
   cube-ret : 1-coherent-retraction-cube cube
   cube-ret .fst = power-hom-cube←arrow-map _ _ F h
-  cube-ret .snd .fst x = funext→ (x ◂ ret .snd .snd .fst)
+  cube-ret .snd .fst x = funext→ (x ◂h ret .snd .snd .fst)
   cube-ret .snd .snd
     = (ret-left .snd .fst
     ,  ret-right .snd .fst
@@ -358,9 +358,9 @@ left-orthogonal-retraction {A = A} {B} f f' F ret {C} {D} h f'h
     ,  (λ f → sym (ap-∘  (h ∘_) (f ∘_) (funext→ (ret .snd .fst))))
     ,  λ a → sym
               (∙-assoc
-                (ap (_∘ Arrow-map.top F) (funext→ (a ◂ _)))
-                (funext→ ((a ∘ Arrow-map.bot (ret .fst)) ◂ (Arrow-map.comm F h⁻¹)))
-                ((precomp D f ◂ ret-right .fst) a))
+                (ap (_∘ Arrow-map.top F) (funext→ (a ◂h _)))
+                (funext→ ((a ∘ Arrow-map.bot (ret .fst)) ◂h (Arrow-map.comm F h⁻¹)))
+                ((precomp D f ◂h ret-right .fst) a))
               ∙ ret-right .snd .snd a ∙ ∙-reflr _) where
     ret-left : Arrow-map-path
                 (paste-squares (precomp-retraction-square F ret .fst)

--- a/src/Core/Postwhisker.lagda.tree
+++ b/src/Core/Postwhisker.lagda.tree
@@ -37,7 +37,7 @@ postwhisker
       {X : Type 𝓦} (f : A → B)
       (g h : X → A)
     → g ~ h → f ∘ g ~ f ∘ h
-postwhisker f g h = f ◂h_
+postwhisker f g h = f ◃h_
 }
 }
 

--- a/src/Core/Postwhisker.lagda.tree
+++ b/src/Core/Postwhisker.lagda.tree
@@ -30,14 +30,14 @@ prewhisker
       {X : Type 𝓦} (f : A → B)
       (g h : B → X)
     → g ~ h → g ∘ f ~ h ∘ f
-prewhisker f g h = _▸ f
+prewhisker f g h = _▸h f
 
 postwhisker
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
       {X : Type 𝓦} (f : A → B)
       (g h : X → A)
     → g ~ h → f ∘ g ~ f ∘ h
-postwhisker f g h = f ◂_
+postwhisker f g h = f ◂h_
 }
 }
 

--- a/src/Core/Postwhisker.lagda.tree
+++ b/src/Core/Postwhisker.lagda.tree
@@ -30,7 +30,7 @@ prewhisker
       {X : Type 𝓦} (f : A → B)
       (g h : B → X)
     → g ~ h → g ∘ f ~ h ∘ f
-prewhisker f g h = _▸h f
+prewhisker f g h = _▹h f
 
 postwhisker
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}

--- a/src/Core/PushoutEquiv.lagda.tree
+++ b/src/Core/PushoutEquiv.lagda.tree
@@ -81,14 +81,14 @@ module _ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     = Cocone S _  ≃⟨ cocone-repr≃ ⟩
       (Σ[ p ∶ (B → Q)] Σ[ q ∶ (C → Q)] (p ∘ f ~ q ∘ g))
                   ≃⟨ Σ-snd-≃ (λ p → Σ-snd-≃ (λ q → mk≃ _
-                      (is-equiv-∘ (∙h-is-equiv (p ◂h (H h⁻¹)))
-                      (∙h-is-equiv' (q ◂h K))))) ⟩
+                      (is-equiv-∘ (∙h-is-equiv (p ◃h (H h⁻¹)))
+                      (∙h-is-equiv' (q ◃h K))))) ⟩
       ((Σ[ p ∶ (B → Q)] Σ[ q ∶ (C → Q)] (p ∘ f' ~ q ∘ g')))
                   ≃⟨ cocone-repr≃ e⁻¹ ⟩
       Cocone S' _ ≃∎
 
   Cocone-map←homotopy : ∀ {𝓠} {Q : Type 𝓠} → Cocone S Q → Cocone S' Q
-  Cocone-map←homotopy cc = mk-cocone p q ((p ◂h (H h⁻¹)) ∙h filler ∙h q ◂h K)
+  Cocone-map←homotopy cc = mk-cocone p q ((p ◃h (H h⁻¹)) ∙h filler ∙h q ◃h K)
     where open Cocone cc
 
   up-pushout←homotopy
@@ -105,11 +105,11 @@ module _ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
                   ~⟨ ∙h-reflr _ ⟩
       Cocone.filler (cocone-map S' (Cocone-map←homotopy cc) f)
                   ~⟨⟩
-      f ◂h ((p ◂h (H h⁻¹)) ∙h filler ∙h q ◂h K)
-                  ~⟨ ◂h∙∙ f (p ◂h (H h⁻¹)) filler (q ◂h K) ⟩
-      (f ◂h (p ◂h (H h⁻¹))) ∙h f ◂h filler ∙h f ◂h q ◂h K
-                  ~⟨ (◂h∘ f p (H h⁻¹) h⁻¹) ⟩∙h⟨ ~refl ⟩∙h⟨ (◂h∘ f q K h⁻¹) ⟩
-      ((f ∘ p) ◂h (H h⁻¹)) ∙h f ◂h filler ∙h (f ∘ q) ◂h K ~∎) where open Cocone cc
+      f ◃h ((p ◃h (H h⁻¹)) ∙h filler ∙h q ◃h K)
+                  ~⟨ ◃h∙∙ f (p ◃h (H h⁻¹)) filler (q ◃h K) ⟩
+      (f ◃h (p ◃h (H h⁻¹))) ∙h f ◃h filler ∙h f ◃h q ◃h K
+                  ~⟨ (◃h∘ f p (H h⁻¹) h⁻¹) ⟩∙h⟨ ~refl ⟩∙h⟨ (◃h∘ f q K h⁻¹) ⟩
+      ((f ∘ p) ◃h (H h⁻¹)) ∙h f ◃h filler ∙h (f ∘ q) ◃h K ~∎) where open Cocone cc
 
   Pushout≃←homotopy : Pushout f' g' ≃ Pushout f g
   Pushout≃←homotopy = mk≃ (cogap (Cocone-map←homotopy pushout))
@@ -320,7 +320,7 @@ module _ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {B' : Type 𝓦}
     {𝓠} {Q} → is-equiv-~∘ (H Q)
                         (extend-cocone ._≃_.fwd-is-equiv)
                         (Pushout-has-up-pushout)) where
-    cc = mk-cocone ι₁ (ι₂ ∘ ι₂) ((glue ∘ g) ∙h ι₂ ◂h glue)
+    cc = mk-cocone ι₁ (ι₂ ∘ ι₂) ((glue ∘ g) ∙h ι₂ ◃h glue)
     map : Pushout (f ∘ g) h → Pushout f (ι₁ {f = g} {h})
     map = cogap cc
 
@@ -328,15 +328,15 @@ module _ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {B' : Type 𝓦}
         → cocone-map (mk-span A (f ∘ g) h) cc
         ~ _≃_.fwd extend-cocone ∘ cocone-map (mk-span B f ι₁) pushout
     H Q f = Cocone-path→ _ _ refl refl
-      ( f ◂h ((glue ∘ g) ∙h ι₂ ◂h glue) ∙h ~refl
+      ( f ◃h ((glue ∘ g) ∙h ι₂ ◃h glue) ∙h ~refl
           ~⟨ ∙h-reflr _ ⟩
-       f ◂h (glue ▸h g ∙h ι₂ ◂h glue)
-          ~⟨ ◂h∙ f (glue ▸h g) _ ⟩
-       (f ◂h glue ▸h g) ∙h (f ◂h ι₂ ◂h glue)
-          ~⟨ ~refl ⟩∙h⟨ (◂h∘ f ι₂ glue h⁻¹) ⟩
-       f ◂h (glue ▸h g) ∙h (f ∘ ι₂) ◂h glue
+       f ◃h (glue ▸h g ∙h ι₂ ◃h glue)
+          ~⟨ ◃h∙ f (glue ▸h g) _ ⟩
+       (f ◃h glue ▸h g) ∙h (f ◃h ι₂ ◃h glue)
+          ~⟨ ~refl ⟩∙h⟨ (◃h∘ f ι₂ glue h⁻¹) ⟩
+       f ◃h (glue ▸h g) ∙h (f ∘ ι₂) ◃h glue
           ~⟨ (λ a → sym (happly funext-redex (g a))) ⟩∙h⟨ ~refl ⟩
-       happly (funext→ (f ◂h glue)) ▸h g ∙h (f ∘ ι₂) ◂h glue
+       happly (funext→ (f ◃h glue)) ▸h g ∙h (f ∘ ι₂) ◃h glue
           ~∎)
 }
 }

--- a/src/Core/PushoutEquiv.lagda.tree
+++ b/src/Core/PushoutEquiv.lagda.tree
@@ -143,7 +143,7 @@ precomp-cocone
     → Cocone S D
     → Cocone (precomp-span S f) D
 precomp-cocone f cc
-  = mk-cocone p q (filler ▸h f) where open Cocone cc
+  = mk-cocone p q (filler ▹h f) where open Cocone cc
 
 precomp-cocone-is-equiv
   : ∀ {𝓤 𝓥 𝓦 𝓜 𝓛} {A : Type 𝓜}  {S : Span 𝓤 𝓥 𝓦}
@@ -297,7 +297,7 @@ module _ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {B' : Type 𝓦}
       open _≊_
 
       qeqv : _ ≊ _
-      qeqv .fwd (mk-cocone q r H , K) = r , happly K ▸h g ∙h H
+      qeqv .fwd (mk-cocone q r H , K) = r , happly K ▹h g ∙h H
       qeqv .fwd-qinv .fst (q , H) = (mk-cocone (p ∘ f) q H) , refl
       qeqv .fwd-qinv .snd .fst cc@(mk-cocone p q filler , refl) = refl
       qeqv .fwd-qinv .snd .snd (p , H) = refl
@@ -330,13 +330,13 @@ module _ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {B' : Type 𝓦}
     H Q f = Cocone-path→ _ _ refl refl
       ( f ◃h ((glue ∘ g) ∙h ι₂ ◃h glue) ∙h ~refl
           ~⟨ ∙h-reflr _ ⟩
-       f ◃h (glue ▸h g ∙h ι₂ ◃h glue)
-          ~⟨ ◃h∙ f (glue ▸h g) _ ⟩
-       (f ◃h glue ▸h g) ∙h (f ◃h ι₂ ◃h glue)
+       f ◃h (glue ▹h g ∙h ι₂ ◃h glue)
+          ~⟨ ◃h∙ f (glue ▹h g) _ ⟩
+       (f ◃h glue ▹h g) ∙h (f ◃h ι₂ ◃h glue)
           ~⟨ ~refl ⟩∙h⟨ (◃h∘ f ι₂ glue h⁻¹) ⟩
-       f ◃h (glue ▸h g) ∙h (f ∘ ι₂) ◃h glue
+       f ◃h (glue ▹h g) ∙h (f ∘ ι₂) ◃h glue
           ~⟨ (λ a → sym (happly funext-redex (g a))) ⟩∙h⟨ ~refl ⟩
-       happly (funext→ (f ◃h glue)) ▸h g ∙h (f ∘ ι₂) ◃h glue
+       happly (funext→ (f ◃h glue)) ▹h g ∙h (f ∘ ι₂) ◃h glue
           ~∎)
 }
 }

--- a/src/Core/PushoutEquiv.lagda.tree
+++ b/src/Core/PushoutEquiv.lagda.tree
@@ -81,14 +81,14 @@ module _ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     = Cocone S _  ≃⟨ cocone-repr≃ ⟩
       (Σ[ p ∶ (B → Q)] Σ[ q ∶ (C → Q)] (p ∘ f ~ q ∘ g))
                   ≃⟨ Σ-snd-≃ (λ p → Σ-snd-≃ (λ q → mk≃ _
-                      (is-equiv-∘ (∙h-is-equiv (p ◂ (H h⁻¹)))
-                      (∙h-is-equiv' (q ◂ K))))) ⟩
+                      (is-equiv-∘ (∙h-is-equiv (p ◂h (H h⁻¹)))
+                      (∙h-is-equiv' (q ◂h K))))) ⟩
       ((Σ[ p ∶ (B → Q)] Σ[ q ∶ (C → Q)] (p ∘ f' ~ q ∘ g')))
                   ≃⟨ cocone-repr≃ e⁻¹ ⟩
       Cocone S' _ ≃∎
 
   Cocone-map←homotopy : ∀ {𝓠} {Q : Type 𝓠} → Cocone S Q → Cocone S' Q
-  Cocone-map←homotopy cc = mk-cocone p q ((p ◂ (H h⁻¹)) ∙h filler ∙h q ◂ K)
+  Cocone-map←homotopy cc = mk-cocone p q ((p ◂h (H h⁻¹)) ∙h filler ∙h q ◂h K)
     where open Cocone cc
 
   up-pushout←homotopy
@@ -105,11 +105,11 @@ module _ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
                   ~⟨ ∙h-reflr _ ⟩
       Cocone.filler (cocone-map S' (Cocone-map←homotopy cc) f)
                   ~⟨⟩
-      f ◂ ((p ◂ (H h⁻¹)) ∙h filler ∙h q ◂ K)
-                  ~⟨ ◂∙∙ f (p ◂ (H h⁻¹)) filler (q ◂ K) ⟩
-      (f ◂ (p ◂ (H h⁻¹))) ∙h f ◂ filler ∙h f ◂ q ◂ K
-                  ~⟨ (◂∘ f p (H h⁻¹) h⁻¹) ⟩∙h⟨ ~refl ⟩∙h⟨ (◂∘ f q K h⁻¹) ⟩
-      ((f ∘ p) ◂ (H h⁻¹)) ∙h f ◂ filler ∙h (f ∘ q) ◂ K ~∎) where open Cocone cc
+      f ◂h ((p ◂h (H h⁻¹)) ∙h filler ∙h q ◂h K)
+                  ~⟨ ◂h∙∙ f (p ◂h (H h⁻¹)) filler (q ◂h K) ⟩
+      (f ◂h (p ◂h (H h⁻¹))) ∙h f ◂h filler ∙h f ◂h q ◂h K
+                  ~⟨ (◂h∘ f p (H h⁻¹) h⁻¹) ⟩∙h⟨ ~refl ⟩∙h⟨ (◂h∘ f q K h⁻¹) ⟩
+      ((f ∘ p) ◂h (H h⁻¹)) ∙h f ◂h filler ∙h (f ∘ q) ◂h K ~∎) where open Cocone cc
 
   Pushout≃←homotopy : Pushout f' g' ≃ Pushout f g
   Pushout≃←homotopy = mk≃ (cogap (Cocone-map←homotopy pushout))
@@ -143,7 +143,7 @@ precomp-cocone
     → Cocone S D
     → Cocone (precomp-span S f) D
 precomp-cocone f cc
-  = mk-cocone p q (filler ▸ f) where open Cocone cc
+  = mk-cocone p q (filler ▸h f) where open Cocone cc
 
 precomp-cocone-is-equiv
   : ∀ {𝓤 𝓥 𝓦 𝓜 𝓛} {A : Type 𝓜}  {S : Span 𝓤 𝓥 𝓦}
@@ -297,7 +297,7 @@ module _ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {B' : Type 𝓦}
       open _≊_
 
       qeqv : _ ≊ _
-      qeqv .fwd (mk-cocone q r H , K) = r , happly K ▸ g ∙h H
+      qeqv .fwd (mk-cocone q r H , K) = r , happly K ▸h g ∙h H
       qeqv .fwd-qinv .fst (q , H) = (mk-cocone (p ∘ f) q H) , refl
       qeqv .fwd-qinv .snd .fst cc@(mk-cocone p q filler , refl) = refl
       qeqv .fwd-qinv .snd .snd (p , H) = refl
@@ -320,7 +320,7 @@ module _ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {B' : Type 𝓦}
     {𝓠} {Q} → is-equiv-~∘ (H Q)
                         (extend-cocone ._≃_.fwd-is-equiv)
                         (Pushout-has-up-pushout)) where
-    cc = mk-cocone ι₁ (ι₂ ∘ ι₂) ((glue ∘ g) ∙h ι₂ ◂ glue)
+    cc = mk-cocone ι₁ (ι₂ ∘ ι₂) ((glue ∘ g) ∙h ι₂ ◂h glue)
     map : Pushout (f ∘ g) h → Pushout f (ι₁ {f = g} {h})
     map = cogap cc
 
@@ -328,15 +328,15 @@ module _ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : Type 𝓥} {B' : Type 𝓦}
         → cocone-map (mk-span A (f ∘ g) h) cc
         ~ _≃_.fwd extend-cocone ∘ cocone-map (mk-span B f ι₁) pushout
     H Q f = Cocone-path→ _ _ refl refl
-      ( f ◂ ((glue ∘ g) ∙h ι₂ ◂ glue) ∙h ~refl
+      ( f ◂h ((glue ∘ g) ∙h ι₂ ◂h glue) ∙h ~refl
           ~⟨ ∙h-reflr _ ⟩
-       f ◂ (glue ▸ g ∙h ι₂ ◂ glue)
-          ~⟨ ◂∙ f (glue ▸ g) _ ⟩
-       (f ◂ glue ▸ g) ∙h (f ◂ ι₂ ◂ glue)
-          ~⟨ ~refl ⟩∙h⟨ (◂∘ f ι₂ glue h⁻¹) ⟩
-       f ◂ (glue ▸ g) ∙h (f ∘ ι₂) ◂ glue
+       f ◂h (glue ▸h g ∙h ι₂ ◂h glue)
+          ~⟨ ◂h∙ f (glue ▸h g) _ ⟩
+       (f ◂h glue ▸h g) ∙h (f ◂h ι₂ ◂h glue)
+          ~⟨ ~refl ⟩∙h⟨ (◂h∘ f ι₂ glue h⁻¹) ⟩
+       f ◂h (glue ▸h g) ∙h (f ∘ ι₂) ◂h glue
           ~⟨ (λ a → sym (happly funext-redex (g a))) ⟩∙h⟨ ~refl ⟩
-       happly (funext→ (f ◂ glue)) ▸ g ∙h (f ∘ ι₂) ◂ glue
+       happly (funext→ (f ◂h glue)) ▸h g ∙h (f ∘ ι₂) ◂h glue
           ~∎)
 }
 }

--- a/src/Core/SeqMapHomotopy.lagda.tree
+++ b/src/Core/SeqMapHomotopy.lagda.tree
@@ -108,24 +108,24 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
     Fbwd = cotower-map-inv←equiv {F = F} Feq
     Fbwd∘F = comp-cotower-map Fbwd F
 
-    lemma : ∀ {n} → (F.bwd ◂ ( (comm F h⁻¹) ▸ F.bwd ▸ map F
-                        ∙h (incr S' {n} ◂ F.ε ▸ map F))
-                     ∙h F.bwd ◂ comm F)
-                   ~ F.bwd ◂ map F ◂ incr S ◂ F.η
-    lemma = ((◂∙ F.bwd _ (comm F)) h⁻¹) ∙h (F.bwd ⟩◂⟨
-        (((comm F h⁻¹) ▸ F.bwd ▸ map F ∙h incr S' ◂ F.ε ▸ map F) ∙h comm F
-                  ~⟨ (~refl ⟩∙h⟨ incr S' ⟩◂⟨ (F.coherent h⁻¹)) ⟩∙h⟨ ~refl: comm F ⟩
-        ((comm F h⁻¹) ▸ F.bwd ▸ map F ∙h incr S' ◂ map F ◂ F.η) ∙h comm F
-                  ~⟨ (~refl ⟩∙h⟨ ((◂∘ (incr S') (map F) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (comm F)) h⁻¹) ⟩
-        ((comm F h⁻¹) ▸ F.bwd ▸ map F ∙h (incr S' ∘ map F) ◂ F.η) ∙h (comm F  ∙h ~refl)
+    lemma : ∀ {n} → (F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd ▸h map F
+                        ∙h (incr S' {n} ◂h F.ε ▸h map F))
+                     ∙h F.bwd ◂h comm F)
+                   ~ F.bwd ◂h map F ◂h incr S ◂h F.η
+    lemma = ((◂h∙ F.bwd _ (comm F)) h⁻¹) ∙h (F.bwd ⟩◂h⟨
+        (((comm F h⁻¹) ▸h F.bwd ▸h map F ∙h incr S' ◂h F.ε ▸h map F) ∙h comm F
+                  ~⟨ (~refl ⟩∙h⟨ incr S' ⟩◂h⟨ (F.coherent h⁻¹)) ⟩∙h⟨ ~refl: comm F ⟩
+        ((comm F h⁻¹) ▸h F.bwd ▸h map F ∙h incr S' ◂h map F ◂h F.η) ∙h comm F
+                  ~⟨ (~refl ⟩∙h⟨ ((◂h∘ (incr S') (map F) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (comm F)) h⁻¹) ⟩
+        ((comm F h⁻¹) ▸h F.bwd ▸h map F ∙h (incr S' ∘ map F) ◂h F.η) ∙h (comm F  ∙h ~refl)
                   ~⟨⟩
-        ((comm F h⁻¹) ◾ F.η)
-           ∙h (comm F ◾ ~refl)
+        ((comm F h⁻¹) ◾h F.η)
+           ∙h (comm F ◾h ~refl)
                  ~⟨ homotopy-interchange (comm F h⁻¹) _ F.η ~refl ⟩
-        ((comm F h⁻¹) ∙h comm F) ◾ (F.η ∙h ~refl)
-                 ~⟨ ∙h-sym' (comm F) ⟩◾⟨ ∙h-reflr _ ⟩
-        (map F ∘ incr S) ◂ F.η ~⟨ ◂∘ (map F) (incr S) _ ⟩
-        map F ◂ incr S ◂ F.η     ~∎))
+        ((comm F h⁻¹) ∙h comm F) ◾h (F.η ∙h ~refl)
+                 ~⟨ ∙h-sym' (comm F) ⟩◾h⟨ ∙h-reflr _ ⟩
+        (map F ∘ incr S) ◂h F.η ~⟨ ◂h∘ (map F) (incr S) _ ⟩
+        map F ◂h incr S ◂h F.η     ~∎))
 
   inverse-seq-map-section
     : cotower-map~
@@ -133,81 +133,81 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
         id-cotower-map
   inverse-seq-map-section .fst = F.η
   inverse-seq-map-section .snd
-    = comm Fbwd∘F ∙h F.η ▸ incr S ~⟨⟩
-      (comm Fbwd ▸ (map F) ∙h (map Fbwd) ◂ comm F) ∙h F.η ▸ incr S
+    = comm Fbwd∘F ∙h F.η ▸h incr S ~⟨⟩
+      (comm Fbwd ▸h (map F) ∙h (map Fbwd) ◂h comm F) ∙h F.η ▸h incr S
                                   ~⟨⟩
 
-      (((F.η h⁻¹) ▸ incr S ▸ F.bwd ▸ map F
-         ∙h F.bwd ◂ ( (comm F h⁻¹) ▸ F.bwd ▸ map F
-                    ∙h (incr S' ◂ F.ε ▸ map F)))
-       ∙h F.bwd ◂ comm F)
-      ∙h F.η ▸ incr S
+      (((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F
+         ∙h F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd ▸h map F
+                    ∙h (incr S' ◂h F.ε ▸h map F)))
+       ∙h F.bwd ◂h comm F)
+      ∙h F.η ▸h incr S
 
-            ~⟨ ∙h-assoc ((F.η h⁻¹) ▸ incr S ▸ F.bwd ▸ map F) _ (F.bwd ◂ comm F) ⟩∙h⟨ ~refl: (F.η ▸ incr S) ⟩
+            ~⟨ ∙h-assoc ((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F) _ (F.bwd ◂h comm F) ⟩∙h⟨ ~refl: (F.η ▸h incr S) ⟩
 
-      (((F.η h⁻¹) ▸ incr S ▸ F.bwd ▸ map F
-         ∙h (  F.bwd ◂ ( (comm F h⁻¹) ▸ F.bwd ▸ map F
-                        ∙h (incr S' ◂ F.ε ▸ map F))
-            ∙h F.bwd ◂ comm F)))
-      ∙h F.η ▸ incr S
+      (((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F
+         ∙h (  F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd ▸h map F
+                        ∙h (incr S' ◂h F.ε ▸h map F))
+            ∙h F.bwd ◂h comm F)))
+      ∙h F.η ▸h incr S
 
-            ~⟨ (~refl: (F.η h⁻¹ ▸ incr S ▸ F.bwd ▸ map F) ⟩∙h⟨ lemma) ⟩∙h⟨ ~refl: (F.η ▸ incr S) ⟩
+            ~⟨ (~refl: (F.η h⁻¹ ▸h incr S ▸h F.bwd ▸h map F) ⟩∙h⟨ lemma) ⟩∙h⟨ ~refl: (F.η ▸h incr S) ⟩
 
-      ((F.η h⁻¹) ▸ incr S ▸ F.bwd ▸ map F
-         ∙h F.bwd ◂ map F ◂ incr S ◂ F.η)
-      ∙h F.η ▸ incr S
+      ((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F
+         ∙h F.bwd ◂h map F ◂h incr S ◂h F.η)
+      ∙h F.η ▸h incr S
 
-            ~⟨ (~refl ⟩∙h⟨ ((◂∘∘ F.bwd (map F) (incr S) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (F.η ▸ incr S)) h⁻¹) ⟩
+            ~⟨ (~refl ⟩∙h⟨ ((◂h∘∘ F.bwd (map F) (incr S) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (F.η ▸h incr S)) h⁻¹) ⟩
 
-      (((F.η h⁻¹) ▸ incr S) ◾ F.η)
-      ∙h ((F.η ▸ incr S) ◾ ~refl)
+      (((F.η h⁻¹) ▸h incr S) ◾h F.η)
+      ∙h ((F.η ▸h incr S) ◾h ~refl)
 
-             ~⟨ homotopy-interchange ((F.η h⁻¹) ▸ incr S) _ (F.η) ~refl ⟩
+             ~⟨ homotopy-interchange ((F.η h⁻¹) ▸h incr S) _ (F.η) ~refl ⟩
 
-      ((F.η h⁻¹) ▸ incr S ∙h F.η ▸ incr S) ◾ (F.η ∙h ~refl)
-                                  ~⟨ ∙h-sym' (F.η ▸ incr S) ⟩◾⟨ ∙h-reflr F.η ⟩
-      ~refl ◾ F.η
+      ((F.η h⁻¹) ▸h incr S ∙h F.η ▸h incr S) ◾h (F.η ∙h ~refl)
+                                  ~⟨ ∙h-sym' (F.η ▸h incr S) ⟩◾h⟨ ∙h-reflr F.η ⟩
+      ~refl ◾h F.η
                                   ~⟨⟩
-      (incr S ◂ F.η)              ~⟨ (∙h-reflr (incr S ◂ F.η))  h⁻¹ ⟩
-      (incr S ◂ F.η ∙h comm (id-cotower-map {S = S})) ~∎
+      (incr S ◂h F.η)              ~⟨ (∙h-reflr (incr S ◂h F.η))  h⁻¹ ⟩
+      (incr S ◂h F.η ∙h comm (id-cotower-map {S = S})) ~∎
 
   private
     F∘Fbwd = comp-cotower-map F Fbwd
 
     lemma2 : ∀ {n} →
-               (map F ◂ (((F.η h⁻¹) ▸ incr S ▸ F.bwd
-                   ∙h F.bwd ◂ ( (comm F h⁻¹) ▸ F.bwd
-                   ∙h (incr S' ◂ F.ε)))) ∙h F.ε ▸ incr S' {n})
-             ~ (comm F h⁻¹) ▸ F.bwd ∙h incr S' ◂ F.ε
+               (map F ◂h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
+                   ∙h F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd
+                   ∙h (incr S' ◂h F.ε)))) ∙h F.ε ▸h incr S' {n})
+             ~ (comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε
 
     lemma2
-      = (map F ◂ (((F.η h⁻¹) ▸ incr S ▸ F.bwd
-                   ∙h F.bwd ◂ ( (comm F h⁻¹) ▸ F.bwd
-                   ∙h (incr S' ◂ F.ε))))
-        ∙h F.ε ▸ incr S')
+      = (map F ◂h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
+                   ∙h F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd
+                   ∙h (incr S' ◂h F.ε))))
+        ∙h F.ε ▸h incr S')
 
-                  ~⟨ ◂∙ (map F) ((F.η h⁻¹) ▸ incr S ▸ F.bwd) _ ⟩∙h⟨ ~refl ⟩
+                  ~⟨ ◂h∙ (map F) ((F.η h⁻¹) ▸h incr S ▸h F.bwd) _ ⟩∙h⟨ ~refl ⟩
 
-           (map F ◂ F.η⁻¹ ▸ incr S ▸ F.bwd
-         ∙h map F ◂ F.bwd ◂ ((comm F h⁻¹) ▸ F.bwd ∙h incr S' ◂ F.ε))
-         ∙h F.ε ▸ incr S'
+           (map F ◂h F.η⁻¹ ▸h incr S ▸h F.bwd
+         ∙h map F ◂h F.bwd ◂h ((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε))
+         ∙h F.ε ▸h incr S'
 
-                  ~⟨ (F.coh⁻¹ ∘ incr S ∘ F.bwd ⟩∙h⟨ ~refl) ⟩∙h⟨ ~refl: (F.ε ▸ incr S') ⟩
+                  ~⟨ (F.coh⁻¹ ∘ incr S ∘ F.bwd ⟩∙h⟨ ~refl) ⟩∙h⟨ ~refl: (F.ε ▸h incr S') ⟩
 
-           (F.ε⁻¹ ▸ map F ▸ incr S ▸ F.bwd
-         ∙h map F ◂ F.bwd ◂ ((comm F h⁻¹) ▸ F.bwd ∙h incr S' ◂ F.ε))
-         ∙h F.ε ▸ incr S'
+           (F.ε⁻¹ ▸h map F ▸h incr S ▸h F.bwd
+         ∙h map F ◂h F.bwd ◂h ((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε))
+         ∙h F.ε ▸h incr S'
 
-                  ~⟨ ( ~refl: (F.ε⁻¹ ▸ map F ▸ incr S ▸ F.bwd) ⟩∙h⟨ ((◂∘ (map F) F.bwd _) h⁻¹)) ⟩∙h⟨ (∙h-reflr _ h⁻¹) ⟩
+                  ~⟨ ( ~refl: (F.ε⁻¹ ▸h map F ▸h incr S ▸h F.bwd) ⟩∙h⟨ ((◂h∘ (map F) F.bwd _) h⁻¹)) ⟩∙h⟨ (∙h-reflr _ h⁻¹) ⟩
 
-           ((F.ε h⁻¹) ◾ ((comm F h⁻¹) ▸ F.bwd ∙h incr S' ◂ F.ε))
-         ∙h (F.ε ◾ ~refl)
+           ((F.ε h⁻¹) ◾h ((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε))
+         ∙h (F.ε ◾h ~refl)
                  ~⟨ homotopy-interchange (F.ε h⁻¹) F.ε _ ~refl ⟩
-        ((F.ε h⁻¹) ∙h F.ε) ◾ (((comm F h⁻¹) ▸ F.bwd ∙h incr S' ◂ F.ε) ∙h ~refl)
-                 ~⟨ ∙h-sym' F.ε ⟩◾⟨ ∙h-reflr _ ⟩
-         (~refl: id) ◾ (((comm F h⁻¹) ▸ F.bwd ∙h incr S' ◂ F.ε))
+        ((F.ε h⁻¹) ∙h F.ε) ◾h (((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε) ∙h ~refl)
+                 ~⟨ ∙h-sym' F.ε ⟩◾h⟨ ∙h-reflr _ ⟩
+         (~refl: id) ◾h (((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε))
                  ~⟨ ap-id ∘ _ ⟩
-        (comm F h⁻¹) ▸ F.bwd ∙h incr S' ◂ F.ε ~∎
+        (comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε ~∎
 
   inverse-seq-map-retraction
     : cotower-map~
@@ -215,30 +215,30 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
         id-cotower-map
   inverse-seq-map-retraction .fst = F.ε
   inverse-seq-map-retraction .snd
-    = (comm F∘Fbwd ∙h F.ε ▸ incr S')  ~⟨⟩
-      (comm F ▸ F.bwd ∙h map F ◂ comm Fbwd) ∙h F.ε ▸ incr S' ~⟨⟩
-      (comm F ▸ F.bwd
-        ∙h map F ◂ (((F.η h⁻¹) ▸ incr S ▸ F.bwd
-                   ∙h F.bwd ◂ ( (comm F h⁻¹) ▸ F.bwd
-                   ∙h (incr S' ◂ F.ε)))))
-      ∙h F.ε ▸ incr S'
+    = (comm F∘Fbwd ∙h F.ε ▸h incr S')  ~⟨⟩
+      (comm F ▸h F.bwd ∙h map F ◂h comm Fbwd) ∙h F.ε ▸h incr S' ~⟨⟩
+      (comm F ▸h F.bwd
+        ∙h map F ◂h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
+                   ∙h F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd
+                   ∙h (incr S' ◂h F.ε)))))
+      ∙h F.ε ▸h incr S'
 
-                  ~⟨ ∙h-assoc (comm F ▸ F.bwd) _ (F.ε ▸ incr S') ⟩
+                  ~⟨ ∙h-assoc (comm F ▸h F.bwd) _ (F.ε ▸h incr S') ⟩
 
-      comm F ▸ F.bwd
-      ∙h (map F ◂ (((F.η h⁻¹) ▸ incr S ▸ F.bwd
-                   ∙h F.bwd ◂ ( (comm F h⁻¹) ▸ F.bwd
-                   ∙h (incr S' ◂ F.ε))))
-          ∙h F.ε ▸ incr S')
+      comm F ▸h F.bwd
+      ∙h (map F ◂h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
+                   ∙h F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd
+                   ∙h (incr S' ◂h F.ε))))
+          ∙h F.ε ▸h incr S')
 
-                  ~⟨ ~refl: (comm F ▸ F.bwd) ⟩∙h⟨ lemma2 ⟩
+                  ~⟨ ~refl: (comm F ▸h F.bwd) ⟩∙h⟨ lemma2 ⟩
 
-      comm F ▸ F.bwd ∙h (comm F h⁻¹) ▸ F.bwd ∙h incr S' ◂ F.ε
-                  ~⟨ (∙h-assoc (comm F ▸ F.bwd) _ (incr S' ◂ F.ε)) h⁻¹ ⟩
-      (comm F ▸ F.bwd ∙h (comm F h⁻¹) ▸ F.bwd) ∙h incr S' ◂ F.ε
+      comm F ▸h F.bwd ∙h (comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε
+                  ~⟨ (∙h-assoc (comm F ▸h F.bwd) _ (incr S' ◂h F.ε)) h⁻¹ ⟩
+      (comm F ▸h F.bwd ∙h (comm F h⁻¹) ▸h F.bwd) ∙h incr S' ◂h F.ε
                   ~⟨ ∙h-sym (comm F) ∘ F.bwd ⟩∙h⟨ ~refl ⟩
-      incr S' ◂ F.ε
+      incr S' ◂h F.ε
                   ~⟨ ∙h-reflr _ h⁻¹ ⟩
-      incr S' ◂ F.ε ∙h comm (id-cotower-map {S = S'})  ~∎
+      incr S' ◂h F.ε ∙h comm (id-cotower-map {S = S'})  ~∎
 }
 }

--- a/src/Core/SeqMapHomotopy.lagda.tree
+++ b/src/Core/SeqMapHomotopy.lagda.tree
@@ -108,24 +108,24 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
     Fbwd = cotower-map-inv←equiv {F = F} Feq
     Fbwd∘F = comp-cotower-map Fbwd F
 
-    lemma : ∀ {n} → (F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd ▸h map F
-                        ∙h (incr S' {n} ◂h F.ε ▸h map F))
-                     ∙h F.bwd ◂h comm F)
-                   ~ F.bwd ◂h map F ◂h incr S ◂h F.η
-    lemma = ((◂h∙ F.bwd _ (comm F)) h⁻¹) ∙h (F.bwd ⟩◂h⟨
-        (((comm F h⁻¹) ▸h F.bwd ▸h map F ∙h incr S' ◂h F.ε ▸h map F) ∙h comm F
-                  ~⟨ (~refl ⟩∙h⟨ incr S' ⟩◂h⟨ (F.coherent h⁻¹)) ⟩∙h⟨ ~refl: comm F ⟩
-        ((comm F h⁻¹) ▸h F.bwd ▸h map F ∙h incr S' ◂h map F ◂h F.η) ∙h comm F
-                  ~⟨ (~refl ⟩∙h⟨ ((◂h∘ (incr S') (map F) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (comm F)) h⁻¹) ⟩
-        ((comm F h⁻¹) ▸h F.bwd ▸h map F ∙h (incr S' ∘ map F) ◂h F.η) ∙h (comm F  ∙h ~refl)
+    lemma : ∀ {n} → (F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd ▸h map F
+                        ∙h (incr S' {n} ◃h F.ε ▸h map F))
+                     ∙h F.bwd ◃h comm F)
+                   ~ F.bwd ◃h map F ◃h incr S ◃h F.η
+    lemma = ((◃h∙ F.bwd _ (comm F)) h⁻¹) ∙h (F.bwd ⟩◃h⟨
+        (((comm F h⁻¹) ▸h F.bwd ▸h map F ∙h incr S' ◃h F.ε ▸h map F) ∙h comm F
+                  ~⟨ (~refl ⟩∙h⟨ incr S' ⟩◃h⟨ (F.coherent h⁻¹)) ⟩∙h⟨ ~refl: comm F ⟩
+        ((comm F h⁻¹) ▸h F.bwd ▸h map F ∙h incr S' ◃h map F ◃h F.η) ∙h comm F
+                  ~⟨ (~refl ⟩∙h⟨ ((◃h∘ (incr S') (map F) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (comm F)) h⁻¹) ⟩
+        ((comm F h⁻¹) ▸h F.bwd ▸h map F ∙h (incr S' ∘ map F) ◃h F.η) ∙h (comm F  ∙h ~refl)
                   ~⟨⟩
         ((comm F h⁻¹) ◾h F.η)
            ∙h (comm F ◾h ~refl)
                  ~⟨ homotopy-interchange (comm F h⁻¹) _ F.η ~refl ⟩
         ((comm F h⁻¹) ∙h comm F) ◾h (F.η ∙h ~refl)
                  ~⟨ ∙h-sym' (comm F) ⟩◾h⟨ ∙h-reflr _ ⟩
-        (map F ∘ incr S) ◂h F.η ~⟨ ◂h∘ (map F) (incr S) _ ⟩
-        map F ◂h incr S ◂h F.η     ~∎))
+        (map F ∘ incr S) ◃h F.η ~⟨ ◃h∘ (map F) (incr S) _ ⟩
+        map F ◃h incr S ◃h F.η     ~∎))
 
   inverse-seq-map-section
     : cotower-map~
@@ -134,30 +134,30 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
   inverse-seq-map-section .fst = F.η
   inverse-seq-map-section .snd
     = comm Fbwd∘F ∙h F.η ▸h incr S ~⟨⟩
-      (comm Fbwd ▸h (map F) ∙h (map Fbwd) ◂h comm F) ∙h F.η ▸h incr S
+      (comm Fbwd ▸h (map F) ∙h (map Fbwd) ◃h comm F) ∙h F.η ▸h incr S
                                   ~⟨⟩
 
       (((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F
-         ∙h F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd ▸h map F
-                    ∙h (incr S' ◂h F.ε ▸h map F)))
-       ∙h F.bwd ◂h comm F)
+         ∙h F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd ▸h map F
+                    ∙h (incr S' ◃h F.ε ▸h map F)))
+       ∙h F.bwd ◃h comm F)
       ∙h F.η ▸h incr S
 
-            ~⟨ ∙h-assoc ((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F) _ (F.bwd ◂h comm F) ⟩∙h⟨ ~refl: (F.η ▸h incr S) ⟩
+            ~⟨ ∙h-assoc ((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F) _ (F.bwd ◃h comm F) ⟩∙h⟨ ~refl: (F.η ▸h incr S) ⟩
 
       (((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F
-         ∙h (  F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd ▸h map F
-                        ∙h (incr S' ◂h F.ε ▸h map F))
-            ∙h F.bwd ◂h comm F)))
+         ∙h (  F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd ▸h map F
+                        ∙h (incr S' ◃h F.ε ▸h map F))
+            ∙h F.bwd ◃h comm F)))
       ∙h F.η ▸h incr S
 
             ~⟨ (~refl: (F.η h⁻¹ ▸h incr S ▸h F.bwd ▸h map F) ⟩∙h⟨ lemma) ⟩∙h⟨ ~refl: (F.η ▸h incr S) ⟩
 
       ((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F
-         ∙h F.bwd ◂h map F ◂h incr S ◂h F.η)
+         ∙h F.bwd ◃h map F ◃h incr S ◃h F.η)
       ∙h F.η ▸h incr S
 
-            ~⟨ (~refl ⟩∙h⟨ ((◂h∘∘ F.bwd (map F) (incr S) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (F.η ▸h incr S)) h⁻¹) ⟩
+            ~⟨ (~refl ⟩∙h⟨ ((◃h∘∘ F.bwd (map F) (incr S) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (F.η ▸h incr S)) h⁻¹) ⟩
 
       (((F.η h⁻¹) ▸h incr S) ◾h F.η)
       ∙h ((F.η ▸h incr S) ◾h ~refl)
@@ -168,46 +168,46 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
                                   ~⟨ ∙h-sym' (F.η ▸h incr S) ⟩◾h⟨ ∙h-reflr F.η ⟩
       ~refl ◾h F.η
                                   ~⟨⟩
-      (incr S ◂h F.η)              ~⟨ (∙h-reflr (incr S ◂h F.η))  h⁻¹ ⟩
-      (incr S ◂h F.η ∙h comm (id-cotower-map {S = S})) ~∎
+      (incr S ◃h F.η)              ~⟨ (∙h-reflr (incr S ◃h F.η))  h⁻¹ ⟩
+      (incr S ◃h F.η ∙h comm (id-cotower-map {S = S})) ~∎
 
   private
     F∘Fbwd = comp-cotower-map F Fbwd
 
     lemma2 : ∀ {n} →
-               (map F ◂h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
-                   ∙h F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd
-                   ∙h (incr S' ◂h F.ε)))) ∙h F.ε ▸h incr S' {n})
-             ~ (comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε
+               (map F ◃h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
+                   ∙h F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd
+                   ∙h (incr S' ◃h F.ε)))) ∙h F.ε ▸h incr S' {n})
+             ~ (comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε
 
     lemma2
-      = (map F ◂h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
-                   ∙h F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd
-                   ∙h (incr S' ◂h F.ε))))
+      = (map F ◃h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
+                   ∙h F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd
+                   ∙h (incr S' ◃h F.ε))))
         ∙h F.ε ▸h incr S')
 
-                  ~⟨ ◂h∙ (map F) ((F.η h⁻¹) ▸h incr S ▸h F.bwd) _ ⟩∙h⟨ ~refl ⟩
+                  ~⟨ ◃h∙ (map F) ((F.η h⁻¹) ▸h incr S ▸h F.bwd) _ ⟩∙h⟨ ~refl ⟩
 
-           (map F ◂h F.η⁻¹ ▸h incr S ▸h F.bwd
-         ∙h map F ◂h F.bwd ◂h ((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε))
+           (map F ◃h F.η⁻¹ ▸h incr S ▸h F.bwd
+         ∙h map F ◃h F.bwd ◃h ((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε))
          ∙h F.ε ▸h incr S'
 
                   ~⟨ (F.coh⁻¹ ∘ incr S ∘ F.bwd ⟩∙h⟨ ~refl) ⟩∙h⟨ ~refl: (F.ε ▸h incr S') ⟩
 
            (F.ε⁻¹ ▸h map F ▸h incr S ▸h F.bwd
-         ∙h map F ◂h F.bwd ◂h ((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε))
+         ∙h map F ◃h F.bwd ◃h ((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε))
          ∙h F.ε ▸h incr S'
 
-                  ~⟨ ( ~refl: (F.ε⁻¹ ▸h map F ▸h incr S ▸h F.bwd) ⟩∙h⟨ ((◂h∘ (map F) F.bwd _) h⁻¹)) ⟩∙h⟨ (∙h-reflr _ h⁻¹) ⟩
+                  ~⟨ ( ~refl: (F.ε⁻¹ ▸h map F ▸h incr S ▸h F.bwd) ⟩∙h⟨ ((◃h∘ (map F) F.bwd _) h⁻¹)) ⟩∙h⟨ (∙h-reflr _ h⁻¹) ⟩
 
-           ((F.ε h⁻¹) ◾h ((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε))
+           ((F.ε h⁻¹) ◾h ((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε))
          ∙h (F.ε ◾h ~refl)
                  ~⟨ homotopy-interchange (F.ε h⁻¹) F.ε _ ~refl ⟩
-        ((F.ε h⁻¹) ∙h F.ε) ◾h (((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε) ∙h ~refl)
+        ((F.ε h⁻¹) ∙h F.ε) ◾h (((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε) ∙h ~refl)
                  ~⟨ ∙h-sym' F.ε ⟩◾h⟨ ∙h-reflr _ ⟩
-         (~refl: id) ◾h (((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε))
+         (~refl: id) ◾h (((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε))
                  ~⟨ ap-id ∘ _ ⟩
-        (comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε ~∎
+        (comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε ~∎
 
   inverse-seq-map-retraction
     : cotower-map~
@@ -216,29 +216,29 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
   inverse-seq-map-retraction .fst = F.ε
   inverse-seq-map-retraction .snd
     = (comm F∘Fbwd ∙h F.ε ▸h incr S')  ~⟨⟩
-      (comm F ▸h F.bwd ∙h map F ◂h comm Fbwd) ∙h F.ε ▸h incr S' ~⟨⟩
+      (comm F ▸h F.bwd ∙h map F ◃h comm Fbwd) ∙h F.ε ▸h incr S' ~⟨⟩
       (comm F ▸h F.bwd
-        ∙h map F ◂h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
-                   ∙h F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd
-                   ∙h (incr S' ◂h F.ε)))))
+        ∙h map F ◃h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
+                   ∙h F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd
+                   ∙h (incr S' ◃h F.ε)))))
       ∙h F.ε ▸h incr S'
 
                   ~⟨ ∙h-assoc (comm F ▸h F.bwd) _ (F.ε ▸h incr S') ⟩
 
       comm F ▸h F.bwd
-      ∙h (map F ◂h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
-                   ∙h F.bwd ◂h ( (comm F h⁻¹) ▸h F.bwd
-                   ∙h (incr S' ◂h F.ε))))
+      ∙h (map F ◃h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
+                   ∙h F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd
+                   ∙h (incr S' ◃h F.ε))))
           ∙h F.ε ▸h incr S')
 
                   ~⟨ ~refl: (comm F ▸h F.bwd) ⟩∙h⟨ lemma2 ⟩
 
-      comm F ▸h F.bwd ∙h (comm F h⁻¹) ▸h F.bwd ∙h incr S' ◂h F.ε
-                  ~⟨ (∙h-assoc (comm F ▸h F.bwd) _ (incr S' ◂h F.ε)) h⁻¹ ⟩
-      (comm F ▸h F.bwd ∙h (comm F h⁻¹) ▸h F.bwd) ∙h incr S' ◂h F.ε
+      comm F ▸h F.bwd ∙h (comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε
+                  ~⟨ (∙h-assoc (comm F ▸h F.bwd) _ (incr S' ◃h F.ε)) h⁻¹ ⟩
+      (comm F ▸h F.bwd ∙h (comm F h⁻¹) ▸h F.bwd) ∙h incr S' ◃h F.ε
                   ~⟨ ∙h-sym (comm F) ∘ F.bwd ⟩∙h⟨ ~refl ⟩
-      incr S' ◂h F.ε
+      incr S' ◃h F.ε
                   ~⟨ ∙h-reflr _ h⁻¹ ⟩
-      incr S' ◂h F.ε ∙h comm (id-cotower-map {S = S'})  ~∎
+      incr S' ◃h F.ε ∙h comm (id-cotower-map {S = S'})  ~∎
 }
 }

--- a/src/Core/SeqMapHomotopy.lagda.tree
+++ b/src/Core/SeqMapHomotopy.lagda.tree
@@ -119,11 +119,11 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
                   ~⟨ (~refl ⟩∙h⟨ ((◃h∘ (incr S') (map F) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (comm F)) h⁻¹) ⟩
         ((comm F h⁻¹) ▹h F.bwd ▹h map F ∙h (incr S' ∘ map F) ◃h F.η) ∙h (comm F  ∙h ~refl)
                   ~⟨⟩
-        ((comm F h⁻¹) ◾h F.η)
-           ∙h (comm F ◾h ~refl)
+        ((comm F h⁻¹) ◽h F.η)
+           ∙h (comm F ◽h ~refl)
                  ~⟨ homotopy-interchange (comm F h⁻¹) _ F.η ~refl ⟩
-        ((comm F h⁻¹) ∙h comm F) ◾h (F.η ∙h ~refl)
-                 ~⟨ ∙h-sym' (comm F) ⟩◾h⟨ ∙h-reflr _ ⟩
+        ((comm F h⁻¹) ∙h comm F) ◽h (F.η ∙h ~refl)
+                 ~⟨ ∙h-sym' (comm F) ⟩◽h⟨ ∙h-reflr _ ⟩
         (map F ∘ incr S) ◃h F.η ~⟨ ◃h∘ (map F) (incr S) _ ⟩
         map F ◃h incr S ◃h F.η     ~∎))
 
@@ -159,14 +159,14 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
 
             ~⟨ (~refl ⟩∙h⟨ ((◃h∘∘ F.bwd (map F) (incr S) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (F.η ▹h incr S)) h⁻¹) ⟩
 
-      (((F.η h⁻¹) ▹h incr S) ◾h F.η)
-      ∙h ((F.η ▹h incr S) ◾h ~refl)
+      (((F.η h⁻¹) ▹h incr S) ◽h F.η)
+      ∙h ((F.η ▹h incr S) ◽h ~refl)
 
              ~⟨ homotopy-interchange ((F.η h⁻¹) ▹h incr S) _ (F.η) ~refl ⟩
 
-      ((F.η h⁻¹) ▹h incr S ∙h F.η ▹h incr S) ◾h (F.η ∙h ~refl)
-                                  ~⟨ ∙h-sym' (F.η ▹h incr S) ⟩◾h⟨ ∙h-reflr F.η ⟩
-      ~refl ◾h F.η
+      ((F.η h⁻¹) ▹h incr S ∙h F.η ▹h incr S) ◽h (F.η ∙h ~refl)
+                                  ~⟨ ∙h-sym' (F.η ▹h incr S) ⟩◽h⟨ ∙h-reflr F.η ⟩
+      ~refl ◽h F.η
                                   ~⟨⟩
       (incr S ◃h F.η)              ~⟨ (∙h-reflr (incr S ◃h F.η))  h⁻¹ ⟩
       (incr S ◃h F.η ∙h comm (id-cotower-map {S = S})) ~∎
@@ -200,12 +200,12 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
 
                   ~⟨ ( ~refl: (F.ε⁻¹ ▹h map F ▹h incr S ▹h F.bwd) ⟩∙h⟨ ((◃h∘ (map F) F.bwd _) h⁻¹)) ⟩∙h⟨ (∙h-reflr _ h⁻¹) ⟩
 
-           ((F.ε h⁻¹) ◾h ((comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε))
-         ∙h (F.ε ◾h ~refl)
+           ((F.ε h⁻¹) ◽h ((comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε))
+         ∙h (F.ε ◽h ~refl)
                  ~⟨ homotopy-interchange (F.ε h⁻¹) F.ε _ ~refl ⟩
-        ((F.ε h⁻¹) ∙h F.ε) ◾h (((comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε) ∙h ~refl)
-                 ~⟨ ∙h-sym' F.ε ⟩◾h⟨ ∙h-reflr _ ⟩
-         (~refl: id) ◾h (((comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε))
+        ((F.ε h⁻¹) ∙h F.ε) ◽h (((comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε) ∙h ~refl)
+                 ~⟨ ∙h-sym' F.ε ⟩◽h⟨ ∙h-reflr _ ⟩
+         (~refl: id) ◽h (((comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε))
                  ~⟨ ap-id ∘ _ ⟩
         (comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε ~∎
 

--- a/src/Core/SeqMapHomotopy.lagda.tree
+++ b/src/Core/SeqMapHomotopy.lagda.tree
@@ -108,16 +108,16 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
     Fbwd = cotower-map-inv←equiv {F = F} Feq
     Fbwd∘F = comp-cotower-map Fbwd F
 
-    lemma : ∀ {n} → (F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd ▸h map F
-                        ∙h (incr S' {n} ◃h F.ε ▸h map F))
+    lemma : ∀ {n} → (F.bwd ◃h ( (comm F h⁻¹) ▹h F.bwd ▹h map F
+                        ∙h (incr S' {n} ◃h F.ε ▹h map F))
                      ∙h F.bwd ◃h comm F)
                    ~ F.bwd ◃h map F ◃h incr S ◃h F.η
     lemma = ((◃h∙ F.bwd _ (comm F)) h⁻¹) ∙h (F.bwd ⟩◃h⟨
-        (((comm F h⁻¹) ▸h F.bwd ▸h map F ∙h incr S' ◃h F.ε ▸h map F) ∙h comm F
+        (((comm F h⁻¹) ▹h F.bwd ▹h map F ∙h incr S' ◃h F.ε ▹h map F) ∙h comm F
                   ~⟨ (~refl ⟩∙h⟨ incr S' ⟩◃h⟨ (F.coherent h⁻¹)) ⟩∙h⟨ ~refl: comm F ⟩
-        ((comm F h⁻¹) ▸h F.bwd ▸h map F ∙h incr S' ◃h map F ◃h F.η) ∙h comm F
+        ((comm F h⁻¹) ▹h F.bwd ▹h map F ∙h incr S' ◃h map F ◃h F.η) ∙h comm F
                   ~⟨ (~refl ⟩∙h⟨ ((◃h∘ (incr S') (map F) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (comm F)) h⁻¹) ⟩
-        ((comm F h⁻¹) ▸h F.bwd ▸h map F ∙h (incr S' ∘ map F) ◃h F.η) ∙h (comm F  ∙h ~refl)
+        ((comm F h⁻¹) ▹h F.bwd ▹h map F ∙h (incr S' ∘ map F) ◃h F.η) ∙h (comm F  ∙h ~refl)
                   ~⟨⟩
         ((comm F h⁻¹) ◾h F.η)
            ∙h (comm F ◾h ~refl)
@@ -133,39 +133,39 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
         id-cotower-map
   inverse-seq-map-section .fst = F.η
   inverse-seq-map-section .snd
-    = comm Fbwd∘F ∙h F.η ▸h incr S ~⟨⟩
-      (comm Fbwd ▸h (map F) ∙h (map Fbwd) ◃h comm F) ∙h F.η ▸h incr S
+    = comm Fbwd∘F ∙h F.η ▹h incr S ~⟨⟩
+      (comm Fbwd ▹h (map F) ∙h (map Fbwd) ◃h comm F) ∙h F.η ▹h incr S
                                   ~⟨⟩
 
-      (((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F
-         ∙h F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd ▸h map F
-                    ∙h (incr S' ◃h F.ε ▸h map F)))
+      (((F.η h⁻¹) ▹h incr S ▹h F.bwd ▹h map F
+         ∙h F.bwd ◃h ( (comm F h⁻¹) ▹h F.bwd ▹h map F
+                    ∙h (incr S' ◃h F.ε ▹h map F)))
        ∙h F.bwd ◃h comm F)
-      ∙h F.η ▸h incr S
+      ∙h F.η ▹h incr S
 
-            ~⟨ ∙h-assoc ((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F) _ (F.bwd ◃h comm F) ⟩∙h⟨ ~refl: (F.η ▸h incr S) ⟩
+            ~⟨ ∙h-assoc ((F.η h⁻¹) ▹h incr S ▹h F.bwd ▹h map F) _ (F.bwd ◃h comm F) ⟩∙h⟨ ~refl: (F.η ▹h incr S) ⟩
 
-      (((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F
-         ∙h (  F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd ▸h map F
-                        ∙h (incr S' ◃h F.ε ▸h map F))
+      (((F.η h⁻¹) ▹h incr S ▹h F.bwd ▹h map F
+         ∙h (  F.bwd ◃h ( (comm F h⁻¹) ▹h F.bwd ▹h map F
+                        ∙h (incr S' ◃h F.ε ▹h map F))
             ∙h F.bwd ◃h comm F)))
-      ∙h F.η ▸h incr S
+      ∙h F.η ▹h incr S
 
-            ~⟨ (~refl: (F.η h⁻¹ ▸h incr S ▸h F.bwd ▸h map F) ⟩∙h⟨ lemma) ⟩∙h⟨ ~refl: (F.η ▸h incr S) ⟩
+            ~⟨ (~refl: (F.η h⁻¹ ▹h incr S ▹h F.bwd ▹h map F) ⟩∙h⟨ lemma) ⟩∙h⟨ ~refl: (F.η ▹h incr S) ⟩
 
-      ((F.η h⁻¹) ▸h incr S ▸h F.bwd ▸h map F
+      ((F.η h⁻¹) ▹h incr S ▹h F.bwd ▹h map F
          ∙h F.bwd ◃h map F ◃h incr S ◃h F.η)
-      ∙h F.η ▸h incr S
+      ∙h F.η ▹h incr S
 
-            ~⟨ (~refl ⟩∙h⟨ ((◃h∘∘ F.bwd (map F) (incr S) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (F.η ▸h incr S)) h⁻¹) ⟩
+            ~⟨ (~refl ⟩∙h⟨ ((◃h∘∘ F.bwd (map F) (incr S) F.η) h⁻¹)) ⟩∙h⟨ ((∙h-reflr (F.η ▹h incr S)) h⁻¹) ⟩
 
-      (((F.η h⁻¹) ▸h incr S) ◾h F.η)
-      ∙h ((F.η ▸h incr S) ◾h ~refl)
+      (((F.η h⁻¹) ▹h incr S) ◾h F.η)
+      ∙h ((F.η ▹h incr S) ◾h ~refl)
 
-             ~⟨ homotopy-interchange ((F.η h⁻¹) ▸h incr S) _ (F.η) ~refl ⟩
+             ~⟨ homotopy-interchange ((F.η h⁻¹) ▹h incr S) _ (F.η) ~refl ⟩
 
-      ((F.η h⁻¹) ▸h incr S ∙h F.η ▸h incr S) ◾h (F.η ∙h ~refl)
-                                  ~⟨ ∙h-sym' (F.η ▸h incr S) ⟩◾h⟨ ∙h-reflr F.η ⟩
+      ((F.η h⁻¹) ▹h incr S ∙h F.η ▹h incr S) ◾h (F.η ∙h ~refl)
+                                  ~⟨ ∙h-sym' (F.η ▹h incr S) ⟩◾h⟨ ∙h-reflr F.η ⟩
       ~refl ◾h F.η
                                   ~⟨⟩
       (incr S ◃h F.η)              ~⟨ (∙h-reflr (incr S ◃h F.η))  h⁻¹ ⟩
@@ -175,39 +175,39 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
     F∘Fbwd = comp-cotower-map F Fbwd
 
     lemma2 : ∀ {n} →
-               (map F ◃h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
-                   ∙h F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd
-                   ∙h (incr S' ◃h F.ε)))) ∙h F.ε ▸h incr S' {n})
-             ~ (comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε
+               (map F ◃h (((F.η h⁻¹) ▹h incr S ▹h F.bwd
+                   ∙h F.bwd ◃h ( (comm F h⁻¹) ▹h F.bwd
+                   ∙h (incr S' ◃h F.ε)))) ∙h F.ε ▹h incr S' {n})
+             ~ (comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε
 
     lemma2
-      = (map F ◃h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
-                   ∙h F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd
+      = (map F ◃h (((F.η h⁻¹) ▹h incr S ▹h F.bwd
+                   ∙h F.bwd ◃h ( (comm F h⁻¹) ▹h F.bwd
                    ∙h (incr S' ◃h F.ε))))
-        ∙h F.ε ▸h incr S')
+        ∙h F.ε ▹h incr S')
 
-                  ~⟨ ◃h∙ (map F) ((F.η h⁻¹) ▸h incr S ▸h F.bwd) _ ⟩∙h⟨ ~refl ⟩
+                  ~⟨ ◃h∙ (map F) ((F.η h⁻¹) ▹h incr S ▹h F.bwd) _ ⟩∙h⟨ ~refl ⟩
 
-           (map F ◃h F.η⁻¹ ▸h incr S ▸h F.bwd
-         ∙h map F ◃h F.bwd ◃h ((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε))
-         ∙h F.ε ▸h incr S'
+           (map F ◃h F.η⁻¹ ▹h incr S ▹h F.bwd
+         ∙h map F ◃h F.bwd ◃h ((comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε))
+         ∙h F.ε ▹h incr S'
 
-                  ~⟨ (F.coh⁻¹ ∘ incr S ∘ F.bwd ⟩∙h⟨ ~refl) ⟩∙h⟨ ~refl: (F.ε ▸h incr S') ⟩
+                  ~⟨ (F.coh⁻¹ ∘ incr S ∘ F.bwd ⟩∙h⟨ ~refl) ⟩∙h⟨ ~refl: (F.ε ▹h incr S') ⟩
 
-           (F.ε⁻¹ ▸h map F ▸h incr S ▸h F.bwd
-         ∙h map F ◃h F.bwd ◃h ((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε))
-         ∙h F.ε ▸h incr S'
+           (F.ε⁻¹ ▹h map F ▹h incr S ▹h F.bwd
+         ∙h map F ◃h F.bwd ◃h ((comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε))
+         ∙h F.ε ▹h incr S'
 
-                  ~⟨ ( ~refl: (F.ε⁻¹ ▸h map F ▸h incr S ▸h F.bwd) ⟩∙h⟨ ((◃h∘ (map F) F.bwd _) h⁻¹)) ⟩∙h⟨ (∙h-reflr _ h⁻¹) ⟩
+                  ~⟨ ( ~refl: (F.ε⁻¹ ▹h map F ▹h incr S ▹h F.bwd) ⟩∙h⟨ ((◃h∘ (map F) F.bwd _) h⁻¹)) ⟩∙h⟨ (∙h-reflr _ h⁻¹) ⟩
 
-           ((F.ε h⁻¹) ◾h ((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε))
+           ((F.ε h⁻¹) ◾h ((comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε))
          ∙h (F.ε ◾h ~refl)
                  ~⟨ homotopy-interchange (F.ε h⁻¹) F.ε _ ~refl ⟩
-        ((F.ε h⁻¹) ∙h F.ε) ◾h (((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε) ∙h ~refl)
+        ((F.ε h⁻¹) ∙h F.ε) ◾h (((comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε) ∙h ~refl)
                  ~⟨ ∙h-sym' F.ε ⟩◾h⟨ ∙h-reflr _ ⟩
-         (~refl: id) ◾h (((comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε))
+         (~refl: id) ◾h (((comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε))
                  ~⟨ ap-id ∘ _ ⟩
-        (comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε ~∎
+        (comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε ~∎
 
   inverse-seq-map-retraction
     : cotower-map~
@@ -215,27 +215,27 @@ module _ {𝓤 𝓥} {S : Cotower 𝓤} {S' : Cotower 𝓥}
         id-cotower-map
   inverse-seq-map-retraction .fst = F.ε
   inverse-seq-map-retraction .snd
-    = (comm F∘Fbwd ∙h F.ε ▸h incr S')  ~⟨⟩
-      (comm F ▸h F.bwd ∙h map F ◃h comm Fbwd) ∙h F.ε ▸h incr S' ~⟨⟩
-      (comm F ▸h F.bwd
-        ∙h map F ◃h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
-                   ∙h F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd
+    = (comm F∘Fbwd ∙h F.ε ▹h incr S')  ~⟨⟩
+      (comm F ▹h F.bwd ∙h map F ◃h comm Fbwd) ∙h F.ε ▹h incr S' ~⟨⟩
+      (comm F ▹h F.bwd
+        ∙h map F ◃h (((F.η h⁻¹) ▹h incr S ▹h F.bwd
+                   ∙h F.bwd ◃h ( (comm F h⁻¹) ▹h F.bwd
                    ∙h (incr S' ◃h F.ε)))))
-      ∙h F.ε ▸h incr S'
+      ∙h F.ε ▹h incr S'
 
-                  ~⟨ ∙h-assoc (comm F ▸h F.bwd) _ (F.ε ▸h incr S') ⟩
+                  ~⟨ ∙h-assoc (comm F ▹h F.bwd) _ (F.ε ▹h incr S') ⟩
 
-      comm F ▸h F.bwd
-      ∙h (map F ◃h (((F.η h⁻¹) ▸h incr S ▸h F.bwd
-                   ∙h F.bwd ◃h ( (comm F h⁻¹) ▸h F.bwd
+      comm F ▹h F.bwd
+      ∙h (map F ◃h (((F.η h⁻¹) ▹h incr S ▹h F.bwd
+                   ∙h F.bwd ◃h ( (comm F h⁻¹) ▹h F.bwd
                    ∙h (incr S' ◃h F.ε))))
-          ∙h F.ε ▸h incr S')
+          ∙h F.ε ▹h incr S')
 
-                  ~⟨ ~refl: (comm F ▸h F.bwd) ⟩∙h⟨ lemma2 ⟩
+                  ~⟨ ~refl: (comm F ▹h F.bwd) ⟩∙h⟨ lemma2 ⟩
 
-      comm F ▸h F.bwd ∙h (comm F h⁻¹) ▸h F.bwd ∙h incr S' ◃h F.ε
-                  ~⟨ (∙h-assoc (comm F ▸h F.bwd) _ (incr S' ◃h F.ε)) h⁻¹ ⟩
-      (comm F ▸h F.bwd ∙h (comm F h⁻¹) ▸h F.bwd) ∙h incr S' ◃h F.ε
+      comm F ▹h F.bwd ∙h (comm F h⁻¹) ▹h F.bwd ∙h incr S' ◃h F.ε
+                  ~⟨ (∙h-assoc (comm F ▹h F.bwd) _ (incr S' ◃h F.ε)) h⁻¹ ⟩
+      (comm F ▹h F.bwd ∙h (comm F h⁻¹) ▹h F.bwd) ∙h incr S' ◃h F.ε
                   ~⟨ ∙h-sym (comm F) ∘ F.bwd ⟩∙h⟨ ~refl ⟩
       incr S' ◃h F.ε
                   ~⟨ ∙h-reflr _ h⁻¹ ⟩

--- a/src/Core/Slices.lagda.tree
+++ b/src/Core/Slices.lagda.tree
@@ -40,7 +40,7 @@ Slice-map-∘
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {X : Type 𝓥} {Y : Type 𝓦} {Z : Type 𝓜}
       (p : X → A) (q : Y → A) (r : Z → A)
     → Slice-map q r → Slice-map p q → Slice-map p r
-Slice-map-∘ p q r (f , H) (g , K) = (f ∘ g , H ▸ g ∙h K)
+Slice-map-∘ p q r (f , H) (g , K) = (f ∘ g , H ▸h g ∙h K)
 
 Slice-map-postcompose
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {X : Type 𝓥} {Y : Type 𝓦} {Z : Type 𝓜}

--- a/src/Core/Slices.lagda.tree
+++ b/src/Core/Slices.lagda.tree
@@ -40,7 +40,7 @@ Slice-map-∘
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {X : Type 𝓥} {Y : Type 𝓦} {Z : Type 𝓜}
       (p : X → A) (q : Y → A) (r : Z → A)
     → Slice-map q r → Slice-map p q → Slice-map p r
-Slice-map-∘ p q r (f , H) (g , K) = (f ∘ g , H ▸h g ∙h K)
+Slice-map-∘ p q r (f , H) (g , K) = (f ∘ g , H ▹h g ∙h K)
 
 Slice-map-postcompose
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {X : Type 𝓥} {Y : Type 𝓦} {Z : Type 𝓜}

--- a/src/Core/Small.lagda.tree
+++ b/src/Core/Small.lagda.tree
@@ -161,7 +161,7 @@ module _
     : (S T : is-small 𝓥 A)
     → is-small-equiv S T
   any-is-small-equiv (_ , f) (_ , g)
-    = (f e⁻¹) ∙e g , (_≃_.fwd g ◂ _≃_.η f)
+    = (f e⁻¹) ∙e g , (_≃_.fwd g ◂h _≃_.η f)
 
   is-small-is-prop
     : is-prop (is-small 𝓥 A)

--- a/src/Core/Small.lagda.tree
+++ b/src/Core/Small.lagda.tree
@@ -161,7 +161,7 @@ module _
     : (S T : is-small 𝓥 A)
     → is-small-equiv S T
   any-is-small-equiv (_ , f) (_ , g)
-    = (f e⁻¹) ∙e g , (_≃_.fwd g ◂h _≃_.η f)
+    = (f e⁻¹) ∙e g , (_≃_.fwd g ◃h _≃_.η f)
 
   is-small-is-prop
     : is-prop (is-small 𝓥 A)

--- a/src/Core/SpanMaps.lagda.tree
+++ b/src/Core/SpanMaps.lagda.tree
@@ -156,10 +156,10 @@ span-map-pathᵈ→
     → (Q : f.h₁ ＝ g.h₁ ∘ coe q)
     → (P : f.h₂ ＝ g.h₂ ∘ coe p)
     → (R : f.h₃ ＝ g.h₃ ∘ coe r)
-    → (H : f.H ＝   (happly Q ▸ S'.left) ∙h (g.h₁ ◂ happly k)
-                  ∙h (g.H ▸ coe p) ∙h (S.left ◂ happly (sym P)))
-    → (K : f.K ＝ (happly R ▸ S'.right) ∙h (g.h₃ ◂ happly h)
-                 ∙h (g.K ▸ coe p) ∙h S.right ◂ (happly (sym P)))
+    → (H : f.H ＝   (happly Q ▸h S'.left) ∙h (g.h₁ ◂h happly k)
+                  ∙h (g.H ▸h coe p) ∙h (S.left ◂h happly (sym P)))
+    → (K : f.K ＝ (happly R ▸h S'.right) ∙h (g.h₃ ◂h happly h)
+                 ∙h (g.K ▸h coe p) ∙h S.right ◂h (happly (sym P)))
     → Idᶠ (λ P → Span-map P S) (Span-path→ p q r h k) f g
 span-map-pathᵈ→ refl refl refl refl refl refl refl refl refl refl
   = ap₂ (λ P Q → mk-span-map _ _ _ P Q)
@@ -217,13 +217,13 @@ Span⁻¹←Span-equiv F (e1 , e2 , e3)
 
 
   K1 : F.h₁ ∘ F₁.bwd ∘ S'.left ∘ F.h₂ ~ F.h₁ ∘ S.left ∘ F₂.bwd ∘ F.h₂
-  K1 = (F₁.ε ▸ S'.left ▸ F.h₂ ∙h (F.H h⁻¹) ∙h (F.h₁ ◂ (S.left ◂ F₂.η) h⁻¹))
+  K1 = (F₁.ε ▸h S'.left ▸h F.h₂ ∙h (F.H h⁻¹) ∙h (F.h₁ ◂h (S.left ◂h F₂.η) h⁻¹))
 
   H1 : F₁.bwd ∘ S'.left ~ S.left ∘ F₂.bwd
   H1 = e1 ◂e⁻¹ K1 ▸e⁻¹ e2
 
   K2 : F.h₃ ∘ F₃.bwd ∘ S'.right ∘ F.h₂ ~ F.h₃ ∘ S.right ∘ F₂.bwd ∘ F.h₂
-  K2 = (F₃.ε ▸ S'.right ▸ F.h₂) ∙h (F.K h⁻¹) ∙h (F.h₃ ◂ (S.right ◂ F₂.η) h⁻¹)
+  K2 = (F₃.ε ▸h S'.right ▸h F.h₂) ∙h (F.K h⁻¹) ∙h (F.h₃ ◂h (S.right ◂h F₂.η) h⁻¹)
 
   H2 : F₃.bwd ∘ S'.right ~ S.right ∘ F₂.bwd
   H2 = e3 ◂e⁻¹ K2 ▸e⁻¹ e2
@@ -249,8 +249,8 @@ compose-span-map F G = map where
   map .Span-map.h₁ = F.h₁ ∘ G.h₁
   map .Span-map.h₂ = F.h₂ ∘ G.h₂
   map .Span-map.h₃ = F.h₃ ∘ G.h₃
-  map .Span-map.H = (F.h₁ ◂ G.H) ∙h (F.H ▸ G.h₂)
-  map .Span-map.K = F.h₃ ◂ G.K ∙h F.K ▸ G.h₂
+  map .Span-map.H = (F.h₁ ◂h G.H) ∙h (F.H ▸h G.h₂)
+  map .Span-map.K = F.h₃ ◂h G.K ∙h F.K ▸h G.h₂
 
 id-span-map
   : ∀ {𝓤 𝓥 𝓦} {S : Span 𝓤 𝓥 𝓦}
@@ -411,8 +411,8 @@ Span-map-homotopy
     → (F G : Span-map S S') → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓤' ⊔ 𝓥' ⊔ 𝓦')
 Span-map-homotopy F G
   = Σ[ H₁ ∶ F.h₁ ~ G.h₁ ] Σ[ H₂ ∶ F.h₂ ~ G.h₂ ] Σ[ H₃ ∶ F.h₃ ~ G.h₃ ]
-       ((F.H ~ H₁ ▸ F.S.left ∙h G.H ∙h F.S'.left ◂ (H₂ h⁻¹))
-       ×  (F.K ~ (H₃ ▸ F.S.right ∙h G.K ∙h F.S'.right ◂ (H₂ h⁻¹)))) where
+       ((F.H ~ H₁ ▸h F.S.left ∙h G.H ∙h F.S'.left ◂h (H₂ h⁻¹))
+       ×  (F.K ~ (H₃ ▸h F.S.right ∙h G.K ∙h F.S'.right ◂h (H₂ h⁻¹)))) where
   module F = Span-map F
   module G = Span-map G
 
@@ -430,12 +430,12 @@ Span-map-funext→ {S = S} {S'} {F} {G} (p , q , r , s , t)
      (funext→ (λ a → s a
                    ∙ ap ((p (S.left a) ∙_) ∘ (G.H a ∙_))
                         (ap (ap G.S'.left) (q-sym-happly a)))
-      ∙ ap (λ x → x ▸ G.S.left ∙h G.H ∙h G.S'.left ◂ happly (sym (funext→ q)))
+      ∙ ap (λ x → x ▸h G.S.left ∙h G.H ∙h G.S'.left ◂h happly (sym (funext→ q)))
            (sym funext-redex))
      (funext→ (λ a → t a
                    ∙ ap ((r (S.right a) ∙_) ∘ (G.K a ∙_))
                         (ap (ap S'.right) (q-sym-happly a)))
-      ∙ ap (λ x → x ▸ G.S.right ∙h G.K ∙h S'.right ◂ happly (sym (funext→ q)))
+      ∙ ap (λ x → x ▸h G.S.right ∙h G.K ∙h S'.right ◂h happly (sym (funext→ q)))
            (sym funext-redex)) where
    module S = Span S
    module S' = Span S'

--- a/src/Core/SpanMaps.lagda.tree
+++ b/src/Core/SpanMaps.lagda.tree
@@ -156,10 +156,10 @@ span-map-pathᵈ→
     → (Q : f.h₁ ＝ g.h₁ ∘ coe q)
     → (P : f.h₂ ＝ g.h₂ ∘ coe p)
     → (R : f.h₃ ＝ g.h₃ ∘ coe r)
-    → (H : f.H ＝   (happly Q ▸h S'.left) ∙h (g.h₁ ◃h happly k)
-                  ∙h (g.H ▸h coe p) ∙h (S.left ◃h happly (sym P)))
-    → (K : f.K ＝ (happly R ▸h S'.right) ∙h (g.h₃ ◃h happly h)
-                 ∙h (g.K ▸h coe p) ∙h S.right ◃h (happly (sym P)))
+    → (H : f.H ＝   (happly Q ▹h S'.left) ∙h (g.h₁ ◃h happly k)
+                  ∙h (g.H ▹h coe p) ∙h (S.left ◃h happly (sym P)))
+    → (K : f.K ＝ (happly R ▹h S'.right) ∙h (g.h₃ ◃h happly h)
+                 ∙h (g.K ▹h coe p) ∙h S.right ◃h (happly (sym P)))
     → Idᶠ (λ P → Span-map P S) (Span-path→ p q r h k) f g
 span-map-pathᵈ→ refl refl refl refl refl refl refl refl refl refl
   = ap₂ (λ P Q → mk-span-map _ _ _ P Q)
@@ -217,13 +217,13 @@ Span⁻¹←Span-equiv F (e1 , e2 , e3)
 
 
   K1 : F.h₁ ∘ F₁.bwd ∘ S'.left ∘ F.h₂ ~ F.h₁ ∘ S.left ∘ F₂.bwd ∘ F.h₂
-  K1 = (F₁.ε ▸h S'.left ▸h F.h₂ ∙h (F.H h⁻¹) ∙h (F.h₁ ◃h (S.left ◃h F₂.η) h⁻¹))
+  K1 = (F₁.ε ▹h S'.left ▹h F.h₂ ∙h (F.H h⁻¹) ∙h (F.h₁ ◃h (S.left ◃h F₂.η) h⁻¹))
 
   H1 : F₁.bwd ∘ S'.left ~ S.left ∘ F₂.bwd
   H1 = e1 ◂e⁻¹ K1 ▸e⁻¹ e2
 
   K2 : F.h₃ ∘ F₃.bwd ∘ S'.right ∘ F.h₂ ~ F.h₃ ∘ S.right ∘ F₂.bwd ∘ F.h₂
-  K2 = (F₃.ε ▸h S'.right ▸h F.h₂) ∙h (F.K h⁻¹) ∙h (F.h₃ ◃h (S.right ◃h F₂.η) h⁻¹)
+  K2 = (F₃.ε ▹h S'.right ▹h F.h₂) ∙h (F.K h⁻¹) ∙h (F.h₃ ◃h (S.right ◃h F₂.η) h⁻¹)
 
   H2 : F₃.bwd ∘ S'.right ~ S.right ∘ F₂.bwd
   H2 = e3 ◂e⁻¹ K2 ▸e⁻¹ e2
@@ -249,8 +249,8 @@ compose-span-map F G = map where
   map .Span-map.h₁ = F.h₁ ∘ G.h₁
   map .Span-map.h₂ = F.h₂ ∘ G.h₂
   map .Span-map.h₃ = F.h₃ ∘ G.h₃
-  map .Span-map.H = (F.h₁ ◃h G.H) ∙h (F.H ▸h G.h₂)
-  map .Span-map.K = F.h₃ ◃h G.K ∙h F.K ▸h G.h₂
+  map .Span-map.H = (F.h₁ ◃h G.H) ∙h (F.H ▹h G.h₂)
+  map .Span-map.K = F.h₃ ◃h G.K ∙h F.K ▹h G.h₂
 
 id-span-map
   : ∀ {𝓤 𝓥 𝓦} {S : Span 𝓤 𝓥 𝓦}
@@ -411,8 +411,8 @@ Span-map-homotopy
     → (F G : Span-map S S') → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓤' ⊔ 𝓥' ⊔ 𝓦')
 Span-map-homotopy F G
   = Σ[ H₁ ∶ F.h₁ ~ G.h₁ ] Σ[ H₂ ∶ F.h₂ ~ G.h₂ ] Σ[ H₃ ∶ F.h₃ ~ G.h₃ ]
-       ((F.H ~ H₁ ▸h F.S.left ∙h G.H ∙h F.S'.left ◃h (H₂ h⁻¹))
-       ×  (F.K ~ (H₃ ▸h F.S.right ∙h G.K ∙h F.S'.right ◃h (H₂ h⁻¹)))) where
+       ((F.H ~ H₁ ▹h F.S.left ∙h G.H ∙h F.S'.left ◃h (H₂ h⁻¹))
+       ×  (F.K ~ (H₃ ▹h F.S.right ∙h G.K ∙h F.S'.right ◃h (H₂ h⁻¹)))) where
   module F = Span-map F
   module G = Span-map G
 
@@ -430,12 +430,12 @@ Span-map-funext→ {S = S} {S'} {F} {G} (p , q , r , s , t)
      (funext→ (λ a → s a
                    ∙ ap ((p (S.left a) ∙_) ∘ (G.H a ∙_))
                         (ap (ap G.S'.left) (q-sym-happly a)))
-      ∙ ap (λ x → x ▸h G.S.left ∙h G.H ∙h G.S'.left ◃h happly (sym (funext→ q)))
+      ∙ ap (λ x → x ▹h G.S.left ∙h G.H ∙h G.S'.left ◃h happly (sym (funext→ q)))
            (sym funext-redex))
      (funext→ (λ a → t a
                    ∙ ap ((r (S.right a) ∙_) ∘ (G.K a ∙_))
                         (ap (ap S'.right) (q-sym-happly a)))
-      ∙ ap (λ x → x ▸h G.S.right ∙h G.K ∙h S'.right ◃h happly (sym (funext→ q)))
+      ∙ ap (λ x → x ▹h G.S.right ∙h G.K ∙h S'.right ◃h happly (sym (funext→ q)))
            (sym funext-redex)) where
    module S = Span S
    module S' = Span S'

--- a/src/Core/SpanMaps.lagda.tree
+++ b/src/Core/SpanMaps.lagda.tree
@@ -156,10 +156,10 @@ span-map-pathᵈ→
     → (Q : f.h₁ ＝ g.h₁ ∘ coe q)
     → (P : f.h₂ ＝ g.h₂ ∘ coe p)
     → (R : f.h₃ ＝ g.h₃ ∘ coe r)
-    → (H : f.H ＝   (happly Q ▸h S'.left) ∙h (g.h₁ ◂h happly k)
-                  ∙h (g.H ▸h coe p) ∙h (S.left ◂h happly (sym P)))
-    → (K : f.K ＝ (happly R ▸h S'.right) ∙h (g.h₃ ◂h happly h)
-                 ∙h (g.K ▸h coe p) ∙h S.right ◂h (happly (sym P)))
+    → (H : f.H ＝   (happly Q ▸h S'.left) ∙h (g.h₁ ◃h happly k)
+                  ∙h (g.H ▸h coe p) ∙h (S.left ◃h happly (sym P)))
+    → (K : f.K ＝ (happly R ▸h S'.right) ∙h (g.h₃ ◃h happly h)
+                 ∙h (g.K ▸h coe p) ∙h S.right ◃h (happly (sym P)))
     → Idᶠ (λ P → Span-map P S) (Span-path→ p q r h k) f g
 span-map-pathᵈ→ refl refl refl refl refl refl refl refl refl refl
   = ap₂ (λ P Q → mk-span-map _ _ _ P Q)
@@ -217,13 +217,13 @@ Span⁻¹←Span-equiv F (e1 , e2 , e3)
 
 
   K1 : F.h₁ ∘ F₁.bwd ∘ S'.left ∘ F.h₂ ~ F.h₁ ∘ S.left ∘ F₂.bwd ∘ F.h₂
-  K1 = (F₁.ε ▸h S'.left ▸h F.h₂ ∙h (F.H h⁻¹) ∙h (F.h₁ ◂h (S.left ◂h F₂.η) h⁻¹))
+  K1 = (F₁.ε ▸h S'.left ▸h F.h₂ ∙h (F.H h⁻¹) ∙h (F.h₁ ◃h (S.left ◃h F₂.η) h⁻¹))
 
   H1 : F₁.bwd ∘ S'.left ~ S.left ∘ F₂.bwd
   H1 = e1 ◂e⁻¹ K1 ▸e⁻¹ e2
 
   K2 : F.h₃ ∘ F₃.bwd ∘ S'.right ∘ F.h₂ ~ F.h₃ ∘ S.right ∘ F₂.bwd ∘ F.h₂
-  K2 = (F₃.ε ▸h S'.right ▸h F.h₂) ∙h (F.K h⁻¹) ∙h (F.h₃ ◂h (S.right ◂h F₂.η) h⁻¹)
+  K2 = (F₃.ε ▸h S'.right ▸h F.h₂) ∙h (F.K h⁻¹) ∙h (F.h₃ ◃h (S.right ◃h F₂.η) h⁻¹)
 
   H2 : F₃.bwd ∘ S'.right ~ S.right ∘ F₂.bwd
   H2 = e3 ◂e⁻¹ K2 ▸e⁻¹ e2
@@ -249,8 +249,8 @@ compose-span-map F G = map where
   map .Span-map.h₁ = F.h₁ ∘ G.h₁
   map .Span-map.h₂ = F.h₂ ∘ G.h₂
   map .Span-map.h₃ = F.h₃ ∘ G.h₃
-  map .Span-map.H = (F.h₁ ◂h G.H) ∙h (F.H ▸h G.h₂)
-  map .Span-map.K = F.h₃ ◂h G.K ∙h F.K ▸h G.h₂
+  map .Span-map.H = (F.h₁ ◃h G.H) ∙h (F.H ▸h G.h₂)
+  map .Span-map.K = F.h₃ ◃h G.K ∙h F.K ▸h G.h₂
 
 id-span-map
   : ∀ {𝓤 𝓥 𝓦} {S : Span 𝓤 𝓥 𝓦}
@@ -411,8 +411,8 @@ Span-map-homotopy
     → (F G : Span-map S S') → Type (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓤' ⊔ 𝓥' ⊔ 𝓦')
 Span-map-homotopy F G
   = Σ[ H₁ ∶ F.h₁ ~ G.h₁ ] Σ[ H₂ ∶ F.h₂ ~ G.h₂ ] Σ[ H₃ ∶ F.h₃ ~ G.h₃ ]
-       ((F.H ~ H₁ ▸h F.S.left ∙h G.H ∙h F.S'.left ◂h (H₂ h⁻¹))
-       ×  (F.K ~ (H₃ ▸h F.S.right ∙h G.K ∙h F.S'.right ◂h (H₂ h⁻¹)))) where
+       ((F.H ~ H₁ ▸h F.S.left ∙h G.H ∙h F.S'.left ◃h (H₂ h⁻¹))
+       ×  (F.K ~ (H₃ ▸h F.S.right ∙h G.K ∙h F.S'.right ◃h (H₂ h⁻¹)))) where
   module F = Span-map F
   module G = Span-map G
 
@@ -430,12 +430,12 @@ Span-map-funext→ {S = S} {S'} {F} {G} (p , q , r , s , t)
      (funext→ (λ a → s a
                    ∙ ap ((p (S.left a) ∙_) ∘ (G.H a ∙_))
                         (ap (ap G.S'.left) (q-sym-happly a)))
-      ∙ ap (λ x → x ▸h G.S.left ∙h G.H ∙h G.S'.left ◂h happly (sym (funext→ q)))
+      ∙ ap (λ x → x ▸h G.S.left ∙h G.H ∙h G.S'.left ◃h happly (sym (funext→ q)))
            (sym funext-redex))
      (funext→ (λ a → t a
                    ∙ ap ((r (S.right a) ∙_) ∘ (G.K a ∙_))
                         (ap (ap S'.right) (q-sym-happly a)))
-      ∙ ap (λ x → x ▸h G.S.right ∙h G.K ∙h S'.right ◂h happly (sym (funext→ q)))
+      ∙ ap (λ x → x ▸h G.S.right ∙h G.K ∙h S'.right ◃h happly (sym (funext→ q)))
            (sym funext-redex)) where
    module S = Span S
    module S' = Span S'

--- a/src/Core/Suspensions.lagda.tree
+++ b/src/Core/Suspensions.lagda.tree
@@ -93,7 +93,7 @@ Susp-UP-is-equiv
   : ∀ {𝓤 𝓥} {X : Type 𝓤} {Y : Type 𝓥}
     → is-equiv (Susp-UP→ {X = X} {Y})
 Susp-UP-is-equiv = is-equiv←qinv (λ where
-  .fst po → (po (ι₁ tt) , po (ι₂ tt) , po ◂ glue)
+  .fst po → (po (ι₁ tt) , po (ι₂ tt) , po ◂h glue)
   .snd .fst (a , b , H) → ap ((a ,_) ∘ (b ,_)) (funext→ pushout-rec-apβ)
   .snd .snd → is-equiv.η Pushout-has-up-pushout)
 

--- a/src/Core/Suspensions.lagda.tree
+++ b/src/Core/Suspensions.lagda.tree
@@ -93,7 +93,7 @@ Susp-UP-is-equiv
   : ∀ {𝓤 𝓥} {X : Type 𝓤} {Y : Type 𝓥}
     → is-equiv (Susp-UP→ {X = X} {Y})
 Susp-UP-is-equiv = is-equiv←qinv (λ where
-  .fst po → (po (ι₁ tt) , po (ι₂ tt) , po ◂h glue)
+  .fst po → (po (ι₁ tt) , po (ι₂ tt) , po ◃h glue)
   .snd .fst (a , b , H) → ap ((a ,_) ∘ (b ,_)) (funext→ pushout-rec-apβ)
   .snd .snd → is-equiv.η Pushout-has-up-pushout)
 

--- a/src/Ergonomics/PushoutUniv.lagda.tree
+++ b/src/Ergonomics/PushoutUniv.lagda.tree
@@ -50,8 +50,8 @@ CoconeU-path→
     → (c c' : Coconeᵘ {f = f} {g = g} Q)
     → (p : c .Coconeᵘ.p ＝ c' .Coconeᵘ.p)
     → (q : c .Coconeᵘ.q ＝ c' .Coconeᵘ.q)
-    → (c .Coconeᵘ.filler ∙h happly (ap (from q-u) q) ▸h g
-    ~ happly (ap (from p-u) p) ▸h f ∙h c' .Coconeᵘ.filler)
+    → (c .Coconeᵘ.filler ∙h happly (ap (from q-u) q) ▹h g
+    ~ happly (ap (from p-u) p) ▹h f ∙h c' .Coconeᵘ.filler)
     → c ＝ c'
 CoconeU-path→ (mk-coconeU p q filler) (mk-coconeU p q filler')
   refl refl h = ap (mk-coconeU p q) (funext→ ((∙h-reflr _ h⁻¹) ∙h h))

--- a/src/Ergonomics/PushoutUniv.lagda.tree
+++ b/src/Ergonomics/PushoutUniv.lagda.tree
@@ -50,8 +50,8 @@ CoconeU-path→
     → (c c' : Coconeᵘ {f = f} {g = g} Q)
     → (p : c .Coconeᵘ.p ＝ c' .Coconeᵘ.p)
     → (q : c .Coconeᵘ.q ＝ c' .Coconeᵘ.q)
-    → (c .Coconeᵘ.filler ∙h happly (ap (from q-u) q) ▸ g
-    ~ happly (ap (from p-u) p) ▸ f ∙h c' .Coconeᵘ.filler)
+    → (c .Coconeᵘ.filler ∙h happly (ap (from q-u) q) ▸h g
+    ~ happly (ap (from p-u) p) ▸h f ∙h c' .Coconeᵘ.filler)
     → c ＝ c'
 CoconeU-path→ (mk-coconeU p q filler) (mk-coconeU p q filler')
   refl refl h = ap (mk-coconeU p q) (funext→ ((∙h-reflr _ h⁻¹) ∙h h))

--- a/src/Foundations/3for2.lagda.tree
+++ b/src/Foundations/3for2.lagda.tree
@@ -63,7 +63,7 @@ module _ {𝓤} {A : Type 𝓤}
     qinv : quasi-inv g
     qinv .fst = fg.bwd ∘ f
     qinv .snd .fst = fg.η
-    qinv .snd .snd = (is-embedding←is-equiv fe) ◂emb (fg.ε ▸h f)
+    qinv .snd .snd = (is-embedding←is-equiv fe) ◂emb (fg.ε ▹h f)
 
   3-for-2' : is-equiv g → is-equiv (f ∘ g) → is-equiv f
   3-for-2' ge fge = is-equiv←~⁻¹
@@ -106,7 +106,7 @@ module _ {𝓤} {A : Type 𝓤}
 
   sec-3-for-2 : is-equiv f → section (f ∘ g) → section g
   sec-3-for-2 fe s@(sfg , p)
-    = (sfg ∘ f , fe ◂e⁻¹ (p ▸h f)) where
+    = (sfg ∘ f , fe ◂e⁻¹ (p ▹h f)) where
     module f = is-equiv fe
 
   sec-3-for-2~

--- a/src/Foundations/3for2.lagda.tree
+++ b/src/Foundations/3for2.lagda.tree
@@ -67,7 +67,7 @@ module _ {𝓤} {A : Type 𝓤}
 
   3-for-2' : is-equiv g → is-equiv (f ∘ g) → is-equiv f
   3-for-2' ge fge = is-equiv←~⁻¹
-                    (f ◂h g.ε)
+                    (f ◃h g.ε)
                     (is-equiv-∘ fge (is-equiv⁻¹ ge)) where
     module g = is-equiv ge
 
@@ -94,7 +94,7 @@ module _ {𝓤} {A : Type 𝓤}
   sec-3-for-2' : is-equiv g → section (f ∘ g) → section f
   sec-3-for-2' ge s@(sfg , p)
     = section←~⁻¹
-        (f ◂h g.ε)
+        (f ◃h g.ε)
         (section-∘ {f = f ∘ g} {g = g.bwd}
                    s g.section-bwd) where
     module g = is-equiv ge

--- a/src/Foundations/3for2.lagda.tree
+++ b/src/Foundations/3for2.lagda.tree
@@ -63,11 +63,11 @@ module _ {𝓤} {A : Type 𝓤}
     qinv : quasi-inv g
     qinv .fst = fg.bwd ∘ f
     qinv .snd .fst = fg.η
-    qinv .snd .snd = (is-embedding←is-equiv fe) ◂emb (fg.ε ▸ f)
+    qinv .snd .snd = (is-embedding←is-equiv fe) ◂emb (fg.ε ▸h f)
 
   3-for-2' : is-equiv g → is-equiv (f ∘ g) → is-equiv f
   3-for-2' ge fge = is-equiv←~⁻¹
-                    (f ◂ g.ε)
+                    (f ◂h g.ε)
                     (is-equiv-∘ fge (is-equiv⁻¹ ge)) where
     module g = is-equiv ge
 
@@ -94,7 +94,7 @@ module _ {𝓤} {A : Type 𝓤}
   sec-3-for-2' : is-equiv g → section (f ∘ g) → section f
   sec-3-for-2' ge s@(sfg , p)
     = section←~⁻¹
-        (f ◂ g.ε)
+        (f ◂h g.ε)
         (section-∘ {f = f ∘ g} {g = g.bwd}
                    s g.section-bwd) where
     module g = is-equiv ge
@@ -106,7 +106,7 @@ module _ {𝓤} {A : Type 𝓤}
 
   sec-3-for-2 : is-equiv f → section (f ∘ g) → section g
   sec-3-for-2 fe s@(sfg , p)
-    = (sfg ∘ f , fe ◂e⁻¹ (p ▸ f)) where
+    = (sfg ∘ f , fe ◂e⁻¹ (p ▸h f)) where
     module f = is-equiv fe
 
   sec-3-for-2~

--- a/src/Foundations/6for2.lagda.tree
+++ b/src/Foundations/6for2.lagda.tree
@@ -170,7 +170,7 @@ module _
     → section (h ∘ g)
     → section (h ∘ g ∘ f)
   section-5-for-2-comp (s , p) (t , q)
-    = (s ∘ g ∘ t , h ◃h p ▸h (g ∘ t) ∙h q)
+    = (s ∘ g ∘ t , h ◃h p ▹h (g ∘ t) ∙h q)
 
   section-5-for-2
     : section (g ∘ f)
@@ -253,7 +253,7 @@ module _
     → retraction (h ∘ g)
     → retraction (h ∘ g ∘ f)
   retraction-5-for-2-comp (r , p) (s , q)
-    = (r ∘ g ∘ s , r ◃h ((g ◃h q) ▸h f) ∙h p)
+    = (r ∘ g ∘ s , r ◃h ((g ◃h q) ▹h f) ∙h p)
 
   retraction-5-for-2
     : retraction (g ∘ f)

--- a/src/Foundations/6for2.lagda.tree
+++ b/src/Foundations/6for2.lagda.tree
@@ -170,7 +170,7 @@ module _
     → section (h ∘ g)
     → section (h ∘ g ∘ f)
   section-5-for-2-comp (s , p) (t , q)
-    = (s ∘ g ∘ t , h ◂ p ▸ (g ∘ t) ∙h q)
+    = (s ∘ g ∘ t , h ◂h p ▸h (g ∘ t) ∙h q)
 
   section-5-for-2
     : section (g ∘ f)
@@ -253,7 +253,7 @@ module _
     → retraction (h ∘ g)
     → retraction (h ∘ g ∘ f)
   retraction-5-for-2-comp (r , p) (s , q)
-    = (r ∘ g ∘ s , r ◂ ((g ◂ q) ▸ f) ∙h p)
+    = (r ∘ g ∘ s , r ◂h ((g ◂h q) ▸h f) ∙h p)
 
   retraction-5-for-2
     : retraction (g ∘ f)

--- a/src/Foundations/6for2.lagda.tree
+++ b/src/Foundations/6for2.lagda.tree
@@ -170,7 +170,7 @@ module _
     → section (h ∘ g)
     → section (h ∘ g ∘ f)
   section-5-for-2-comp (s , p) (t , q)
-    = (s ∘ g ∘ t , h ◂h p ▸h (g ∘ t) ∙h q)
+    = (s ∘ g ∘ t , h ◃h p ▸h (g ∘ t) ∙h q)
 
   section-5-for-2
     : section (g ∘ f)
@@ -253,7 +253,7 @@ module _
     → retraction (h ∘ g)
     → retraction (h ∘ g ∘ f)
   retraction-5-for-2-comp (r , p) (s , q)
-    = (r ∘ g ∘ s , r ◂h ((g ◂h q) ▸h f) ∙h p)
+    = (r ∘ g ∘ s , r ◃h ((g ◃h q) ▸h f) ∙h p)
 
   retraction-5-for-2
     : retraction (g ∘ f)

--- a/src/Foundations/BiinvertibleMaps.lagda.tree
+++ b/src/Foundations/BiinvertibleMaps.lagda.tree
@@ -83,7 +83,7 @@ qinv←is-biinv {f = f} ((g , ε) , (h , η)) = (g , ret , ε) where
   g~h b = sym (η (g b)) ∙ ap h (ε b)
 
   ret : retraction-witness f g
-  ret = g~h ▸ f ∙h η
+  ret = g~h ▸h f ∙h η
 
 is-equiv←is-biinv
   : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}

--- a/src/Foundations/BiinvertibleMaps.lagda.tree
+++ b/src/Foundations/BiinvertibleMaps.lagda.tree
@@ -83,7 +83,7 @@ qinv←is-biinv {f = f} ((g , ε) , (h , η)) = (g , ret , ε) where
   g~h b = sym (η (g b)) ∙ ap h (ε b)
 
   ret : retraction-witness f g
-  ret = g~h ▸h f ∙h η
+  ret = g~h ▹h f ∙h η
 
 is-equiv←is-biinv
   : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}

--- a/src/Foundations/CompositionEquiv.lagda.tree
+++ b/src/Foundations/CompositionEquiv.lagda.tree
@@ -49,17 +49,17 @@ and
 postcomp-ret
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} {C : Type 𝓦}
     → retraction f → retraction (postcomp C f)
-postcomp-ret (g , r) = (g ∘_ , λ h → WithFunExtω.funext→ FE (r ▸ h))
+postcomp-ret (g , r) = (g ∘_ , λ h → WithFunExtω.funext→ FE (r ▸h h))
 
 postcomp-qinv
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} {C : Type 𝓦}
     → quasi-inv f → quasi-inv {B = C → B} (f ∘_)
 postcomp-qinv {f = f} (g , ret , sec) = (g ∘_) , ret∘ , sec∘ where
   sec∘ : section-witness (_∘_ f) (g ∘_)
-  sec∘ h  = WithFunExtω.funext→ FE (sec ▸ h)
+  sec∘ h  = WithFunExtω.funext→ FE (sec ▸h h)
 
   ret∘ : retraction-witness (_∘_ f) (g ∘_)
-  ret∘ h = WithFunExtω.funext→ FE (ret ▸ h)
+  ret∘ h = WithFunExtω.funext→ FE (ret ▸h h)
 
 postcomp-equiv
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}
@@ -113,10 +113,10 @@ precomp-qinv
     → quasi-inv f → quasi-inv {B = A → C} (_∘ f)
 precomp-qinv {f = f} (g , η , ε) = (_∘ g) , η∘ , ε∘ where
   η∘ : retraction-witness (_∘ f) (_∘ g)
-  η∘ h = WithFunExtω.funext→ FE (h ◂ ε)
+  η∘ h = WithFunExtω.funext→ FE (h ◂h ε)
 
   ε∘ : section-witness (_∘ f) (_∘ g)
-  ε∘ h = WithFunExtω.funext→ FE (h ◂ η)
+  ε∘ h = WithFunExtω.funext→ FE (h ◂h η)
 
 precomp-equiv
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} {C : Type 𝓦}
@@ -295,7 +295,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} where
     → is-embedding (precomp B f)
     → is-equiv f
   is-equiv←embedding-precomp-cod←retraction (r , ret) pre
-    = is-equiv←qinv (r , ret , happly (unap pre (WithFunExtω.funext→ FE (f ◂ ret))))
+    = is-equiv←qinv (r , ret , happly (unap pre (WithFunExtω.funext→ FE (f ◂h ret))))
 
   is-equiv←embedding-precomp-cod←section-precomp-dom
     : section (precomp A f)

--- a/src/Foundations/CompositionEquiv.lagda.tree
+++ b/src/Foundations/CompositionEquiv.lagda.tree
@@ -49,17 +49,17 @@ and
 postcomp-ret
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} {C : Type 𝓦}
     → retraction f → retraction (postcomp C f)
-postcomp-ret (g , r) = (g ∘_ , λ h → WithFunExtω.funext→ FE (r ▸h h))
+postcomp-ret (g , r) = (g ∘_ , λ h → WithFunExtω.funext→ FE (r ▹h h))
 
 postcomp-qinv
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} {C : Type 𝓦}
     → quasi-inv f → quasi-inv {B = C → B} (f ∘_)
 postcomp-qinv {f = f} (g , ret , sec) = (g ∘_) , ret∘ , sec∘ where
   sec∘ : section-witness (_∘_ f) (g ∘_)
-  sec∘ h  = WithFunExtω.funext→ FE (sec ▸h h)
+  sec∘ h  = WithFunExtω.funext→ FE (sec ▹h h)
 
   ret∘ : retraction-witness (_∘_ f) (g ∘_)
-  ret∘ h = WithFunExtω.funext→ FE (ret ▸h h)
+  ret∘ h = WithFunExtω.funext→ FE (ret ▹h h)
 
 postcomp-equiv
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥}

--- a/src/Foundations/CompositionEquiv.lagda.tree
+++ b/src/Foundations/CompositionEquiv.lagda.tree
@@ -113,10 +113,10 @@ precomp-qinv
     → quasi-inv f → quasi-inv {B = A → C} (_∘ f)
 precomp-qinv {f = f} (g , η , ε) = (_∘ g) , η∘ , ε∘ where
   η∘ : retraction-witness (_∘ f) (_∘ g)
-  η∘ h = WithFunExtω.funext→ FE (h ◂h ε)
+  η∘ h = WithFunExtω.funext→ FE (h ◃h ε)
 
   ε∘ : section-witness (_∘ f) (_∘ g)
-  ε∘ h = WithFunExtω.funext→ FE (h ◂h η)
+  ε∘ h = WithFunExtω.funext→ FE (h ◃h η)
 
 precomp-equiv
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} {C : Type 𝓦}
@@ -295,7 +295,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} where
     → is-embedding (precomp B f)
     → is-equiv f
   is-equiv←embedding-precomp-cod←retraction (r , ret) pre
-    = is-equiv←qinv (r , ret , happly (unap pre (WithFunExtω.funext→ FE (f ◂h ret))))
+    = is-equiv←qinv (r , ret , happly (unap pre (WithFunExtω.funext→ FE (f ◃h ret))))
 
   is-equiv←embedding-precomp-cod←section-precomp-dom
     : section (precomp A f)

--- a/src/Foundations/Cotowers.lagda.tree
+++ b/src/Foundations/Cotowers.lagda.tree
@@ -114,7 +114,7 @@ comp-cotower-map F G = map where
 
   map : Cotower-map _ _
   map .Cotower-map.map = F.map ∘ G.map
-  map .Cotower-map.comm = F.comm ▸ G.map ∙h F.map ◂ G.comm
+  map .Cotower-map.comm = F.comm ▸h G.map ∙h F.map ◂h G.comm
 
 id-cotower-map
   : ∀ {𝓤} {S : Cotower 𝓤} → Cotower-map S S
@@ -139,8 +139,8 @@ cotower-map~
       (F G : Cotower-map S S')
     → Type (𝓤 ⊔ 𝓥)
 cotower-map~ F G = Σ[ α ∶ (∀ {n} → map F {n} ~ map G)]
-                  (∀ {n} → comm F ∙h α ▸ A.incr G
-                       ~ (B.incr F ◂ α) ∙h comm G {n})
+                  (∀ {n} → comm F ∙h α ▸h A.incr G
+                       ~ (B.incr F ◂h α) ∙h comm G {n})
   where open Cotower-map
 }
 }
@@ -171,9 +171,9 @@ cotower-map-inv←equiv {A = A} {B} {F} Feq = imap where
   module F {n} = is-equiv (Feq n)
   imap : Cotower-map B A
   imap .map = F.bwd
-  imap .comm =   (F.η h⁻¹) ▸ Cotower.incr A ▸ F.bwd
-               ∙h F.bwd ◂ (  (comm F h⁻¹) ▸ F.bwd
-                          ∙h Cotower.incr B ◂ F.ε)
+  imap .comm =   (F.η h⁻¹) ▸h Cotower.incr A ▸h F.bwd
+               ∙h F.bwd ◂h (  (comm F h⁻¹) ▸h F.bwd
+                          ∙h Cotower.incr B ◂h F.ε)
 }
 }
 

--- a/src/Foundations/Cotowers.lagda.tree
+++ b/src/Foundations/Cotowers.lagda.tree
@@ -114,7 +114,7 @@ comp-cotower-map F G = map where
 
   map : Cotower-map _ _
   map .Cotower-map.map = F.map ∘ G.map
-  map .Cotower-map.comm = F.comm ▸h G.map ∙h F.map ◃h G.comm
+  map .Cotower-map.comm = F.comm ▹h G.map ∙h F.map ◃h G.comm
 
 id-cotower-map
   : ∀ {𝓤} {S : Cotower 𝓤} → Cotower-map S S
@@ -139,7 +139,7 @@ cotower-map~
       (F G : Cotower-map S S')
     → Type (𝓤 ⊔ 𝓥)
 cotower-map~ F G = Σ[ α ∶ (∀ {n} → map F {n} ~ map G)]
-                  (∀ {n} → comm F ∙h α ▸h A.incr G
+                  (∀ {n} → comm F ∙h α ▹h A.incr G
                        ~ (B.incr F ◃h α) ∙h comm G {n})
   where open Cotower-map
 }
@@ -171,8 +171,8 @@ cotower-map-inv←equiv {A = A} {B} {F} Feq = imap where
   module F {n} = is-equiv (Feq n)
   imap : Cotower-map B A
   imap .map = F.bwd
-  imap .comm =   (F.η h⁻¹) ▸h Cotower.incr A ▸h F.bwd
-               ∙h F.bwd ◃h (  (comm F h⁻¹) ▸h F.bwd
+  imap .comm =   (F.η h⁻¹) ▹h Cotower.incr A ▹h F.bwd
+               ∙h F.bwd ◃h (  (comm F h⁻¹) ▹h F.bwd
                           ∙h Cotower.incr B ◃h F.ε)
 }
 }

--- a/src/Foundations/Cotowers.lagda.tree
+++ b/src/Foundations/Cotowers.lagda.tree
@@ -114,7 +114,7 @@ comp-cotower-map F G = map where
 
   map : Cotower-map _ _
   map .Cotower-map.map = F.map ∘ G.map
-  map .Cotower-map.comm = F.comm ▸h G.map ∙h F.map ◂h G.comm
+  map .Cotower-map.comm = F.comm ▸h G.map ∙h F.map ◃h G.comm
 
 id-cotower-map
   : ∀ {𝓤} {S : Cotower 𝓤} → Cotower-map S S
@@ -140,7 +140,7 @@ cotower-map~
     → Type (𝓤 ⊔ 𝓥)
 cotower-map~ F G = Σ[ α ∶ (∀ {n} → map F {n} ~ map G)]
                   (∀ {n} → comm F ∙h α ▸h A.incr G
-                       ~ (B.incr F ◂h α) ∙h comm G {n})
+                       ~ (B.incr F ◃h α) ∙h comm G {n})
   where open Cotower-map
 }
 }
@@ -172,8 +172,8 @@ cotower-map-inv←equiv {A = A} {B} {F} Feq = imap where
   imap : Cotower-map B A
   imap .map = F.bwd
   imap .comm =   (F.η h⁻¹) ▸h Cotower.incr A ▸h F.bwd
-               ∙h F.bwd ◂h (  (comm F h⁻¹) ▸h F.bwd
-                          ∙h Cotower.incr B ◂h F.ε)
+               ∙h F.bwd ◃h (  (comm F h⁻¹) ▸h F.bwd
+                          ∙h Cotower.incr B ◃h F.ε)
 }
 }
 

--- a/src/Foundations/DependentCocones.lagda.tree
+++ b/src/Foundations/DependentCocones.lagda.tree
@@ -38,7 +38,7 @@ record Coconeᵈ {𝓤 𝓥 𝓦} (S : Span 𝓤 𝓥 𝓦)
   field
     p : (l : Left) → P (p' l)
     q : (r : Right) → P (q' r)
-    filler : Homotopyᵈ (P ◂h filler') (p ∘ left) (q ∘ right)
+    filler : Homotopyᵈ (P ◃h filler') (p ∘ left) (q ∘ right)
 
 
 module _ {𝓤 𝓥 𝓦} {S : Span 𝓤 𝓥 𝓦}
@@ -60,7 +60,7 @@ module _ {𝓤 𝓥 𝓦} {S : Span 𝓤 𝓥 𝓦}
       q~ : a.q ~ b.q
       filler~
         : Homotopyᵈ
-           (λ c → ap₂ (Idᵈ ((P ◂h cc.filler) c)) (p~ (left c)) (q~ (right c)))
+           (λ c → ap₂ (Idᵈ ((P ◃h cc.filler) c)) (p~ (left c)) (q~ (right c)))
            a.filler
            b.filler
 
@@ -72,7 +72,7 @@ module _ {𝓤 𝓥 𝓦} {S : Span 𝓤 𝓥 𝓦}
       q＝ : a.q ＝ b.q
       filler＝
         : Idᵈ
-            (ap₂ (Homotopyᵈ (P ◂h cc.filler)) (ap (_∘ left) p＝) (ap (_∘ right) q＝))
+            (ap₂ (Homotopyᵈ (P ◃h cc.filler)) (ap (_∘ left) p＝) (ap (_∘ right) q＝))
             a.filler
             b.filler
 

--- a/src/Foundations/DependentCocones.lagda.tree
+++ b/src/Foundations/DependentCocones.lagda.tree
@@ -38,7 +38,7 @@ record Coconeᵈ {𝓤 𝓥 𝓦} (S : Span 𝓤 𝓥 𝓦)
   field
     p : (l : Left) → P (p' l)
     q : (r : Right) → P (q' r)
-    filler : Homotopyᵈ (P ◂ filler') (p ∘ left) (q ∘ right)
+    filler : Homotopyᵈ (P ◂h filler') (p ∘ left) (q ∘ right)
 
 
 module _ {𝓤 𝓥 𝓦} {S : Span 𝓤 𝓥 𝓦}
@@ -60,7 +60,7 @@ module _ {𝓤 𝓥 𝓦} {S : Span 𝓤 𝓥 𝓦}
       q~ : a.q ~ b.q
       filler~
         : Homotopyᵈ
-           (λ c → ap₂ (Idᵈ ((P ◂ cc.filler) c)) (p~ (left c)) (q~ (right c)))
+           (λ c → ap₂ (Idᵈ ((P ◂h cc.filler) c)) (p~ (left c)) (q~ (right c)))
            a.filler
            b.filler
 
@@ -72,7 +72,7 @@ module _ {𝓤 𝓥 𝓦} {S : Span 𝓤 𝓥 𝓦}
       q＝ : a.q ＝ b.q
       filler＝
         : Idᵈ
-            (ap₂ (Homotopyᵈ (P ◂ cc.filler)) (ap (_∘ left) p＝) (ap (_∘ right) q＝))
+            (ap₂ (Homotopyᵈ (P ◂h cc.filler)) (ap (_∘ left) p＝) (ap (_∘ right) q＝))
             a.filler
             b.filler
 

--- a/src/Foundations/DependentHomotopy.lagda.tree
+++ b/src/Foundations/DependentHomotopy.lagda.tree
@@ -81,7 +81,7 @@ _◂ᵈ_
       {f g : (a : A) → B a}
       (x : ∀ {a} → (b : B a) → C b)
       (h : f ~ g)
-    → (x ∘ f) ~[ C ◂h h ] (x ∘ g)
+    → (x ∘ f) ~[ C ◃h h ] (x ∘ g)
 _◂ᵈ_ {A = A} {B} {C} x h a = apᶠ x (h a)
 }
 }

--- a/src/Foundations/DependentHomotopy.lagda.tree
+++ b/src/Foundations/DependentHomotopy.lagda.tree
@@ -81,7 +81,7 @@ _◂ᵈ_
       {f g : (a : A) → B a}
       (x : ∀ {a} → (b : B a) → C b)
       (h : f ~ g)
-    → (x ∘ f) ~[ C ◂ h ] (x ∘ g)
+    → (x ∘ f) ~[ C ◂h h ] (x ∘ g)
 _◂ᵈ_ {A = A} {B} {C} x h a = apᶠ x (h a)
 }
 }

--- a/src/Foundations/Embeddings.lagda.tree
+++ b/src/Foundations/Embeddings.lagda.tree
@@ -123,7 +123,7 @@ _◂e⁻¹_
   : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
     → is-equiv f → ∀ {𝓦} {C : Type 𝓦} {g h : C → A}
     → f ∘ g ~ f ∘ h → g ~ h
-_◂e⁻¹_ {f = f} fe {g = g} {h} H = (η h⁻¹) ▸h g ∙h bwd ◂h H ∙h η ▸h h
+_◂e⁻¹_ {f = f} fe {g = g} {h} H = (η h⁻¹) ▸h g ∙h bwd ◃h H ∙h η ▸h h
   where open is-equiv fe
 
 _▸e⁻¹_
@@ -131,7 +131,7 @@ _▸e⁻¹_
     → ∀ {𝓦} {C : Type 𝓦} {g h : B → C}
     → g ∘ f ~ h ∘ f → is-equiv f → g ~ h
 (_▸e⁻¹_) {g = g} {h} H fe
-  = (g ◂h ε h⁻¹) ∙h H ▸h bwd ∙h h ◂h ε where open is-equiv fe
+  = (g ◃h ε h⁻¹) ∙h H ▸h bwd ∙h h ◃h ε where open is-equiv fe
 }
 }
 

--- a/src/Foundations/Embeddings.lagda.tree
+++ b/src/Foundations/Embeddings.lagda.tree
@@ -123,7 +123,7 @@ _◂e⁻¹_
   : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
     → is-equiv f → ∀ {𝓦} {C : Type 𝓦} {g h : C → A}
     → f ∘ g ~ f ∘ h → g ~ h
-_◂e⁻¹_ {f = f} fe {g = g} {h} H = (η h⁻¹) ▸ g ∙h bwd ◂ H ∙h η ▸ h
+_◂e⁻¹_ {f = f} fe {g = g} {h} H = (η h⁻¹) ▸h g ∙h bwd ◂h H ∙h η ▸h h
   where open is-equiv fe
 
 _▸e⁻¹_
@@ -131,7 +131,7 @@ _▸e⁻¹_
     → ∀ {𝓦} {C : Type 𝓦} {g h : B → C}
     → g ∘ f ~ h ∘ f → is-equiv f → g ~ h
 (_▸e⁻¹_) {g = g} {h} H fe
-  = (g ◂ ε h⁻¹) ∙h H ▸ bwd ∙h h ◂ ε where open is-equiv fe
+  = (g ◂h ε h⁻¹) ∙h H ▸h bwd ∙h h ◂h ε where open is-equiv fe
 }
 }
 

--- a/src/Foundations/Embeddings.lagda.tree
+++ b/src/Foundations/Embeddings.lagda.tree
@@ -123,7 +123,7 @@ _◂e⁻¹_
   : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B}
     → is-equiv f → ∀ {𝓦} {C : Type 𝓦} {g h : C → A}
     → f ∘ g ~ f ∘ h → g ~ h
-_◂e⁻¹_ {f = f} fe {g = g} {h} H = (η h⁻¹) ▸h g ∙h bwd ◃h H ∙h η ▸h h
+_◂e⁻¹_ {f = f} fe {g = g} {h} H = (η h⁻¹) ▹h g ∙h bwd ◃h H ∙h η ▹h h
   where open is-equiv fe
 
 _▸e⁻¹_
@@ -131,7 +131,7 @@ _▸e⁻¹_
     → ∀ {𝓦} {C : Type 𝓦} {g h : B → C}
     → g ∘ f ~ h ∘ f → is-equiv f → g ~ h
 (_▸e⁻¹_) {g = g} {h} H fe
-  = (g ◃h ε h⁻¹) ∙h H ▸h bwd ∙h h ◃h ε where open is-equiv fe
+  = (g ◃h ε h⁻¹) ∙h H ▹h bwd ∙h h ◃h ε where open is-equiv fe
 }
 }
 

--- a/src/Foundations/EquivHomotopy.lagda.tree
+++ b/src/Foundations/EquivHomotopy.lagda.tree
@@ -31,13 +31,13 @@ equivalences.
 module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} where
 
   section←~ : (g ~ f) → section f → section g
-  section←~ H (h , sec) = (h , H ▸ h ∙h sec)
+  section←~ H (h , sec) = (h , H ▸h h ∙h sec)
 
   section←~⁻¹ : (f ~ g) → section f → section g
   section←~⁻¹ H = section←~ (H h⁻¹)
 
   retraction←~ : (g ~ f) → retraction f → retraction g
-  retraction←~ H (h , ret) = (h , h ◂ H ∙h ret)
+  retraction←~ H (h , ret) = (h , h ◂h H ∙h ret)
 
   retraction←~⁻¹ : (f ~ g) → retraction f → retraction g
   retraction←~⁻¹ H = retraction←~ (H h⁻¹)
@@ -45,8 +45,8 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} where
   qinv←~
     : (g ~ f) → quasi-inv f → quasi-inv g
   qinv←~ H (f⁻¹ , R , S) .fst = f⁻¹
-  qinv←~ H (f⁻¹ , R , S) .snd .fst =  f⁻¹ ◂ H ∙h R
-  qinv←~ H (f⁻¹ , R , S) .snd .snd =  H ▸ f⁻¹ ∙h S
+  qinv←~ H (f⁻¹ , R , S) .snd .fst =  f⁻¹ ◂h H ∙h R
+  qinv←~ H (f⁻¹ , R , S) .snd .snd =  H ▸h f⁻¹ ∙h S
 
   is-equiv←~
     : (g ~ f) → is-equiv f → is-equiv g
@@ -54,40 +54,40 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} where
   is-equiv←~ H e .is-equiv.coherent = coh where opaque
     open is-equiv e
 
-    Hη : g ◂ η ~ (H ▸ bwd ▸ f ∙h ε ▸ f) ∙h (H h⁻¹)
+    Hη : g ◂h η ~ (H ▸h bwd ▸h f ∙h ε ▸h f) ∙h (H h⁻¹)
     Hη = right-transpose-∙h
-          ((( (~refl: (H ▸ bwd ▸ f)) ⟩∙h⟨ coherent h⁻¹) ∙h switch-◾ H η) h⁻¹)
+          ((( (~refl: (H ▸h bwd ▸h f)) ⟩∙h⟨ coherent h⁻¹) ∙h switch-◾h H η) h⁻¹)
 
-    εH : f ◂ bwd ◂ H ∙h ε ▸ f ~ ε ▸ g ∙h H
-    εH = ((◂∘ f bwd H h⁻¹) ⟩∙h⟨ (~refl: (ε ▸ f)))
-      ∙h (switch-◾ ε H h⁻¹)
-      ∙h ((~refl: (ε ▸ g)) ⟩∙h⟨ id◂ H)
+    εH : f ◂h bwd ◂h H ∙h ε ▸h f ~ ε ▸h g ∙h H
+    εH = ((◂h∘ f bwd H h⁻¹) ⟩∙h⟨ (~refl: (ε ▸h f)))
+      ∙h (switch-◾h ε H h⁻¹)
+      ∙h ((~refl: (ε ▸h g)) ⟩∙h⟨ id◂h H)
 
     coh : qinv-coh (qinv←~ H (is-equiv.qinv e))
     coh =
-      g ◂ (bwd ◂ H ∙h η)
-        ~⟨ ◂∙ g (bwd ◂ H) η ⟩
-      g ◂ bwd ◂ H ∙h g ◂ η
-        ~⟨ (~refl: (g ◂ bwd ◂ H)) ⟩∙h⟨ Hη ⟩
-      g ◂ bwd ◂ H ∙h ((H ▸ bwd ▸ f ∙h ε ▸ f) ∙h (H h⁻¹))
-        ~⟨ ∙h-assoc (g ◂ bwd ◂ H) (H ▸ bwd ▸ f ∙h ε ▸ f) (H h⁻¹) h⁻¹ ⟩
-      (g ◂ bwd ◂ H ∙h (H ▸ bwd ▸ f ∙h ε ▸ f)) ∙h (H h⁻¹)
-        ~⟨ (∙h-assoc (g ◂ bwd ◂ H) (H ▸ bwd ▸ f) (ε ▸ f) h⁻¹) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
-      ((g ◂ bwd ◂ H ∙h H ▸ bwd ▸ f) ∙h ε ▸ f) ∙h (H h⁻¹)
-        ~⟨ _⟩∙h⟨_ ((switch-◾ H (bwd ◂ H)) h⁻¹) (~refl: (ε ▸ f)) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
-      ((H ▸ bwd ▸ g ∙h f ◂ bwd ◂ H) ∙h ε ▸ f) ∙h (H h⁻¹)
-        ~⟨ ∙h-assoc (H ▸ bwd ▸ g) (f ◂ bwd ◂ H) (ε ▸ f) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
-      (H ▸ bwd ▸ g ∙h (f ◂ bwd ◂ H ∙h ε ▸ f)) ∙h (H h⁻¹)
-        ~⟨ ∙h-assoc (H ▸ bwd ▸ g) (f ◂ bwd ◂ H ∙h ε ▸ f) (H h⁻¹) ⟩
-      H ▸ bwd ▸ g ∙h ((f ◂ bwd ◂ H ∙h ε ▸ f) ∙h (H h⁻¹))
-        ~⟨ (~refl: (H ▸ bwd ▸ g)) ⟩∙h⟨ εH ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
-      H ▸ bwd ▸ g ∙h ((ε ▸ g ∙h H) ∙h (H h⁻¹))
-        ~⟨ (~refl: (H ▸ bwd ▸ g)) ⟩∙h⟨ ∙h-assoc (ε ▸ g) H (H h⁻¹) ⟩
-      H ▸ bwd ▸ g ∙h (ε ▸ g ∙h H ∙h (H h⁻¹))
-        ~⟨ (~refl: (H ▸ bwd ▸ g)) ⟩∙h⟨ (~refl: (ε ▸ g)) ⟩∙h⟨ ∙h-sym H ⟩
-      H ▸ bwd ▸ g ∙h (ε ▸ g ∙h ~refl)
-        ~⟨ (~refl: (H ▸ bwd ▸ g)) ⟩∙h⟨ ∙h-reflr (ε ▸ g) ⟩
-      H ▸ bwd ▸ g ∙h ε ▸ g
+      g ◂h (bwd ◂h H ∙h η)
+        ~⟨ ◂h∙ g (bwd ◂h H) η ⟩
+      g ◂h bwd ◂h H ∙h g ◂h η
+        ~⟨ (~refl: (g ◂h bwd ◂h H)) ⟩∙h⟨ Hη ⟩
+      g ◂h bwd ◂h H ∙h ((H ▸h bwd ▸h f ∙h ε ▸h f) ∙h (H h⁻¹))
+        ~⟨ ∙h-assoc (g ◂h bwd ◂h H) (H ▸h bwd ▸h f ∙h ε ▸h f) (H h⁻¹) h⁻¹ ⟩
+      (g ◂h bwd ◂h H ∙h (H ▸h bwd ▸h f ∙h ε ▸h f)) ∙h (H h⁻¹)
+        ~⟨ (∙h-assoc (g ◂h bwd ◂h H) (H ▸h bwd ▸h f) (ε ▸h f) h⁻¹) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
+      ((g ◂h bwd ◂h H ∙h H ▸h bwd ▸h f) ∙h ε ▸h f) ∙h (H h⁻¹)
+        ~⟨ _⟩∙h⟨_ ((switch-◾h H (bwd ◂h H)) h⁻¹) (~refl: (ε ▸h f)) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
+      ((H ▸h bwd ▸h g ∙h f ◂h bwd ◂h H) ∙h ε ▸h f) ∙h (H h⁻¹)
+        ~⟨ ∙h-assoc (H ▸h bwd ▸h g) (f ◂h bwd ◂h H) (ε ▸h f) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
+      (H ▸h bwd ▸h g ∙h (f ◂h bwd ◂h H ∙h ε ▸h f)) ∙h (H h⁻¹)
+        ~⟨ ∙h-assoc (H ▸h bwd ▸h g) (f ◂h bwd ◂h H ∙h ε ▸h f) (H h⁻¹) ⟩
+      H ▸h bwd ▸h g ∙h ((f ◂h bwd ◂h H ∙h ε ▸h f) ∙h (H h⁻¹))
+        ~⟨ (~refl: (H ▸h bwd ▸h g)) ⟩∙h⟨ εH ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
+      H ▸h bwd ▸h g ∙h ((ε ▸h g ∙h H) ∙h (H h⁻¹))
+        ~⟨ (~refl: (H ▸h bwd ▸h g)) ⟩∙h⟨ ∙h-assoc (ε ▸h g) H (H h⁻¹) ⟩
+      H ▸h bwd ▸h g ∙h (ε ▸h g ∙h H ∙h (H h⁻¹))
+        ~⟨ (~refl: (H ▸h bwd ▸h g)) ⟩∙h⟨ (~refl: (ε ▸h g)) ⟩∙h⟨ ∙h-sym H ⟩
+      H ▸h bwd ▸h g ∙h (ε ▸h g ∙h ~refl)
+        ~⟨ (~refl: (H ▸h bwd ▸h g)) ⟩∙h⟨ ∙h-reflr (ε ▸h g) ⟩
+      H ▸h bwd ▸h g ∙h ε ▸h g
         ~∎
 
   is-equiv←~⁻¹ : (f ~ g) → is-equiv f → is-equiv g

--- a/src/Foundations/EquivHomotopy.lagda.tree
+++ b/src/Foundations/EquivHomotopy.lagda.tree
@@ -56,11 +56,11 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} where
 
     Hη : g ◃h η ~ (H ▹h bwd ▹h f ∙h ε ▹h f) ∙h (H h⁻¹)
     Hη = right-transpose-∙h
-          ((( (~refl: (H ▹h bwd ▹h f)) ⟩∙h⟨ coherent h⁻¹) ∙h switch-◾h H η) h⁻¹)
+          ((( (~refl: (H ▹h bwd ▹h f)) ⟩∙h⟨ coherent h⁻¹) ∙h switch-◽h H η) h⁻¹)
 
     εH : f ◃h bwd ◃h H ∙h ε ▹h f ~ ε ▹h g ∙h H
     εH = ((◃h∘ f bwd H h⁻¹) ⟩∙h⟨ (~refl: (ε ▹h f)))
-      ∙h (switch-◾h ε H h⁻¹)
+      ∙h (switch-◽h ε H h⁻¹)
       ∙h ((~refl: (ε ▹h g)) ⟩∙h⟨ id◃h H)
 
     coh : qinv-coh (qinv←~ H (is-equiv.qinv e))
@@ -74,7 +74,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} where
       (g ◃h bwd ◃h H ∙h (H ▹h bwd ▹h f ∙h ε ▹h f)) ∙h (H h⁻¹)
         ~⟨ (∙h-assoc (g ◃h bwd ◃h H) (H ▹h bwd ▹h f) (ε ▹h f) h⁻¹) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
       ((g ◃h bwd ◃h H ∙h H ▹h bwd ▹h f) ∙h ε ▹h f) ∙h (H h⁻¹)
-        ~⟨ _⟩∙h⟨_ ((switch-◾h H (bwd ◃h H)) h⁻¹) (~refl: (ε ▹h f)) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
+        ~⟨ _⟩∙h⟨_ ((switch-◽h H (bwd ◃h H)) h⁻¹) (~refl: (ε ▹h f)) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
       ((H ▹h bwd ▹h g ∙h f ◃h bwd ◃h H) ∙h ε ▹h f) ∙h (H h⁻¹)
         ~⟨ ∙h-assoc (H ▹h bwd ▹h g) (f ◃h bwd ◃h H) (ε ▹h f) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
       (H ▹h bwd ▹h g ∙h (f ◃h bwd ◃h H ∙h ε ▹h f)) ∙h (H h⁻¹)

--- a/src/Foundations/EquivHomotopy.lagda.tree
+++ b/src/Foundations/EquivHomotopy.lagda.tree
@@ -31,7 +31,7 @@ equivalences.
 module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} where
 
   section←~ : (g ~ f) → section f → section g
-  section←~ H (h , sec) = (h , H ▸h h ∙h sec)
+  section←~ H (h , sec) = (h , H ▹h h ∙h sec)
 
   section←~⁻¹ : (f ~ g) → section f → section g
   section←~⁻¹ H = section←~ (H h⁻¹)
@@ -46,7 +46,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} where
     : (g ~ f) → quasi-inv f → quasi-inv g
   qinv←~ H (f⁻¹ , R , S) .fst = f⁻¹
   qinv←~ H (f⁻¹ , R , S) .snd .fst =  f⁻¹ ◃h H ∙h R
-  qinv←~ H (f⁻¹ , R , S) .snd .snd =  H ▸h f⁻¹ ∙h S
+  qinv←~ H (f⁻¹ , R , S) .snd .snd =  H ▹h f⁻¹ ∙h S
 
   is-equiv←~
     : (g ~ f) → is-equiv f → is-equiv g
@@ -54,14 +54,14 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} where
   is-equiv←~ H e .is-equiv.coherent = coh where opaque
     open is-equiv e
 
-    Hη : g ◃h η ~ (H ▸h bwd ▸h f ∙h ε ▸h f) ∙h (H h⁻¹)
+    Hη : g ◃h η ~ (H ▹h bwd ▹h f ∙h ε ▹h f) ∙h (H h⁻¹)
     Hη = right-transpose-∙h
-          ((( (~refl: (H ▸h bwd ▸h f)) ⟩∙h⟨ coherent h⁻¹) ∙h switch-◾h H η) h⁻¹)
+          ((( (~refl: (H ▹h bwd ▹h f)) ⟩∙h⟨ coherent h⁻¹) ∙h switch-◾h H η) h⁻¹)
 
-    εH : f ◃h bwd ◃h H ∙h ε ▸h f ~ ε ▸h g ∙h H
-    εH = ((◃h∘ f bwd H h⁻¹) ⟩∙h⟨ (~refl: (ε ▸h f)))
+    εH : f ◃h bwd ◃h H ∙h ε ▹h f ~ ε ▹h g ∙h H
+    εH = ((◃h∘ f bwd H h⁻¹) ⟩∙h⟨ (~refl: (ε ▹h f)))
       ∙h (switch-◾h ε H h⁻¹)
-      ∙h ((~refl: (ε ▸h g)) ⟩∙h⟨ id◃h H)
+      ∙h ((~refl: (ε ▹h g)) ⟩∙h⟨ id◃h H)
 
     coh : qinv-coh (qinv←~ H (is-equiv.qinv e))
     coh =
@@ -69,25 +69,25 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} where
         ~⟨ ◃h∙ g (bwd ◃h H) η ⟩
       g ◃h bwd ◃h H ∙h g ◃h η
         ~⟨ (~refl: (g ◃h bwd ◃h H)) ⟩∙h⟨ Hη ⟩
-      g ◃h bwd ◃h H ∙h ((H ▸h bwd ▸h f ∙h ε ▸h f) ∙h (H h⁻¹))
-        ~⟨ ∙h-assoc (g ◃h bwd ◃h H) (H ▸h bwd ▸h f ∙h ε ▸h f) (H h⁻¹) h⁻¹ ⟩
-      (g ◃h bwd ◃h H ∙h (H ▸h bwd ▸h f ∙h ε ▸h f)) ∙h (H h⁻¹)
-        ~⟨ (∙h-assoc (g ◃h bwd ◃h H) (H ▸h bwd ▸h f) (ε ▸h f) h⁻¹) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
-      ((g ◃h bwd ◃h H ∙h H ▸h bwd ▸h f) ∙h ε ▸h f) ∙h (H h⁻¹)
-        ~⟨ _⟩∙h⟨_ ((switch-◾h H (bwd ◃h H)) h⁻¹) (~refl: (ε ▸h f)) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
-      ((H ▸h bwd ▸h g ∙h f ◃h bwd ◃h H) ∙h ε ▸h f) ∙h (H h⁻¹)
-        ~⟨ ∙h-assoc (H ▸h bwd ▸h g) (f ◃h bwd ◃h H) (ε ▸h f) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
-      (H ▸h bwd ▸h g ∙h (f ◃h bwd ◃h H ∙h ε ▸h f)) ∙h (H h⁻¹)
-        ~⟨ ∙h-assoc (H ▸h bwd ▸h g) (f ◃h bwd ◃h H ∙h ε ▸h f) (H h⁻¹) ⟩
-      H ▸h bwd ▸h g ∙h ((f ◃h bwd ◃h H ∙h ε ▸h f) ∙h (H h⁻¹))
-        ~⟨ (~refl: (H ▸h bwd ▸h g)) ⟩∙h⟨ εH ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
-      H ▸h bwd ▸h g ∙h ((ε ▸h g ∙h H) ∙h (H h⁻¹))
-        ~⟨ (~refl: (H ▸h bwd ▸h g)) ⟩∙h⟨ ∙h-assoc (ε ▸h g) H (H h⁻¹) ⟩
-      H ▸h bwd ▸h g ∙h (ε ▸h g ∙h H ∙h (H h⁻¹))
-        ~⟨ (~refl: (H ▸h bwd ▸h g)) ⟩∙h⟨ (~refl: (ε ▸h g)) ⟩∙h⟨ ∙h-sym H ⟩
-      H ▸h bwd ▸h g ∙h (ε ▸h g ∙h ~refl)
-        ~⟨ (~refl: (H ▸h bwd ▸h g)) ⟩∙h⟨ ∙h-reflr (ε ▸h g) ⟩
-      H ▸h bwd ▸h g ∙h ε ▸h g
+      g ◃h bwd ◃h H ∙h ((H ▹h bwd ▹h f ∙h ε ▹h f) ∙h (H h⁻¹))
+        ~⟨ ∙h-assoc (g ◃h bwd ◃h H) (H ▹h bwd ▹h f ∙h ε ▹h f) (H h⁻¹) h⁻¹ ⟩
+      (g ◃h bwd ◃h H ∙h (H ▹h bwd ▹h f ∙h ε ▹h f)) ∙h (H h⁻¹)
+        ~⟨ (∙h-assoc (g ◃h bwd ◃h H) (H ▹h bwd ▹h f) (ε ▹h f) h⁻¹) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
+      ((g ◃h bwd ◃h H ∙h H ▹h bwd ▹h f) ∙h ε ▹h f) ∙h (H h⁻¹)
+        ~⟨ _⟩∙h⟨_ ((switch-◾h H (bwd ◃h H)) h⁻¹) (~refl: (ε ▹h f)) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
+      ((H ▹h bwd ▹h g ∙h f ◃h bwd ◃h H) ∙h ε ▹h f) ∙h (H h⁻¹)
+        ~⟨ ∙h-assoc (H ▹h bwd ▹h g) (f ◃h bwd ◃h H) (ε ▹h f) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
+      (H ▹h bwd ▹h g ∙h (f ◃h bwd ◃h H ∙h ε ▹h f)) ∙h (H h⁻¹)
+        ~⟨ ∙h-assoc (H ▹h bwd ▹h g) (f ◃h bwd ◃h H ∙h ε ▹h f) (H h⁻¹) ⟩
+      H ▹h bwd ▹h g ∙h ((f ◃h bwd ◃h H ∙h ε ▹h f) ∙h (H h⁻¹))
+        ~⟨ (~refl: (H ▹h bwd ▹h g)) ⟩∙h⟨ εH ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
+      H ▹h bwd ▹h g ∙h ((ε ▹h g ∙h H) ∙h (H h⁻¹))
+        ~⟨ (~refl: (H ▹h bwd ▹h g)) ⟩∙h⟨ ∙h-assoc (ε ▹h g) H (H h⁻¹) ⟩
+      H ▹h bwd ▹h g ∙h (ε ▹h g ∙h H ∙h (H h⁻¹))
+        ~⟨ (~refl: (H ▹h bwd ▹h g)) ⟩∙h⟨ (~refl: (ε ▹h g)) ⟩∙h⟨ ∙h-sym H ⟩
+      H ▹h bwd ▹h g ∙h (ε ▹h g ∙h ~refl)
+        ~⟨ (~refl: (H ▹h bwd ▹h g)) ⟩∙h⟨ ∙h-reflr (ε ▹h g) ⟩
+      H ▹h bwd ▹h g ∙h ε ▹h g
         ~∎
 
   is-equiv←~⁻¹ : (f ~ g) → is-equiv f → is-equiv g

--- a/src/Foundations/EquivHomotopy.lagda.tree
+++ b/src/Foundations/EquivHomotopy.lagda.tree
@@ -37,7 +37,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} where
   section←~⁻¹ H = section←~ (H h⁻¹)
 
   retraction←~ : (g ~ f) → retraction f → retraction g
-  retraction←~ H (h , ret) = (h , h ◂h H ∙h ret)
+  retraction←~ H (h , ret) = (h , h ◃h H ∙h ret)
 
   retraction←~⁻¹ : (f ~ g) → retraction f → retraction g
   retraction←~⁻¹ H = retraction←~ (H h⁻¹)
@@ -45,7 +45,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} where
   qinv←~
     : (g ~ f) → quasi-inv f → quasi-inv g
   qinv←~ H (f⁻¹ , R , S) .fst = f⁻¹
-  qinv←~ H (f⁻¹ , R , S) .snd .fst =  f⁻¹ ◂h H ∙h R
+  qinv←~ H (f⁻¹ , R , S) .snd .fst =  f⁻¹ ◃h H ∙h R
   qinv←~ H (f⁻¹ , R , S) .snd .snd =  H ▸h f⁻¹ ∙h S
 
   is-equiv←~
@@ -54,32 +54,32 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} where
   is-equiv←~ H e .is-equiv.coherent = coh where opaque
     open is-equiv e
 
-    Hη : g ◂h η ~ (H ▸h bwd ▸h f ∙h ε ▸h f) ∙h (H h⁻¹)
+    Hη : g ◃h η ~ (H ▸h bwd ▸h f ∙h ε ▸h f) ∙h (H h⁻¹)
     Hη = right-transpose-∙h
           ((( (~refl: (H ▸h bwd ▸h f)) ⟩∙h⟨ coherent h⁻¹) ∙h switch-◾h H η) h⁻¹)
 
-    εH : f ◂h bwd ◂h H ∙h ε ▸h f ~ ε ▸h g ∙h H
-    εH = ((◂h∘ f bwd H h⁻¹) ⟩∙h⟨ (~refl: (ε ▸h f)))
+    εH : f ◃h bwd ◃h H ∙h ε ▸h f ~ ε ▸h g ∙h H
+    εH = ((◃h∘ f bwd H h⁻¹) ⟩∙h⟨ (~refl: (ε ▸h f)))
       ∙h (switch-◾h ε H h⁻¹)
-      ∙h ((~refl: (ε ▸h g)) ⟩∙h⟨ id◂h H)
+      ∙h ((~refl: (ε ▸h g)) ⟩∙h⟨ id◃h H)
 
     coh : qinv-coh (qinv←~ H (is-equiv.qinv e))
     coh =
-      g ◂h (bwd ◂h H ∙h η)
-        ~⟨ ◂h∙ g (bwd ◂h H) η ⟩
-      g ◂h bwd ◂h H ∙h g ◂h η
-        ~⟨ (~refl: (g ◂h bwd ◂h H)) ⟩∙h⟨ Hη ⟩
-      g ◂h bwd ◂h H ∙h ((H ▸h bwd ▸h f ∙h ε ▸h f) ∙h (H h⁻¹))
-        ~⟨ ∙h-assoc (g ◂h bwd ◂h H) (H ▸h bwd ▸h f ∙h ε ▸h f) (H h⁻¹) h⁻¹ ⟩
-      (g ◂h bwd ◂h H ∙h (H ▸h bwd ▸h f ∙h ε ▸h f)) ∙h (H h⁻¹)
-        ~⟨ (∙h-assoc (g ◂h bwd ◂h H) (H ▸h bwd ▸h f) (ε ▸h f) h⁻¹) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
-      ((g ◂h bwd ◂h H ∙h H ▸h bwd ▸h f) ∙h ε ▸h f) ∙h (H h⁻¹)
-        ~⟨ _⟩∙h⟨_ ((switch-◾h H (bwd ◂h H)) h⁻¹) (~refl: (ε ▸h f)) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
-      ((H ▸h bwd ▸h g ∙h f ◂h bwd ◂h H) ∙h ε ▸h f) ∙h (H h⁻¹)
-        ~⟨ ∙h-assoc (H ▸h bwd ▸h g) (f ◂h bwd ◂h H) (ε ▸h f) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
-      (H ▸h bwd ▸h g ∙h (f ◂h bwd ◂h H ∙h ε ▸h f)) ∙h (H h⁻¹)
-        ~⟨ ∙h-assoc (H ▸h bwd ▸h g) (f ◂h bwd ◂h H ∙h ε ▸h f) (H h⁻¹) ⟩
-      H ▸h bwd ▸h g ∙h ((f ◂h bwd ◂h H ∙h ε ▸h f) ∙h (H h⁻¹))
+      g ◃h (bwd ◃h H ∙h η)
+        ~⟨ ◃h∙ g (bwd ◃h H) η ⟩
+      g ◃h bwd ◃h H ∙h g ◃h η
+        ~⟨ (~refl: (g ◃h bwd ◃h H)) ⟩∙h⟨ Hη ⟩
+      g ◃h bwd ◃h H ∙h ((H ▸h bwd ▸h f ∙h ε ▸h f) ∙h (H h⁻¹))
+        ~⟨ ∙h-assoc (g ◃h bwd ◃h H) (H ▸h bwd ▸h f ∙h ε ▸h f) (H h⁻¹) h⁻¹ ⟩
+      (g ◃h bwd ◃h H ∙h (H ▸h bwd ▸h f ∙h ε ▸h f)) ∙h (H h⁻¹)
+        ~⟨ (∙h-assoc (g ◃h bwd ◃h H) (H ▸h bwd ▸h f) (ε ▸h f) h⁻¹) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
+      ((g ◃h bwd ◃h H ∙h H ▸h bwd ▸h f) ∙h ε ▸h f) ∙h (H h⁻¹)
+        ~⟨ _⟩∙h⟨_ ((switch-◾h H (bwd ◃h H)) h⁻¹) (~refl: (ε ▸h f)) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
+      ((H ▸h bwd ▸h g ∙h f ◃h bwd ◃h H) ∙h ε ▸h f) ∙h (H h⁻¹)
+        ~⟨ ∙h-assoc (H ▸h bwd ▸h g) (f ◃h bwd ◃h H) (ε ▸h f) ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
+      (H ▸h bwd ▸h g ∙h (f ◃h bwd ◃h H ∙h ε ▸h f)) ∙h (H h⁻¹)
+        ~⟨ ∙h-assoc (H ▸h bwd ▸h g) (f ◃h bwd ◃h H ∙h ε ▸h f) (H h⁻¹) ⟩
+      H ▸h bwd ▸h g ∙h ((f ◃h bwd ◃h H ∙h ε ▸h f) ∙h (H h⁻¹))
         ~⟨ (~refl: (H ▸h bwd ▸h g)) ⟩∙h⟨ εH ⟩∙h⟨ ~refl: (H h⁻¹) ⟩
       H ▸h bwd ▸h g ∙h ((ε ▸h g ∙h H) ∙h (H h⁻¹))
         ~⟨ (~refl: (H ▸h bwd ▸h g)) ⟩∙h⟨ ∙h-assoc (ε ▸h g) H (H h⁻¹) ⟩

--- a/src/Foundations/Equivalences.lagda.tree
+++ b/src/Foundations/Equivalences.lagda.tree
@@ -73,7 +73,7 @@ an equivalence into a proposition.
 
 \agda{
 qinv-coh : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} → quasi-inv f → Type (𝓤 ⊔ 𝓥)
-qinv-coh {f = f} (g , ε , η) = f ◂ ε ~ η ▸ f
+qinv-coh {f = f} (g , ε , η) = f ◂h ε ~ η ▸h f
 }
 }
 
@@ -108,14 +108,14 @@ record is-equiv {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} (f : A → B) : Type
   η⁻¹ : id ~ bwd ∘ f
   η⁻¹ = η h⁻¹
 
-  coh⁻¹ :  (f ◂ η⁻¹) ~ (ε⁻¹ ▸ f)
+  coh⁻¹ :  (f ◂h η⁻¹) ~ (ε⁻¹ ▸h f)
   coh⁻¹ a = ap-sym f (η a) ∙ ap sym (coherent a)
 
   swizzle-bwd
     : ∀ {𝓦} {C : Type 𝓦}
         (g : C → B) (h : C → A)
       → g ~ f ∘ h → bwd ∘ g ~ h
-  swizzle-bwd g h K = bwd ◂ K ∙h η ▸ h
+  swizzle-bwd g h K = bwd ◂h K ∙h η ▸h h
 }
 
 \p{We also define the packaged version of an equivalence together with the proof of it being an equivalence}
@@ -194,37 +194,37 @@ By taking the horizontal composition of these #{\alpha}'s gives us our desired #
 is-equiv←qinv : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} → quasi-inv f → is-equiv f
 is-equiv←qinv {f = f} (g , η , ε) = mk-eqv (g , η , ε') coh where opaque
   ε' : f ∘ g ~ id
-  ε' = (ε h⁻¹) ▸ f ▸ g ∙h
-      f ◂ η ▸ g       ∙h
+  ε' = (ε h⁻¹) ▸h f ▸h g ∙h
+      f ◂h η ▸h g       ∙h
       ε
 
-  lem3 : g ◂ f ◂ η ~ η ▸ g ▸ f
+  lem3 : g ◂h f ◂h η ~ η ▸h g ▸h f
   lem3 x = sym (ap-∘ g f (η x)) ∙ n where
-    n : ((g ∘ f) ◂ η) x ＝ (η ▸ g ▸ f) x
+    n : ((g ∘ f) ◂h η) x ＝ (η ▸h g ▸h f) x
     n = sym (homotopy-inverse (g ∘ f) η x)
 
-  lem2 : ε ▸ f ▸ g ▸ f ∙h f ◂ η ~ f ◂ g ◂ f ◂ η ∙h ε ▸ f
+  lem2 : ε ▸h f ▸h g ▸h f ∙h f ◂h η ~ f ◂h g ◂h f ◂h η ∙h ε ▸h f
   lem2 x = I ∙ ap (_∙ (ε (f x))) (ap-∘ f g (ap f (η x))) where
     I : ε (f (g (f x))) ∙ (ap f (η x)) ＝
          ap (λ z → (f ∘ g) z) (ap f (η x)) ∙ ε (f x)
     I = ap (ε (f (g (f x))) ∙_) (sym (ap-id (ap f (η x)))) ∙
         homotopy-natural ε {f (g (f x))} (ap f (η x))
 
-  lem1 : f ◂ η ~
-           (((ε ▸ f ▸ g ▸ f) h⁻¹) ∙h ε ▸ f ▸ g ▸ f ∙h f ◂ η)
+  lem1 : f ◂h η ~
+           (((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h ε ▸h f ▸h g ▸h f ∙h f ◂h η)
   lem1 a = ∙.insertr _ {h = ε (f (g (f a)))} {i = sym (ε (f (g (f a))))} (∙-sym' (ε (f (g (f a))))) {_} {ap f (η a)}
 
   coh : qinv-coh (g , η , ε')
   coh
-    = (f ◂ η)
+    = (f ◂h η)
         ~⟨ lem1 ⟩
-      ((ε ▸ f ▸ g ▸ f) h⁻¹) ∙h ε ▸ f ▸ g ▸ f ∙h f ◂ η
-        ~⟨ ~refl: ((ε ▸ f ▸ g ▸ f) h⁻¹) ⟩∙h⟨ lem2 ⟩
-      ((ε ▸ f ▸ g ▸ f) h⁻¹) ∙h (f ◂ g ◂ f ◂ η) ∙h ε ▸ f
-        ~⟨ (~refl: ((ε ▸ f ▸ g ▸ f) h⁻¹)) ⟩∙h⟨ (f ⟩◂⟨ lem3) ⟩∙h⟨ ~refl: (ε ▸ f) ⟩
-      ((ε ▸ f ▸ g ▸ f) h⁻¹) ∙h f ◂ (η ▸ g ▸ f) ∙h ε ▸ f
+      ((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h ε ▸h f ▸h g ▸h f ∙h f ◂h η
+        ~⟨ ~refl: ((ε ▸h f ▸h g ▸h f) h⁻¹) ⟩∙h⟨ lem2 ⟩
+      ((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h (f ◂h g ◂h f ◂h η) ∙h ε ▸h f
+        ~⟨ (~refl: ((ε ▸h f ▸h g ▸h f) h⁻¹)) ⟩∙h⟨ (f ⟩◂h⟨ lem3) ⟩∙h⟨ ~refl: (ε ▸h f) ⟩
+      ((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h f ◂h (η ▸h g ▸h f) ∙h ε ▸h f
         ~⟨⟩
-        ε' ▸ f
+        ε' ▸h f
         ~∎
 
 equiv←qequiv : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} → A ≊ B → A ≃ B
@@ -316,9 +316,9 @@ is-equiv-∘-qinv
 is-equiv-∘-qinv {f = f} {g} fe ge .fst
   = is-equiv.bwd ge ∘ is-equiv.bwd fe
 is-equiv-∘-qinv {f = f} {g} fe ge .snd .fst
-  = is-equiv.bwd ge ◂ is-equiv.η fe ▸ g ∙h is-equiv.η ge
+  = is-equiv.bwd ge ◂h is-equiv.η fe ▸h g ∙h is-equiv.η ge
 is-equiv-∘-qinv {f = f} {g} fe ge .snd .snd
-  = f ◂ is-equiv.ε ge ▸ is-equiv.bwd fe ∙h is-equiv.ε fe
+  = f ◂h is-equiv.ε ge ▸h is-equiv.bwd fe ∙h is-equiv.ε fe
 
 opaque
   is-equiv-∘-coh

--- a/src/Foundations/Equivalences.lagda.tree
+++ b/src/Foundations/Equivalences.lagda.tree
@@ -73,7 +73,7 @@ an equivalence into a proposition.
 
 \agda{
 qinv-coh : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} → quasi-inv f → Type (𝓤 ⊔ 𝓥)
-qinv-coh {f = f} (g , ε , η) = f ◃h ε ~ η ▸h f
+qinv-coh {f = f} (g , ε , η) = f ◃h ε ~ η ▹h f
 }
 }
 
@@ -108,14 +108,14 @@ record is-equiv {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} (f : A → B) : Type
   η⁻¹ : id ~ bwd ∘ f
   η⁻¹ = η h⁻¹
 
-  coh⁻¹ :  (f ◃h η⁻¹) ~ (ε⁻¹ ▸h f)
+  coh⁻¹ :  (f ◃h η⁻¹) ~ (ε⁻¹ ▹h f)
   coh⁻¹ a = ap-sym f (η a) ∙ ap sym (coherent a)
 
   swizzle-bwd
     : ∀ {𝓦} {C : Type 𝓦}
         (g : C → B) (h : C → A)
       → g ~ f ∘ h → bwd ∘ g ~ h
-  swizzle-bwd g h K = bwd ◃h K ∙h η ▸h h
+  swizzle-bwd g h K = bwd ◃h K ∙h η ▹h h
 }
 
 \p{We also define the packaged version of an equivalence together with the proof of it being an equivalence}
@@ -194,16 +194,16 @@ By taking the horizontal composition of these #{\alpha}'s gives us our desired #
 is-equiv←qinv : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} → quasi-inv f → is-equiv f
 is-equiv←qinv {f = f} (g , η , ε) = mk-eqv (g , η , ε') coh where opaque
   ε' : f ∘ g ~ id
-  ε' = (ε h⁻¹) ▸h f ▸h g ∙h
-      f ◃h η ▸h g       ∙h
+  ε' = (ε h⁻¹) ▹h f ▹h g ∙h
+      f ◃h η ▹h g       ∙h
       ε
 
-  lem3 : g ◃h f ◃h η ~ η ▸h g ▸h f
+  lem3 : g ◃h f ◃h η ~ η ▹h g ▹h f
   lem3 x = sym (ap-∘ g f (η x)) ∙ n where
-    n : ((g ∘ f) ◃h η) x ＝ (η ▸h g ▸h f) x
+    n : ((g ∘ f) ◃h η) x ＝ (η ▹h g ▹h f) x
     n = sym (homotopy-inverse (g ∘ f) η x)
 
-  lem2 : ε ▸h f ▸h g ▸h f ∙h f ◃h η ~ f ◃h g ◃h f ◃h η ∙h ε ▸h f
+  lem2 : ε ▹h f ▹h g ▹h f ∙h f ◃h η ~ f ◃h g ◃h f ◃h η ∙h ε ▹h f
   lem2 x = I ∙ ap (_∙ (ε (f x))) (ap-∘ f g (ap f (η x))) where
     I : ε (f (g (f x))) ∙ (ap f (η x)) ＝
          ap (λ z → (f ∘ g) z) (ap f (η x)) ∙ ε (f x)
@@ -211,20 +211,20 @@ is-equiv←qinv {f = f} (g , η , ε) = mk-eqv (g , η , ε') coh where opaque
         homotopy-natural ε {f (g (f x))} (ap f (η x))
 
   lem1 : f ◃h η ~
-           (((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h ε ▸h f ▸h g ▸h f ∙h f ◃h η)
+           (((ε ▹h f ▹h g ▹h f) h⁻¹) ∙h ε ▹h f ▹h g ▹h f ∙h f ◃h η)
   lem1 a = ∙.insertr _ {h = ε (f (g (f a)))} {i = sym (ε (f (g (f a))))} (∙-sym' (ε (f (g (f a))))) {_} {ap f (η a)}
 
   coh : qinv-coh (g , η , ε')
   coh
     = (f ◃h η)
         ~⟨ lem1 ⟩
-      ((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h ε ▸h f ▸h g ▸h f ∙h f ◃h η
-        ~⟨ ~refl: ((ε ▸h f ▸h g ▸h f) h⁻¹) ⟩∙h⟨ lem2 ⟩
-      ((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h (f ◃h g ◃h f ◃h η) ∙h ε ▸h f
-        ~⟨ (~refl: ((ε ▸h f ▸h g ▸h f) h⁻¹)) ⟩∙h⟨ (f ⟩◃h⟨ lem3) ⟩∙h⟨ ~refl: (ε ▸h f) ⟩
-      ((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h f ◃h (η ▸h g ▸h f) ∙h ε ▸h f
+      ((ε ▹h f ▹h g ▹h f) h⁻¹) ∙h ε ▹h f ▹h g ▹h f ∙h f ◃h η
+        ~⟨ ~refl: ((ε ▹h f ▹h g ▹h f) h⁻¹) ⟩∙h⟨ lem2 ⟩
+      ((ε ▹h f ▹h g ▹h f) h⁻¹) ∙h (f ◃h g ◃h f ◃h η) ∙h ε ▹h f
+        ~⟨ (~refl: ((ε ▹h f ▹h g ▹h f) h⁻¹)) ⟩∙h⟨ (f ⟩◃h⟨ lem3) ⟩∙h⟨ ~refl: (ε ▹h f) ⟩
+      ((ε ▹h f ▹h g ▹h f) h⁻¹) ∙h f ◃h (η ▹h g ▹h f) ∙h ε ▹h f
         ~⟨⟩
-        ε' ▸h f
+        ε' ▹h f
         ~∎
 
 equiv←qequiv : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} → A ≊ B → A ≃ B
@@ -316,9 +316,9 @@ is-equiv-∘-qinv
 is-equiv-∘-qinv {f = f} {g} fe ge .fst
   = is-equiv.bwd ge ∘ is-equiv.bwd fe
 is-equiv-∘-qinv {f = f} {g} fe ge .snd .fst
-  = is-equiv.bwd ge ◃h is-equiv.η fe ▸h g ∙h is-equiv.η ge
+  = is-equiv.bwd ge ◃h is-equiv.η fe ▹h g ∙h is-equiv.η ge
 is-equiv-∘-qinv {f = f} {g} fe ge .snd .snd
-  = f ◃h is-equiv.ε ge ▸h is-equiv.bwd fe ∙h is-equiv.ε fe
+  = f ◃h is-equiv.ε ge ▹h is-equiv.bwd fe ∙h is-equiv.ε fe
 
 opaque
   is-equiv-∘-coh

--- a/src/Foundations/Equivalences.lagda.tree
+++ b/src/Foundations/Equivalences.lagda.tree
@@ -73,7 +73,7 @@ an equivalence into a proposition.
 
 \agda{
 qinv-coh : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} → quasi-inv f → Type (𝓤 ⊔ 𝓥)
-qinv-coh {f = f} (g , ε , η) = f ◂h ε ~ η ▸h f
+qinv-coh {f = f} (g , ε , η) = f ◃h ε ~ η ▸h f
 }
 }
 
@@ -108,14 +108,14 @@ record is-equiv {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} (f : A → B) : Type
   η⁻¹ : id ~ bwd ∘ f
   η⁻¹ = η h⁻¹
 
-  coh⁻¹ :  (f ◂h η⁻¹) ~ (ε⁻¹ ▸h f)
+  coh⁻¹ :  (f ◃h η⁻¹) ~ (ε⁻¹ ▸h f)
   coh⁻¹ a = ap-sym f (η a) ∙ ap sym (coherent a)
 
   swizzle-bwd
     : ∀ {𝓦} {C : Type 𝓦}
         (g : C → B) (h : C → A)
       → g ~ f ∘ h → bwd ∘ g ~ h
-  swizzle-bwd g h K = bwd ◂h K ∙h η ▸h h
+  swizzle-bwd g h K = bwd ◃h K ∙h η ▸h h
 }
 
 \p{We also define the packaged version of an equivalence together with the proof of it being an equivalence}
@@ -195,34 +195,34 @@ is-equiv←qinv : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f : A → B} 
 is-equiv←qinv {f = f} (g , η , ε) = mk-eqv (g , η , ε') coh where opaque
   ε' : f ∘ g ~ id
   ε' = (ε h⁻¹) ▸h f ▸h g ∙h
-      f ◂h η ▸h g       ∙h
+      f ◃h η ▸h g       ∙h
       ε
 
-  lem3 : g ◂h f ◂h η ~ η ▸h g ▸h f
+  lem3 : g ◃h f ◃h η ~ η ▸h g ▸h f
   lem3 x = sym (ap-∘ g f (η x)) ∙ n where
-    n : ((g ∘ f) ◂h η) x ＝ (η ▸h g ▸h f) x
+    n : ((g ∘ f) ◃h η) x ＝ (η ▸h g ▸h f) x
     n = sym (homotopy-inverse (g ∘ f) η x)
 
-  lem2 : ε ▸h f ▸h g ▸h f ∙h f ◂h η ~ f ◂h g ◂h f ◂h η ∙h ε ▸h f
+  lem2 : ε ▸h f ▸h g ▸h f ∙h f ◃h η ~ f ◃h g ◃h f ◃h η ∙h ε ▸h f
   lem2 x = I ∙ ap (_∙ (ε (f x))) (ap-∘ f g (ap f (η x))) where
     I : ε (f (g (f x))) ∙ (ap f (η x)) ＝
          ap (λ z → (f ∘ g) z) (ap f (η x)) ∙ ε (f x)
     I = ap (ε (f (g (f x))) ∙_) (sym (ap-id (ap f (η x)))) ∙
         homotopy-natural ε {f (g (f x))} (ap f (η x))
 
-  lem1 : f ◂h η ~
-           (((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h ε ▸h f ▸h g ▸h f ∙h f ◂h η)
+  lem1 : f ◃h η ~
+           (((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h ε ▸h f ▸h g ▸h f ∙h f ◃h η)
   lem1 a = ∙.insertr _ {h = ε (f (g (f a)))} {i = sym (ε (f (g (f a))))} (∙-sym' (ε (f (g (f a))))) {_} {ap f (η a)}
 
   coh : qinv-coh (g , η , ε')
   coh
-    = (f ◂h η)
+    = (f ◃h η)
         ~⟨ lem1 ⟩
-      ((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h ε ▸h f ▸h g ▸h f ∙h f ◂h η
+      ((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h ε ▸h f ▸h g ▸h f ∙h f ◃h η
         ~⟨ ~refl: ((ε ▸h f ▸h g ▸h f) h⁻¹) ⟩∙h⟨ lem2 ⟩
-      ((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h (f ◂h g ◂h f ◂h η) ∙h ε ▸h f
-        ~⟨ (~refl: ((ε ▸h f ▸h g ▸h f) h⁻¹)) ⟩∙h⟨ (f ⟩◂h⟨ lem3) ⟩∙h⟨ ~refl: (ε ▸h f) ⟩
-      ((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h f ◂h (η ▸h g ▸h f) ∙h ε ▸h f
+      ((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h (f ◃h g ◃h f ◃h η) ∙h ε ▸h f
+        ~⟨ (~refl: ((ε ▸h f ▸h g ▸h f) h⁻¹)) ⟩∙h⟨ (f ⟩◃h⟨ lem3) ⟩∙h⟨ ~refl: (ε ▸h f) ⟩
+      ((ε ▸h f ▸h g ▸h f) h⁻¹) ∙h f ◃h (η ▸h g ▸h f) ∙h ε ▸h f
         ~⟨⟩
         ε' ▸h f
         ~∎
@@ -316,9 +316,9 @@ is-equiv-∘-qinv
 is-equiv-∘-qinv {f = f} {g} fe ge .fst
   = is-equiv.bwd ge ∘ is-equiv.bwd fe
 is-equiv-∘-qinv {f = f} {g} fe ge .snd .fst
-  = is-equiv.bwd ge ◂h is-equiv.η fe ▸h g ∙h is-equiv.η ge
+  = is-equiv.bwd ge ◃h is-equiv.η fe ▸h g ∙h is-equiv.η ge
 is-equiv-∘-qinv {f = f} {g} fe ge .snd .snd
-  = f ◂h is-equiv.ε ge ▸h is-equiv.bwd fe ∙h is-equiv.ε fe
+  = f ◃h is-equiv.ε ge ▸h is-equiv.bwd fe ∙h is-equiv.ε fe
 
 opaque
   is-equiv-∘-coh

--- a/src/Foundations/Forks.lagda.tree
+++ b/src/Foundations/Forks.lagda.tree
@@ -51,6 +51,6 @@ fork-map
   → ∀ {𝓠} {Q : Type 𝓠}
   → (Q → E)
   → Fork f g Q
-fork-map (e , H) u = (e ∘ u , H ▸ u)
+fork-map (e , H) u = (e ∘ u , H ▸h u)
 }
 }

--- a/src/Foundations/Forks.lagda.tree
+++ b/src/Foundations/Forks.lagda.tree
@@ -51,6 +51,6 @@ fork-map
   → ∀ {𝓠} {Q : Type 𝓠}
   → (Q → E)
   → Fork f g Q
-fork-map (e , H) u = (e ∘ u , H ▸h u)
+fork-map (e , H) u = (e ∘ u , H ▹h u)
 }
 }

--- a/src/Foundations/FunctionInverses.lagda.tree
+++ b/src/Foundations/FunctionInverses.lagda.tree
@@ -100,7 +100,7 @@ section-∘
     → section g
     → section (f ∘ g)
 section-∘ {f = f} {g} (sf , pf) (sg , pg)
-  = (sg ∘ sf , f ◂ pg ▸ sf ∙h pf)
+  = (sg ∘ sf , f ◂h pg ▸h sf ∙h pf)
 
 retraction-∘
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤}
@@ -110,7 +110,7 @@ retraction-∘
     → retraction g
     → retraction (f ∘ g)
 retraction-∘ {f = f} {g} (rf , pf) (rg , pg)
-  = (rg ∘ rf , rg ◂ pf ▸ g ∙h pg)
+  = (rg ∘ rf , rg ◂h pf ▸h g ∙h pg)
 }
 }
 

--- a/src/Foundations/FunctionInverses.lagda.tree
+++ b/src/Foundations/FunctionInverses.lagda.tree
@@ -100,7 +100,7 @@ section-∘
     → section g
     → section (f ∘ g)
 section-∘ {f = f} {g} (sf , pf) (sg , pg)
-  = (sg ∘ sf , f ◂h pg ▸h sf ∙h pf)
+  = (sg ∘ sf , f ◃h pg ▸h sf ∙h pf)
 
 retraction-∘
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤}
@@ -110,7 +110,7 @@ retraction-∘
     → retraction g
     → retraction (f ∘ g)
 retraction-∘ {f = f} {g} (rf , pf) (rg , pg)
-  = (rg ∘ rf , rg ◂h pf ▸h g ∙h pg)
+  = (rg ∘ rf , rg ◃h pf ▸h g ∙h pg)
 }
 }
 

--- a/src/Foundations/FunctionInverses.lagda.tree
+++ b/src/Foundations/FunctionInverses.lagda.tree
@@ -100,7 +100,7 @@ section-∘
     → section g
     → section (f ∘ g)
 section-∘ {f = f} {g} (sf , pf) (sg , pg)
-  = (sg ∘ sf , f ◃h pg ▸h sf ∙h pf)
+  = (sg ∘ sf , f ◃h pg ▹h sf ∙h pf)
 
 retraction-∘
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤}
@@ -110,7 +110,7 @@ retraction-∘
     → retraction g
     → retraction (f ∘ g)
 retraction-∘ {f = f} {g} (rf , pf) (rg , pg)
-  = (rg ∘ rf , rg ◃h pf ▸h g ∙h pg)
+  = (rg ∘ rf , rg ◃h pf ▹h g ∙h pg)
 }
 }
 

--- a/src/Foundations/Homotopy.lagda.tree
+++ b/src/Foundations/Homotopy.lagda.tree
@@ -119,14 +119,14 @@ _⟩∙h⟨_
 
 
 \agda{
-infixr 16 _◂h_
-_◂h_
+infixr 16 _◃h_
+_◃h_
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : A → Type 𝓥} {C : Type 𝓦}
     → (h : ∀ {a} → B a → C) {f g : Π A B} → f ~ g → h ∘ f ~ h ∘ g
-(h ◂h p) x = ap h (p x)
+(h ◃h p) x = ap h (p x)
 
-id◂h : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} (H : f ~ g) → id ◂h H ~ H
-id◂h H a = ap-id (H a)
+id◃h : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} (H : f ~ g) → id ◃h H ~ H
+id◃h H a = ap-id (H a)
 
 
 infixl 17 _▸h_
@@ -136,46 +136,46 @@ _▸h_
 (p ▸h h) x = p (h x)
 
 
-infixr 2 _⟩◂h⟨_
-_⟩◂h⟨_ : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
-           (f : B → C) {g h : A → B} {p q : g ~ h} → p ~ q → f ◂h p ~ f ◂h q
-(f ⟩◂h⟨ p) a = ap (ap f) (p a)
+infixr 2 _⟩◃h⟨_
+_⟩◃h⟨_ : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
+           (f : B → C) {g h : A → B} {p q : g ~ h} → p ~ q → f ◃h p ~ f ◃h q
+(f ⟩◃h⟨ p) a = ap (ap f) (p a)
 
 
-◂h∙
+◃h∙
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : A → Type 𝓥} {C : Type 𝓦}
       (k : ∀ {a} → B a → C) {f g h : Π A B} (H : f ~ g) (K : g ~ h)
-    → k ◂h (H ∙h K) ~ (k ◂h H) ∙h (k ◂h K)
-◂h∙ k H K a = ap-∙ k (H a) (K a)
+    → k ◃h (H ∙h K) ~ (k ◃h H) ∙h (k ◃h K)
+◃h∙ k H K a = ap-∙ k (H a) (K a)
 
-◂h∙∙
+◃h∙∙
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : A → Type 𝓥} {C : Type 𝓦}
       (l : ∀ {a} → B a → C) {f g h k : Π A B}
       (H : f ~ g) (K : g ~ h) (L : h ~ k)
-    → l ◂h (H ∙h K ∙h L) ~ (l ◂h H) ∙h (l ◂h K) ∙h (l ◂h L)
-◂h∙∙ k H K L a = ap-∙∙ k (H a) (K a) (L a)
+    → l ◃h (H ∙h K ∙h L) ~ (l ◃h H) ∙h (l ◃h K) ∙h (l ◃h L)
+◃h∙∙ k H K L a = ap-∙∙ k (H a) (K a) (L a)
 
-◂h∘
+◃h∘
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : A → Type 𝓥} {C : Type 𝓦}
       {D : Type 𝓜}
       (i : C → D) (h : ∀ {a} → B a → C)
       {f g : Π A B} (H : f ~ g)
-    → (i ∘ h) ◂h H ~ i ◂h h ◂h H
-◂h∘ i k H a = ap-∘ i k (H a)
+    → (i ∘ h) ◃h H ~ i ◃h h ◃h H
+◃h∘ i k H a = ap-∘ i k (H a)
 
-◂h∘∘
+◃h∘∘
   : ∀ {𝓤 𝓥 𝓦 𝓜 𝓛} {A : Type 𝓤} {B : A → Type 𝓥} {C : Type 𝓦}
       {D : Type 𝓜} {E : Type 𝓛}
       (j : D → E) (i : C → D) (h : ∀ {a} → B a → C)
       {f g : Π A B} (H : f ~ g)
-    → (j ∘ i ∘ h) ◂h H ~ j ◂h i ◂h h ◂h H
-◂h∘∘ h i j H a = ap-∘∘ h i j (H a)
+    → (j ∘ i ∘ h) ◃h H ~ j ◃h i ◃h h ◃h H
+◃h∘∘ h i j H a = ap-∘∘ h i j (H a)
 
-◂h⁻¹
+◃h⁻¹
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : A → Type 𝓥} {C : Type 𝓦}
       (f : ∀ {a} → B a → C) {g h : Π A B} (H : g ~ h)
-    → f ◂h (H h⁻¹) ~ ((f ◂h H) h⁻¹)
-◂h⁻¹ f H = ap-sym f ∘ H
+    → f ◃h (H h⁻¹) ~ ((f ◃h H) h⁻¹)
+◃h⁻¹ f H = ap-sym f ∘ H
 }
 }
 
@@ -214,7 +214,7 @@ homotopy-cancel
     → (ap f p ∙ H y) ∙ sym (ap g p) ＝ H x
 homotopy-cancel H refl = ∙-reflr _
 
-homotopy-inverse : ∀ {𝓤} {A : Type 𝓤} (f : A → A) (p : f ~ id) → p ▸h f ~ f ◂h p
+homotopy-inverse : ∀ {𝓤} {A : Type 𝓤} (f : A → A) (p : f ~ id) → p ▸h f ~ f ◃h p
 homotopy-inverse {𝓤} {A} f p x = p (f x)                ＝⟨ ∙.insertl A (∙-sym (p x)) ⟩
                          (p (f x) ∙ p x) ∙ sym (p x)    ＝⟨ II x ⟩
                          (ap f (p x) ∙ p x) ∙ sym (p x) ＝⟨ ∙.cancell A (∙-sym (p x)) ⟩
@@ -246,7 +246,7 @@ _◾h_
     → {f g : B → C} → f ~ g
     → {h k : A → B} → h ~ k
     → f ∘ h ~ g ∘ k
-_◾h_ {g = g} H {h = h} K = H ▸h h ∙h g ◂h K
+_◾h_ {g = g} H {h = h} K = H ▸h h ∙h g ◃h K
 
 infixr 2 _⟩◾h⟨_
 _⟩◾h⟨_
@@ -261,7 +261,7 @@ _◾h'_
     → {f g : B → C} → f ~ g
     → {h k : A → B} → h ~ k
     → f ∘ h ~ g ∘ k
-_◾h'_ {f = f} H {k = k} K = f ◂h K ∙h H ▸h k
+_◾h'_ {f = f} H {k = k} K = f ◃h K ∙h H ▸h k
 
 switch-◾h
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
@@ -277,17 +277,17 @@ homotopy-interchange
     → (H ◾h K) ∙h (L ◾h J) ~ ((H ∙h L) ◾h (K ∙h J))
 homotopy-interchange {f = f} {g} {h} H L {k} {l} {m} K J
   = (H ◾h K) ∙h (L ◾h J)                   ~⟨⟩
-    (H ▸h k ∙h g ◂h K) ∙h L ▸h l ∙h h ◂h J   ~⟨ ∙h-assoc _ (L ▸h l) (h ◂h J) h⁻¹ ⟩
-    ((H ▸h k ∙h g ◂h K) ∙h L ▸h l) ∙h h ◂h J ~⟨ ∙h-assoc _ (g ◂h K) (L ▸h l) ⟩∙h⟨ ~refl: (h ◂h J) ⟩
-    (H ▸h k ∙h (g ◂h K ∙h L ▸h l)) ∙h h ◂h J ~⟨ ∙h-assoc (H ▸h k) _ (h ◂h J) ⟩
-    H ▸h k ∙h (g ◂h K ∙h L ▸h l) ∙h h ◂h J
+    (H ▸h k ∙h g ◃h K) ∙h L ▸h l ∙h h ◃h J   ~⟨ ∙h-assoc _ (L ▸h l) (h ◃h J) h⁻¹ ⟩
+    ((H ▸h k ∙h g ◃h K) ∙h L ▸h l) ∙h h ◃h J ~⟨ ∙h-assoc _ (g ◃h K) (L ▸h l) ⟩∙h⟨ ~refl: (h ◃h J) ⟩
+    (H ▸h k ∙h (g ◃h K ∙h L ▸h l)) ∙h h ◃h J ~⟨ ∙h-assoc (H ▸h k) _ (h ◃h J) ⟩
+    H ▸h k ∙h (g ◃h K ∙h L ▸h l) ∙h h ◃h J
 
-        ~⟨ ~refl: (H ▸h k) ⟩∙h⟨ sym ∘ homotopy-natural L ∘ K ⟩∙h⟨ ~refl: (h ◂h J) ⟩
+        ~⟨ ~refl: (H ▸h k) ⟩∙h⟨ sym ∘ homotopy-natural L ∘ K ⟩∙h⟨ ~refl: (h ◃h J) ⟩
 
-    H ▸h k ∙h (L ▸h k ∙h h ◂h K) ∙h h ◂h J   ~⟨ ~refl: (H ▸h k) ⟩∙h⟨ ∙h-assoc (L ▸h k) (h ◂h K) (h ◂h J) ⟩
-    H ▸h k ∙h L ▸h k ∙h (h ◂h K ∙h h ◂h J)   ~⟨ ~refl: (H ▸h k) ⟩∙h⟨ ~refl: (L ▸h k) ⟩∙h⟨ ◂h∙ h K J h⁻¹ ⟩
-    H ▸h k ∙h L ▸h k ∙h h ◂h (K ∙h J)       ~⟨ ∙h-assoc (H ▸h k) (L ▸h k) _ h⁻¹ ⟩
-    (H ▸h k ∙h L ▸h k) ∙h h ◂h (K ∙h J)     ~⟨⟩
+    H ▸h k ∙h (L ▸h k ∙h h ◃h K) ∙h h ◃h J   ~⟨ ~refl: (H ▸h k) ⟩∙h⟨ ∙h-assoc (L ▸h k) (h ◃h K) (h ◃h J) ⟩
+    H ▸h k ∙h L ▸h k ∙h (h ◃h K ∙h h ◃h J)   ~⟨ ~refl: (H ▸h k) ⟩∙h⟨ ~refl: (L ▸h k) ⟩∙h⟨ ◃h∙ h K J h⁻¹ ⟩
+    H ▸h k ∙h L ▸h k ∙h h ◃h (K ∙h J)       ~⟨ ∙h-assoc (H ▸h k) (L ▸h k) _ h⁻¹ ⟩
+    (H ▸h k ∙h L ▸h k) ∙h h ◃h (K ∙h J)     ~⟨⟩
     (H ∙h L) ◾h (K ∙h J) ~∎
 }
 }

--- a/src/Foundations/Homotopy.lagda.tree
+++ b/src/Foundations/Homotopy.lagda.tree
@@ -237,46 +237,46 @@ it admits an interchange law with respect to vertical concatenation.}
 
 \proof{Follows from [naturality](stt-001O)}
 
-\p{The symbol we use for horizontal concatenation \code{◾} has agda-input sequence:
-\code{sq5}.}
+\p{The symbol we use for horizontal concatenation \code{◽} has agda-input sequence:
+\code{sq6}.}
 
 \agda{
-_◾h_
+_◽h_
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → {f g : B → C} → f ~ g
     → {h k : A → B} → h ~ k
     → f ∘ h ~ g ∘ k
-_◾h_ {g = g} H {h = h} K = H ▹h h ∙h g ◃h K
+_◽h_ {g = g} H {h = h} K = H ▹h h ∙h g ◃h K
 
-infixr 2 _⟩◾h⟨_
-_⟩◾h⟨_
+infixr 2 _⟩◽h⟨_
+_⟩◽h⟨_
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → {f g : B → C} {H H' : f ~ g} → H ~ H'
     → {h k : A → B} {K K' : h ~ k} → K ~ K'
-    → H ◾h K ~ H' ◾h K'
-(P ⟩◾h⟨ Q) a = ap₂ (_∙_) (P _) (ap (ap _) (Q a))
+    → H ◽h K ~ H' ◽h K'
+(P ⟩◽h⟨ Q) a = ap₂ (_∙_) (P _) (ap (ap _) (Q a))
 
-_◾h'_
+_◽h'_
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → {f g : B → C} → f ~ g
     → {h k : A → B} → h ~ k
     → f ∘ h ~ g ∘ k
-_◾h'_ {f = f} H {k = k} K = f ◃h K ∙h H ▹h k
+_◽h'_ {f = f} H {k = k} K = f ◃h K ∙h H ▹h k
 
-switch-◾h
+switch-◽h
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → {f g : B → C} (H : f ~ g)
     → {h k : A → B} (K : h ~ k)
-    → H ◾h K ~ H ◾h' K
-switch-◾h H K a = homotopy-natural H (K a)
+    → H ◽h K ~ H ◽h' K
+switch-◽h H K a = homotopy-natural H (K a)
 
 homotopy-interchange
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
       {f g h : B → C} (H : f ~ g) (L : g ~ h)
       {k l m : A → B} (K : k ~ l) (J : l ~ m)
-    → (H ◾h K) ∙h (L ◾h J) ~ ((H ∙h L) ◾h (K ∙h J))
+    → (H ◽h K) ∙h (L ◽h J) ~ ((H ∙h L) ◽h (K ∙h J))
 homotopy-interchange {f = f} {g} {h} H L {k} {l} {m} K J
-  = (H ◾h K) ∙h (L ◾h J)                   ~⟨⟩
+  = (H ◽h K) ∙h (L ◽h J)                   ~⟨⟩
     (H ▹h k ∙h g ◃h K) ∙h L ▹h l ∙h h ◃h J   ~⟨ ∙h-assoc _ (L ▹h l) (h ◃h J) h⁻¹ ⟩
     ((H ▹h k ∙h g ◃h K) ∙h L ▹h l) ∙h h ◃h J ~⟨ ∙h-assoc _ (g ◃h K) (L ▹h l) ⟩∙h⟨ ~refl: (h ◃h J) ⟩
     (H ▹h k ∙h (g ◃h K ∙h L ▹h l)) ∙h h ◃h J ~⟨ ∙h-assoc (H ▹h k) _ (h ◃h J) ⟩
@@ -288,6 +288,6 @@ homotopy-interchange {f = f} {g} {h} H L {k} {l} {m} K J
     H ▹h k ∙h L ▹h k ∙h (h ◃h K ∙h h ◃h J)   ~⟨ ~refl: (H ▹h k) ⟩∙h⟨ ~refl: (L ▹h k) ⟩∙h⟨ ◃h∙ h K J h⁻¹ ⟩
     H ▹h k ∙h L ▹h k ∙h h ◃h (K ∙h J)       ~⟨ ∙h-assoc (H ▹h k) (L ▹h k) _ h⁻¹ ⟩
     (H ▹h k ∙h L ▹h k) ∙h h ◃h (K ∙h J)     ~⟨⟩
-    (H ∙h L) ◾h (K ∙h J) ~∎
+    (H ∙h L) ◽h (K ∙h J) ~∎
 }
 }

--- a/src/Foundations/Homotopy.lagda.tree
+++ b/src/Foundations/Homotopy.lagda.tree
@@ -129,11 +129,11 @@ id◃h : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} (H : f 
 id◃h H a = ap-id (H a)
 
 
-infixl 17 _▸h_
-_▸h_
+infixl 17 _▹h_
+_▹h_
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → {f g : B → C} → f ~ g → (h : A → B) → f ∘ h ~ g ∘ h
-(p ▸h h) x = p (h x)
+(p ▹h h) x = p (h x)
 
 
 infixr 2 _⟩◃h⟨_
@@ -214,7 +214,7 @@ homotopy-cancel
     → (ap f p ∙ H y) ∙ sym (ap g p) ＝ H x
 homotopy-cancel H refl = ∙-reflr _
 
-homotopy-inverse : ∀ {𝓤} {A : Type 𝓤} (f : A → A) (p : f ~ id) → p ▸h f ~ f ◃h p
+homotopy-inverse : ∀ {𝓤} {A : Type 𝓤} (f : A → A) (p : f ~ id) → p ▹h f ~ f ◃h p
 homotopy-inverse {𝓤} {A} f p x = p (f x)                ＝⟨ ∙.insertl A (∙-sym (p x)) ⟩
                          (p (f x) ∙ p x) ∙ sym (p x)    ＝⟨ II x ⟩
                          (ap f (p x) ∙ p x) ∙ sym (p x) ＝⟨ ∙.cancell A (∙-sym (p x)) ⟩
@@ -246,7 +246,7 @@ _◾h_
     → {f g : B → C} → f ~ g
     → {h k : A → B} → h ~ k
     → f ∘ h ~ g ∘ k
-_◾h_ {g = g} H {h = h} K = H ▸h h ∙h g ◃h K
+_◾h_ {g = g} H {h = h} K = H ▹h h ∙h g ◃h K
 
 infixr 2 _⟩◾h⟨_
 _⟩◾h⟨_
@@ -261,7 +261,7 @@ _◾h'_
     → {f g : B → C} → f ~ g
     → {h k : A → B} → h ~ k
     → f ∘ h ~ g ∘ k
-_◾h'_ {f = f} H {k = k} K = f ◃h K ∙h H ▸h k
+_◾h'_ {f = f} H {k = k} K = f ◃h K ∙h H ▹h k
 
 switch-◾h
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
@@ -277,17 +277,17 @@ homotopy-interchange
     → (H ◾h K) ∙h (L ◾h J) ~ ((H ∙h L) ◾h (K ∙h J))
 homotopy-interchange {f = f} {g} {h} H L {k} {l} {m} K J
   = (H ◾h K) ∙h (L ◾h J)                   ~⟨⟩
-    (H ▸h k ∙h g ◃h K) ∙h L ▸h l ∙h h ◃h J   ~⟨ ∙h-assoc _ (L ▸h l) (h ◃h J) h⁻¹ ⟩
-    ((H ▸h k ∙h g ◃h K) ∙h L ▸h l) ∙h h ◃h J ~⟨ ∙h-assoc _ (g ◃h K) (L ▸h l) ⟩∙h⟨ ~refl: (h ◃h J) ⟩
-    (H ▸h k ∙h (g ◃h K ∙h L ▸h l)) ∙h h ◃h J ~⟨ ∙h-assoc (H ▸h k) _ (h ◃h J) ⟩
-    H ▸h k ∙h (g ◃h K ∙h L ▸h l) ∙h h ◃h J
+    (H ▹h k ∙h g ◃h K) ∙h L ▹h l ∙h h ◃h J   ~⟨ ∙h-assoc _ (L ▹h l) (h ◃h J) h⁻¹ ⟩
+    ((H ▹h k ∙h g ◃h K) ∙h L ▹h l) ∙h h ◃h J ~⟨ ∙h-assoc _ (g ◃h K) (L ▹h l) ⟩∙h⟨ ~refl: (h ◃h J) ⟩
+    (H ▹h k ∙h (g ◃h K ∙h L ▹h l)) ∙h h ◃h J ~⟨ ∙h-assoc (H ▹h k) _ (h ◃h J) ⟩
+    H ▹h k ∙h (g ◃h K ∙h L ▹h l) ∙h h ◃h J
 
-        ~⟨ ~refl: (H ▸h k) ⟩∙h⟨ sym ∘ homotopy-natural L ∘ K ⟩∙h⟨ ~refl: (h ◃h J) ⟩
+        ~⟨ ~refl: (H ▹h k) ⟩∙h⟨ sym ∘ homotopy-natural L ∘ K ⟩∙h⟨ ~refl: (h ◃h J) ⟩
 
-    H ▸h k ∙h (L ▸h k ∙h h ◃h K) ∙h h ◃h J   ~⟨ ~refl: (H ▸h k) ⟩∙h⟨ ∙h-assoc (L ▸h k) (h ◃h K) (h ◃h J) ⟩
-    H ▸h k ∙h L ▸h k ∙h (h ◃h K ∙h h ◃h J)   ~⟨ ~refl: (H ▸h k) ⟩∙h⟨ ~refl: (L ▸h k) ⟩∙h⟨ ◃h∙ h K J h⁻¹ ⟩
-    H ▸h k ∙h L ▸h k ∙h h ◃h (K ∙h J)       ~⟨ ∙h-assoc (H ▸h k) (L ▸h k) _ h⁻¹ ⟩
-    (H ▸h k ∙h L ▸h k) ∙h h ◃h (K ∙h J)     ~⟨⟩
+    H ▹h k ∙h (L ▹h k ∙h h ◃h K) ∙h h ◃h J   ~⟨ ~refl: (H ▹h k) ⟩∙h⟨ ∙h-assoc (L ▹h k) (h ◃h K) (h ◃h J) ⟩
+    H ▹h k ∙h L ▹h k ∙h (h ◃h K ∙h h ◃h J)   ~⟨ ~refl: (H ▹h k) ⟩∙h⟨ ~refl: (L ▹h k) ⟩∙h⟨ ◃h∙ h K J h⁻¹ ⟩
+    H ▹h k ∙h L ▹h k ∙h h ◃h (K ∙h J)       ~⟨ ∙h-assoc (H ▹h k) (L ▹h k) _ h⁻¹ ⟩
+    (H ▹h k ∙h L ▹h k) ∙h h ◃h (K ∙h J)     ~⟨⟩
     (H ∙h L) ◾h (K ∙h J) ~∎
 }
 }

--- a/src/Foundations/Homotopy.lagda.tree
+++ b/src/Foundations/Homotopy.lagda.tree
@@ -119,63 +119,63 @@ _⟩∙h⟨_
 
 
 \agda{
-infixr 16 _◂_
-_◂_
+infixr 16 _◂h_
+_◂h_
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : A → Type 𝓥} {C : Type 𝓦}
     → (h : ∀ {a} → B a → C) {f g : Π A B} → f ~ g → h ∘ f ~ h ∘ g
-(h ◂ p) x = ap h (p x)
+(h ◂h p) x = ap h (p x)
 
-id◂ : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} (H : f ~ g) → id ◂ H ~ H
-id◂ H a = ap-id (H a)
+id◂h : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B} (H : f ~ g) → id ◂h H ~ H
+id◂h H a = ap-id (H a)
 
 
-infixl 17 _▸_
-_▸_
+infixl 17 _▸h_
+_▸h_
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → {f g : B → C} → f ~ g → (h : A → B) → f ∘ h ~ g ∘ h
-(p ▸ h) x = p (h x)
+(p ▸h h) x = p (h x)
 
 
-infixr 2 _⟩◂⟨_
-_⟩◂⟨_ : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
-           (f : B → C) {g h : A → B} {p q : g ~ h} → p ~ q → f ◂ p ~ f ◂ q
-(f ⟩◂⟨ p) a = ap (ap f) (p a)
+infixr 2 _⟩◂h⟨_
+_⟩◂h⟨_ : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
+           (f : B → C) {g h : A → B} {p q : g ~ h} → p ~ q → f ◂h p ~ f ◂h q
+(f ⟩◂h⟨ p) a = ap (ap f) (p a)
 
 
-◂∙
+◂h∙
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : A → Type 𝓥} {C : Type 𝓦}
       (k : ∀ {a} → B a → C) {f g h : Π A B} (H : f ~ g) (K : g ~ h)
-    → k ◂ (H ∙h K) ~ (k ◂ H) ∙h (k ◂ K)
-◂∙ k H K a = ap-∙ k (H a) (K a)
+    → k ◂h (H ∙h K) ~ (k ◂h H) ∙h (k ◂h K)
+◂h∙ k H K a = ap-∙ k (H a) (K a)
 
-◂∙∙
+◂h∙∙
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : A → Type 𝓥} {C : Type 𝓦}
       (l : ∀ {a} → B a → C) {f g h k : Π A B}
       (H : f ~ g) (K : g ~ h) (L : h ~ k)
-    → l ◂ (H ∙h K ∙h L) ~ (l ◂ H) ∙h (l ◂ K) ∙h (l ◂ L)
-◂∙∙ k H K L a = ap-∙∙ k (H a) (K a) (L a)
+    → l ◂h (H ∙h K ∙h L) ~ (l ◂h H) ∙h (l ◂h K) ∙h (l ◂h L)
+◂h∙∙ k H K L a = ap-∙∙ k (H a) (K a) (L a)
 
-◂∘
+◂h∘
   : ∀ {𝓤 𝓥 𝓦 𝓜} {A : Type 𝓤} {B : A → Type 𝓥} {C : Type 𝓦}
       {D : Type 𝓜}
       (i : C → D) (h : ∀ {a} → B a → C)
       {f g : Π A B} (H : f ~ g)
-    → (i ∘ h) ◂ H ~ i ◂ h ◂ H
-◂∘ i k H a = ap-∘ i k (H a)
+    → (i ∘ h) ◂h H ~ i ◂h h ◂h H
+◂h∘ i k H a = ap-∘ i k (H a)
 
-◂∘∘
+◂h∘∘
   : ∀ {𝓤 𝓥 𝓦 𝓜 𝓛} {A : Type 𝓤} {B : A → Type 𝓥} {C : Type 𝓦}
       {D : Type 𝓜} {E : Type 𝓛}
       (j : D → E) (i : C → D) (h : ∀ {a} → B a → C)
       {f g : Π A B} (H : f ~ g)
-    → (j ∘ i ∘ h) ◂ H ~ j ◂ i ◂ h ◂ H
-◂∘∘ h i j H a = ap-∘∘ h i j (H a)
+    → (j ∘ i ∘ h) ◂h H ~ j ◂h i ◂h h ◂h H
+◂h∘∘ h i j H a = ap-∘∘ h i j (H a)
 
-◂⁻¹
+◂h⁻¹
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : A → Type 𝓥} {C : Type 𝓦}
       (f : ∀ {a} → B a → C) {g h : Π A B} (H : g ~ h)
-    → f ◂ (H h⁻¹) ~ ((f ◂ H) h⁻¹)
-◂⁻¹ f H = ap-sym f ∘ H
+    → f ◂h (H h⁻¹) ~ ((f ◂h H) h⁻¹)
+◂h⁻¹ f H = ap-sym f ∘ H
 }
 }
 
@@ -194,6 +194,12 @@ homotopy-natural
     → ∀ {x y} (p : x ＝ y) → h x ∙ ap g p ＝ ap f p ∙ h y
 homotopy-natural _ refl = ∙-reflr _
 
+homotopy-natural~id
+  : ∀ {𝓤} {A : Type 𝓤} {f : A → A} (H : f ~ id)
+    → ∀ {x y} (p : x ＝ y) → ap f p ∙ H y ＝ H x ∙ p
+homotopy-natural~id H p
+  = sym (homotopy-natural H p) ∙ ap (H _ ∙_) (ap-id p)
+
 homotopy-conjugate
   : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} {f g : A → B}
       (H : f ~ g)
@@ -208,7 +214,7 @@ homotopy-cancel
     → (ap f p ∙ H y) ∙ sym (ap g p) ＝ H x
 homotopy-cancel H refl = ∙-reflr _
 
-homotopy-inverse : ∀ {𝓤} {A : Type 𝓤} (f : A → A) (p : f ~ id) → p ▸ f ~ f ◂ p
+homotopy-inverse : ∀ {𝓤} {A : Type 𝓤} (f : A → A) (p : f ~ id) → p ▸h f ~ f ◂h p
 homotopy-inverse {𝓤} {A} f p x = p (f x)                ＝⟨ ∙.insertl A (∙-sym (p x)) ⟩
                          (p (f x) ∙ p x) ∙ sym (p x)    ＝⟨ II x ⟩
                          (ap f (p x) ∙ p x) ∙ sym (p x) ＝⟨ ∙.cancell A (∙-sym (p x)) ⟩
@@ -235,53 +241,53 @@ it admits an interchange law with respect to vertical concatenation.}
 \code{sq5}.}
 
 \agda{
-_◾_
+_◾h_
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → {f g : B → C} → f ~ g
     → {h k : A → B} → h ~ k
     → f ∘ h ~ g ∘ k
-_◾_ {g = g} H {h = h} K = H ▸ h ∙h g ◂ K
+_◾h_ {g = g} H {h = h} K = H ▸h h ∙h g ◂h K
 
-infixr 2 _⟩◾⟨_
-_⟩◾⟨_
+infixr 2 _⟩◾h⟨_
+_⟩◾h⟨_
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → {f g : B → C} {H H' : f ~ g} → H ~ H'
     → {h k : A → B} {K K' : h ~ k} → K ~ K'
-    → H ◾ K ~ H' ◾ K'
-(P ⟩◾⟨ Q) a = ap₂ (_∙_) (P _) (ap (ap _) (Q a))
+    → H ◾h K ~ H' ◾h K'
+(P ⟩◾h⟨ Q) a = ap₂ (_∙_) (P _) (ap (ap _) (Q a))
 
-_◾'_
+_◾h'_
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → {f g : B → C} → f ~ g
     → {h k : A → B} → h ~ k
     → f ∘ h ~ g ∘ k
-_◾'_ {f = f} H {k = k} K = f ◂ K ∙h H ▸ k
+_◾h'_ {f = f} H {k = k} K = f ◂h K ∙h H ▸h k
 
-switch-◾
+switch-◾h
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → {f g : B → C} (H : f ~ g)
     → {h k : A → B} (K : h ~ k)
-    → H ◾ K ~ H ◾' K
-switch-◾ H K a = homotopy-natural H (K a)
+    → H ◾h K ~ H ◾h' K
+switch-◾h H K a = homotopy-natural H (K a)
 
 homotopy-interchange
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
       {f g h : B → C} (H : f ~ g) (L : g ~ h)
       {k l m : A → B} (K : k ~ l) (J : l ~ m)
-    → (H ◾ K) ∙h (L ◾ J) ~ ((H ∙h L) ◾ (K ∙h J))
+    → (H ◾h K) ∙h (L ◾h J) ~ ((H ∙h L) ◾h (K ∙h J))
 homotopy-interchange {f = f} {g} {h} H L {k} {l} {m} K J
-  = (H ◾ K) ∙h (L ◾ J) ~⟨⟩
-    (H ▸ k ∙h g ◂ K) ∙h L ▸ l ∙h h ◂ J   ~⟨ ∙h-assoc _ (L ▸ l) (h ◂ J) h⁻¹ ⟩
-    ((H ▸ k ∙h g ◂ K) ∙h L ▸ l) ∙h h ◂ J ~⟨ ∙h-assoc _ (g ◂ K) (L ▸ l) ⟩∙h⟨ ~refl: (h ◂ J) ⟩
-    (H ▸ k ∙h (g ◂ K ∙h L ▸ l)) ∙h h ◂ J ~⟨ ∙h-assoc (H ▸ k) _ (h ◂ J) ⟩
-    H ▸ k ∙h (g ◂ K ∙h L ▸ l) ∙h h ◂ J
+  = (H ◾h K) ∙h (L ◾h J)                   ~⟨⟩
+    (H ▸h k ∙h g ◂h K) ∙h L ▸h l ∙h h ◂h J   ~⟨ ∙h-assoc _ (L ▸h l) (h ◂h J) h⁻¹ ⟩
+    ((H ▸h k ∙h g ◂h K) ∙h L ▸h l) ∙h h ◂h J ~⟨ ∙h-assoc _ (g ◂h K) (L ▸h l) ⟩∙h⟨ ~refl: (h ◂h J) ⟩
+    (H ▸h k ∙h (g ◂h K ∙h L ▸h l)) ∙h h ◂h J ~⟨ ∙h-assoc (H ▸h k) _ (h ◂h J) ⟩
+    H ▸h k ∙h (g ◂h K ∙h L ▸h l) ∙h h ◂h J
 
-        ~⟨ ~refl: (H ▸ k) ⟩∙h⟨ sym ∘ homotopy-natural L ∘ K ⟩∙h⟨ ~refl: (h ◂ J) ⟩
+        ~⟨ ~refl: (H ▸h k) ⟩∙h⟨ sym ∘ homotopy-natural L ∘ K ⟩∙h⟨ ~refl: (h ◂h J) ⟩
 
-    H ▸ k ∙h (L ▸ k ∙h h ◂ K) ∙h h ◂ J ~⟨ ~refl: (H ▸ k) ⟩∙h⟨ ∙h-assoc (L ▸ k) (h ◂ K) (h ◂ J) ⟩
-    H ▸ k ∙h L ▸ k ∙h (h ◂ K ∙h h ◂ J) ~⟨ ~refl: (H ▸ k) ⟩∙h⟨ ~refl: (L ▸ k) ⟩∙h⟨ ◂∙ h K J h⁻¹ ⟩
-    H ▸ k ∙h L ▸ k ∙h h ◂ (K ∙h J)     ~⟨ ∙h-assoc (H ▸ k) (L ▸ k) _ h⁻¹ ⟩
-    (H ▸ k ∙h L ▸ k) ∙h h ◂ (K ∙h J)   ~⟨⟩
-    (H ∙h L) ◾ (K ∙h J) ~∎
+    H ▸h k ∙h (L ▸h k ∙h h ◂h K) ∙h h ◂h J   ~⟨ ~refl: (H ▸h k) ⟩∙h⟨ ∙h-assoc (L ▸h k) (h ◂h K) (h ◂h J) ⟩
+    H ▸h k ∙h L ▸h k ∙h (h ◂h K ∙h h ◂h J)   ~⟨ ~refl: (H ▸h k) ⟩∙h⟨ ~refl: (L ▸h k) ⟩∙h⟨ ◂h∙ h K J h⁻¹ ⟩
+    H ▸h k ∙h L ▸h k ∙h h ◂h (K ∙h J)       ~⟨ ∙h-assoc (H ▸h k) (L ▸h k) _ h⁻¹ ⟩
+    (H ▸h k ∙h L ▸h k) ∙h h ◂h (K ∙h J)     ~⟨⟩
+    (H ∙h L) ◾h (K ∙h J) ~∎
 }
 }

--- a/src/Foundations/IdempotentMaps.lagda.tree
+++ b/src/Foundations/IdempotentMaps.lagda.tree
@@ -119,7 +119,7 @@ qcoh-preidempotence
   : ∀ {𝓤} {X : Type 𝓤} (f : X → X)
     → preidempotence f
     → Type 𝓤
-qcoh-preidempotence f I = (f ◃h I) ~ (I ▸h f)
+qcoh-preidempotence f I = (f ◃h I) ~ (I ▹h f)
 
 qidempotence
   : ∀ {𝓤} {X : Type 𝓤}

--- a/src/Foundations/IdempotentMaps.lagda.tree
+++ b/src/Foundations/IdempotentMaps.lagda.tree
@@ -119,7 +119,7 @@ qcoh-preidempotence
   : ∀ {𝓤} {X : Type 𝓤} (f : X → X)
     → preidempotence f
     → Type 𝓤
-qcoh-preidempotence f I = (f ◂ I) ~ (I ▸ f)
+qcoh-preidempotence f I = (f ◂h I) ~ (I ▸h f)
 
 qidempotence
   : ∀ {𝓤} {X : Type 𝓤}

--- a/src/Foundations/IdempotentMaps.lagda.tree
+++ b/src/Foundations/IdempotentMaps.lagda.tree
@@ -119,7 +119,7 @@ qcoh-preidempotence
   : ∀ {𝓤} {X : Type 𝓤} (f : X → X)
     → preidempotence f
     → Type 𝓤
-qcoh-preidempotence f I = (f ◂h I) ~ (I ▸h f)
+qcoh-preidempotence f I = (f ◃h I) ~ (I ▸h f)
 
 qidempotence
   : ∀ {𝓤} {X : Type 𝓤}

--- a/src/Foundations/IsEquivIsProp.lagda.tree
+++ b/src/Foundations/IsEquivIsProp.lagda.tree
@@ -95,7 +95,7 @@ section #{s}.}
 section-coherence
   : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} (f : A → B)
     → section f → Type (𝓤 ⊔ 𝓥)
-section-coherence f (g , ε) = Σ (g ∘ f ~ id) λ η → f ◂h η ~ ε ▸h f
+section-coherence f (g , ε) = Σ (g ∘ f ~ id) λ η → f ◃h η ~ ε ▸h f
 }
 }
 
@@ -144,7 +144,7 @@ section-coherence-path
     → (section-coherence f sec)
     ≃ (∀ (x : A) → Id (fibre f (f x)) (g (f x) , ε (f x)) (x , refl))
 section-coherence-path {f = f} (g , ε)
-  = Σ (g ∘ f ~ id) (λ η → f ◂h η ~ ε ▸h f)                        ≃⟨ Σ-Π-swap≃ _ _ e⁻¹ ⟩
+  = Σ (g ∘ f ~ id) (λ η → f ◃h η ~ ε ▸h f)                        ≃⟨ Σ-Π-swap≃ _ _ e⁻¹ ⟩
     (∀ a → Σ ((g ∘ f) a ＝ a) (λ η → ap f η ＝ ε (f a)))         ≃⟨ Π-fam-≃ (λ _ → Σ-snd-≃ lem) ⟩
     (∀ a → Σ ((g ∘ f) a ＝ a) (λ η → ap f η ∙ refl ＝ ε (f a)))  ≃⟨ Π-fam-≃ (λ a → fibre-path≃ e⁻¹) ⟩
     (∀ x → Id (fibre f (f x)) (g (f x) , ε (f x)) (x , refl))   ≃∎ where

--- a/src/Foundations/IsEquivIsProp.lagda.tree
+++ b/src/Foundations/IsEquivIsProp.lagda.tree
@@ -95,7 +95,7 @@ section #{s}.}
 section-coherence
   : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} (f : A → B)
     → section f → Type (𝓤 ⊔ 𝓥)
-section-coherence f (g , ε) = Σ (g ∘ f ~ id) λ η → f ◂ η ~ ε ▸ f
+section-coherence f (g , ε) = Σ (g ∘ f ~ id) λ η → f ◂h η ~ ε ▸h f
 }
 }
 
@@ -144,7 +144,7 @@ section-coherence-path
     → (section-coherence f sec)
     ≃ (∀ (x : A) → Id (fibre f (f x)) (g (f x) , ε (f x)) (x , refl))
 section-coherence-path {f = f} (g , ε)
-  = Σ (g ∘ f ~ id) (λ η → f ◂ η ~ ε ▸ f)                        ≃⟨ Σ-Π-swap≃ _ _ e⁻¹ ⟩
+  = Σ (g ∘ f ~ id) (λ η → f ◂h η ~ ε ▸h f)                        ≃⟨ Σ-Π-swap≃ _ _ e⁻¹ ⟩
     (∀ a → Σ ((g ∘ f) a ＝ a) (λ η → ap f η ＝ ε (f a)))         ≃⟨ Π-fam-≃ (λ _ → Σ-snd-≃ lem) ⟩
     (∀ a → Σ ((g ∘ f) a ＝ a) (λ η → ap f η ∙ refl ＝ ε (f a)))  ≃⟨ Π-fam-≃ (λ a → fibre-path≃ e⁻¹) ⟩
     (∀ x → Id (fibre f (f x)) (g (f x) , ε (f x)) (x , refl))   ≃∎ where
@@ -210,7 +210,7 @@ as homotopies of the underlying functions}
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → (e : A ≃ B) → (e' : B ≃ C)
     → e ∙e e' ∙e e' e⁻¹ ＝ e
-∙e-sym e e' = ≃-path→ (WithFunExt-global.funext→ FE (e'.η ▸ e.fwd))
+∙e-sym e e' = ≃-path→ (WithFunExt-global.funext→ FE (e'.η ▸h e.fwd))
   where
   module e = _≃_ e
   module e' = _≃_ e'
@@ -219,7 +219,7 @@ as homotopies of the underlying functions}
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → (e : A ≃ B) → (e' : C ≃ B)
     → (e ∙e e' e⁻¹) ∙e e' ＝ e
-∙e-sym' e e' = ≃-path→ (WithFunExt-global.funext→ FE (e'.ε ▸ e.fwd))
+∙e-sym' e e' = ≃-path→ (WithFunExt-global.funext→ FE (e'.ε ▸h e.fwd))
   where
   module e = _≃_ e
   module e' = _≃_ e'

--- a/src/Foundations/IsEquivIsProp.lagda.tree
+++ b/src/Foundations/IsEquivIsProp.lagda.tree
@@ -95,7 +95,7 @@ section #{s}.}
 section-coherence
   : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} (f : A → B)
     → section f → Type (𝓤 ⊔ 𝓥)
-section-coherence f (g , ε) = Σ (g ∘ f ~ id) λ η → f ◃h η ~ ε ▸h f
+section-coherence f (g , ε) = Σ (g ∘ f ~ id) λ η → f ◃h η ~ ε ▹h f
 }
 }
 
@@ -144,7 +144,7 @@ section-coherence-path
     → (section-coherence f sec)
     ≃ (∀ (x : A) → Id (fibre f (f x)) (g (f x) , ε (f x)) (x , refl))
 section-coherence-path {f = f} (g , ε)
-  = Σ (g ∘ f ~ id) (λ η → f ◃h η ~ ε ▸h f)                        ≃⟨ Σ-Π-swap≃ _ _ e⁻¹ ⟩
+  = Σ (g ∘ f ~ id) (λ η → f ◃h η ~ ε ▹h f)                        ≃⟨ Σ-Π-swap≃ _ _ e⁻¹ ⟩
     (∀ a → Σ ((g ∘ f) a ＝ a) (λ η → ap f η ＝ ε (f a)))         ≃⟨ Π-fam-≃ (λ _ → Σ-snd-≃ lem) ⟩
     (∀ a → Σ ((g ∘ f) a ＝ a) (λ η → ap f η ∙ refl ＝ ε (f a)))  ≃⟨ Π-fam-≃ (λ a → fibre-path≃ e⁻¹) ⟩
     (∀ x → Id (fibre f (f x)) (g (f x) , ε (f x)) (x , refl))   ≃∎ where
@@ -210,7 +210,7 @@ as homotopies of the underlying functions}
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → (e : A ≃ B) → (e' : B ≃ C)
     → e ∙e e' ∙e e' e⁻¹ ＝ e
-∙e-sym e e' = ≃-path→ (WithFunExt-global.funext→ FE (e'.η ▸h e.fwd))
+∙e-sym e e' = ≃-path→ (WithFunExt-global.funext→ FE (e'.η ▹h e.fwd))
   where
   module e = _≃_ e
   module e' = _≃_ e'
@@ -219,7 +219,7 @@ as homotopies of the underlying functions}
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}
     → (e : A ≃ B) → (e' : C ≃ B)
     → (e ∙e e' e⁻¹) ∙e e' ＝ e
-∙e-sym' e e' = ≃-path→ (WithFunExt-global.funext→ FE (e'.ε ▸h e.fwd))
+∙e-sym' e e' = ≃-path→ (WithFunExt-global.funext→ FE (e'.ε ▹h e.fwd))
   where
   module e = _≃_ e
   module e' = _≃_ e'

--- a/src/Foundations/Pullbacks.lagda.tree
+++ b/src/Foundations/Pullbacks.lagda.tree
@@ -64,7 +64,7 @@ cone-map
     → {D : Type 𝓛} → (C : Cone S D)
     → {Q : Type 𝓠} → (Q → D)
     → Cone S Q
-cone-map S C f = mk-cone (i ∘ f) (j ∘ f) (filler ▸ f) where open Cone C
+cone-map S C f = mk-cone (i ∘ f) (j ∘ f) (filler ▸h f) where open Cone C
 
 module _ {𝓤 𝓥 𝓦} (S : Cospan 𝓤 𝓥 𝓦) where
   open Cospan S
@@ -135,7 +135,7 @@ module _
     : (u : X → Y)
     → is-equiv (precomp (Cospan.Left S) u)
     → is-equiv (precomp (Cospan.Right S) u)
-    → ((i : Y → Cospan.Left S) (j : Y → Cospan.Right S) → is-equiv (_▸ u))
+    → ((i : Y → Cospan.Left S) (j : Y → Cospan.Right S) → is-equiv (_▸h u))
     → is-equiv (λ (c : Cone S Y) → cone-map S c u)
   cone-map-is-equiv u leq req heq
     = is-equiv-∘
@@ -152,7 +152,7 @@ module _
       = Σ[ i ∶ (Y → Left) ] Σ[ j ∶ (Y → Right) ] (left ∘ i ~ right ∘ j)
           ≃⟨ Σ-snd-≃
               ( λ i
-                → Σ-snd-≃ (λ j → mk≃ (_▸ u) (heq i j))
+                → Σ-snd-≃ (λ j → mk≃ (_▸h u) (heq i j))
                 ∙e Σ-fst-≃ (mk≃ (precomp Right u) req)) ⟩
         Σ[ i ∶ (Y → Left) ] Σ[ j ∶ (X → Right) ] (left ∘ i ∘ u ~ right ∘ j)
           ≃⟨ Σ-fst-≃ (mk≃ (precomp Left u) leq) ⟩

--- a/src/Foundations/Pullbacks.lagda.tree
+++ b/src/Foundations/Pullbacks.lagda.tree
@@ -64,7 +64,7 @@ cone-map
     → {D : Type 𝓛} → (C : Cone S D)
     → {Q : Type 𝓠} → (Q → D)
     → Cone S Q
-cone-map S C f = mk-cone (i ∘ f) (j ∘ f) (filler ▸h f) where open Cone C
+cone-map S C f = mk-cone (i ∘ f) (j ∘ f) (filler ▹h f) where open Cone C
 
 module _ {𝓤 𝓥 𝓦} (S : Cospan 𝓤 𝓥 𝓦) where
   open Cospan S
@@ -135,7 +135,7 @@ module _
     : (u : X → Y)
     → is-equiv (precomp (Cospan.Left S) u)
     → is-equiv (precomp (Cospan.Right S) u)
-    → ((i : Y → Cospan.Left S) (j : Y → Cospan.Right S) → is-equiv (_▸h u))
+    → ((i : Y → Cospan.Left S) (j : Y → Cospan.Right S) → is-equiv (_▹h u))
     → is-equiv (λ (c : Cone S Y) → cone-map S c u)
   cone-map-is-equiv u leq req heq
     = is-equiv-∘
@@ -152,7 +152,7 @@ module _
       = Σ[ i ∶ (Y → Left) ] Σ[ j ∶ (Y → Right) ] (left ∘ i ~ right ∘ j)
           ≃⟨ Σ-snd-≃
               ( λ i
-                → Σ-snd-≃ (λ j → mk≃ (_▸h u) (heq i j))
+                → Σ-snd-≃ (λ j → mk≃ (_▹h u) (heq i j))
                 ∙e Σ-fst-≃ (mk≃ (precomp Right u) req)) ⟩
         Σ[ i ∶ (Y → Left) ] Σ[ j ∶ (X → Right) ] (left ∘ i ∘ u ~ right ∘ j)
           ≃⟨ Σ-fst-≃ (mk≃ (precomp Left u) leq) ⟩

--- a/src/Foundations/Pushouts.lagda.tree
+++ b/src/Foundations/Pushouts.lagda.tree
@@ -64,7 +64,7 @@ module _ {𝓤 𝓥 𝓦} (S : Span 𝓤 𝓥 𝓦) where
   cocone-map
     : ∀ {𝓛 𝓜} {C : Type 𝓛} (C-cc : Cocone S C)
         {Q : Type 𝓜} → (C → Q) → Cocone S Q
-  cocone-map C f = mk-cocone (f ∘ p) (f ∘ q) (f ◂ filler) where open Cocone C
+  cocone-map C f = mk-cocone (f ∘ p) (f ∘ q) (f ◂h filler) where open Cocone C
 
   up-pushout' : ∀ {𝓛} {C : Type 𝓛} → Cocone S C → ∀ 𝓠 → Type (lsuc (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓠) ⊔ 𝓛)
   up-pushout' C 𝓠 = ∀ {Q : Type 𝓠} → is-equiv (cocone-map C {Q})

--- a/src/Foundations/Pushouts.lagda.tree
+++ b/src/Foundations/Pushouts.lagda.tree
@@ -64,7 +64,7 @@ module _ {𝓤 𝓥 𝓦} (S : Span 𝓤 𝓥 𝓦) where
   cocone-map
     : ∀ {𝓛 𝓜} {C : Type 𝓛} (C-cc : Cocone S C)
         {Q : Type 𝓜} → (C → Q) → Cocone S Q
-  cocone-map C f = mk-cocone (f ∘ p) (f ∘ q) (f ◂h filler) where open Cocone C
+  cocone-map C f = mk-cocone (f ∘ p) (f ∘ q) (f ◃h filler) where open Cocone C
 
   up-pushout' : ∀ {𝓛} {C : Type 𝓛} → Cocone S C → ∀ 𝓠 → Type (lsuc (𝓤 ⊔ 𝓥 ⊔ 𝓦 ⊔ 𝓠) ⊔ 𝓛)
   up-pushout' C 𝓠 = ∀ {Q : Type 𝓠} → is-equiv (cocone-map C {Q})

--- a/src/Foundations/QuasiEquivalences.lagda.tree
+++ b/src/Foundations/QuasiEquivalences.lagda.tree
@@ -82,10 +82,10 @@ comp-qinv
 comp-qinv {f = f} {g} (f-inv , f-ret , f-sec) (g-inv , g-ret , g-sec)
   = (f-inv ∘ g-inv , ret , sec) where
   sec : section-witness (g ∘ f) (f-inv ∘ g-inv)
-  sec = g ◂h f-sec ▸h g-inv ∙h g-sec
+  sec = g ◃h f-sec ▸h g-inv ∙h g-sec
 
   ret : retraction-witness (g ∘ f) (f-inv ∘ g-inv)
-  ret = f-inv ◂h g-ret ▸h f ∙h f-ret
+  ret = f-inv ◃h g-ret ▸h f ∙h f-ret
 
 comp-qequiv
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}

--- a/src/Foundations/QuasiEquivalences.lagda.tree
+++ b/src/Foundations/QuasiEquivalences.lagda.tree
@@ -82,10 +82,10 @@ comp-qinv
 comp-qinv {f = f} {g} (f-inv , f-ret , f-sec) (g-inv , g-ret , g-sec)
   = (f-inv ∘ g-inv , ret , sec) where
   sec : section-witness (g ∘ f) (f-inv ∘ g-inv)
-  sec = g ◃h f-sec ▸h g-inv ∙h g-sec
+  sec = g ◃h f-sec ▹h g-inv ∙h g-sec
 
   ret : retraction-witness (g ∘ f) (f-inv ∘ g-inv)
-  ret = f-inv ◃h g-ret ▸h f ∙h f-ret
+  ret = f-inv ◃h g-ret ▹h f ∙h f-ret
 
 comp-qequiv
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}

--- a/src/Foundations/QuasiEquivalences.lagda.tree
+++ b/src/Foundations/QuasiEquivalences.lagda.tree
@@ -82,10 +82,10 @@ comp-qinv
 comp-qinv {f = f} {g} (f-inv , f-ret , f-sec) (g-inv , g-ret , g-sec)
   = (f-inv ∘ g-inv , ret , sec) where
   sec : section-witness (g ∘ f) (f-inv ∘ g-inv)
-  sec = g ◂ f-sec ▸ g-inv ∙h g-sec
+  sec = g ◂h f-sec ▸h g-inv ∙h g-sec
 
   ret : retraction-witness (g ∘ f) (f-inv ∘ g-inv)
-  ret = f-inv ◂ g-ret ▸ f ∙h f-ret
+  ret = f-inv ◂h g-ret ▸h f ∙h f-ret
 
 comp-qequiv
   : ∀ {𝓤 𝓥 𝓦} {A : Type 𝓤} {B : Type 𝓥} {C : Type 𝓦}

--- a/src/Foundations/Retracts.lagda.tree
+++ b/src/Foundations/Retracts.lagda.tree
@@ -142,7 +142,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} where
       (H : R .snd .fst ~ S .snd .fst)
     → Type 𝓤
   coherence-retract-htpy R S I H
-    = R .snd .snd ~ ((H ◾h I) ∙h S .snd .snd)
+    = R .snd .snd ~ ((H ◽h I) ∙h S .snd .snd)
 
   retract-htpy
     : retract A B → retract A B → Type (𝓤 ⊔ 𝓥)

--- a/src/Foundations/Retracts.lagda.tree
+++ b/src/Foundations/Retracts.lagda.tree
@@ -142,7 +142,7 @@ module _ {𝓤 𝓥} {A : Type 𝓤} {B : Type 𝓥} where
       (H : R .snd .fst ~ S .snd .fst)
     → Type 𝓤
   coherence-retract-htpy R S I H
-    = R .snd .snd ~ ((H ◾ I) ∙h S .snd .snd)
+    = R .snd .snd ~ ((H ◾h I) ∙h S .snd .snd)
 
   retract-htpy
     : retract A B → retract A B → Type (𝓤 ⊔ 𝓥)

--- a/src/Foundations/SequentialColimits.lagda.tree
+++ b/src/Foundations/SequentialColimits.lagda.tree
@@ -37,7 +37,7 @@ seq-cocone-map
       {C : Type 𝓥} (CC : Seq-cocone S C)
       {Q : Type 𝓦}
     → (C → Q) → Seq-cocone S Q
-seq-cocone-map CC f = mk-seq-cocone (f ∘ ι) (f ◂ comm) where
+seq-cocone-map CC f = mk-seq-cocone (f ∘ ι) (f ◂h comm) where
   open Seq-cocone CC
 }
 

--- a/src/Foundations/SequentialColimits.lagda.tree
+++ b/src/Foundations/SequentialColimits.lagda.tree
@@ -37,7 +37,7 @@ seq-cocone-map
       {C : Type 𝓥} (CC : Seq-cocone S C)
       {Q : Type 𝓦}
     → (C → Q) → Seq-cocone S Q
-seq-cocone-map CC f = mk-seq-cocone (f ∘ ι) (f ◂h comm) where
+seq-cocone-map CC f = mk-seq-cocone (f ∘ ι) (f ◃h comm) where
   open Seq-cocone CC
 }
 

--- a/src/Foundations/Spans.lagda.tree
+++ b/src/Foundations/Spans.lagda.tree
@@ -80,8 +80,8 @@ Cocone-path→
     → (c c' : Cocone S X)
     → (p : c .Cocone.p ＝ c' .Cocone.p)
     → (q : c .Cocone.q ＝ c' .Cocone.q)
-    → (c .Cocone.filler ∙h happly q ▸h S .Span.right
-         ~ happly p ▸h S .Span.left ∙h c' .Cocone.filler)
+    → (c .Cocone.filler ∙h happly q ▹h S .Span.right
+         ~ happly p ▹h S .Span.left ∙h c' .Cocone.filler)
     → c ＝ c'
 Cocone-path→ fe
   (mk-cocone p q filler) (mk-cocone p q filler') refl refl h

--- a/src/Foundations/Spans.lagda.tree
+++ b/src/Foundations/Spans.lagda.tree
@@ -80,8 +80,8 @@ Cocone-path→
     → (c c' : Cocone S X)
     → (p : c .Cocone.p ＝ c' .Cocone.p)
     → (q : c .Cocone.q ＝ c' .Cocone.q)
-    → (c .Cocone.filler ∙h happly q ▸ S .Span.right
-         ~ happly p ▸ S .Span.left ∙h c' .Cocone.filler)
+    → (c .Cocone.filler ∙h happly q ▸h S .Span.right
+         ~ happly p ▸h S .Span.left ∙h c' .Cocone.filler)
     → c ＝ c'
 Cocone-path→ fe
   (mk-cocone p q filler) (mk-cocone p q filler') refl refl h

--- a/src/Foundations/SubtypeEquiv.lagda.tree
+++ b/src/Foundations/SubtypeEquiv.lagda.tree
@@ -62,6 +62,6 @@ module FromFibreSubtype {𝓤 𝓥 𝓦} {A : Type 𝓤} (S : Subtype A 𝓥)
 
   pres-carr'
     : f ∘ bwd ~ fst
-  pres-carr' = pres-carr ▸h bwd ∙h fst ◂h ε
+  pres-carr' = pres-carr ▸h bwd ∙h fst ◃h ε
 }
 }

--- a/src/Foundations/SubtypeEquiv.lagda.tree
+++ b/src/Foundations/SubtypeEquiv.lagda.tree
@@ -62,6 +62,6 @@ module FromFibreSubtype {𝓤 𝓥 𝓦} {A : Type 𝓤} (S : Subtype A 𝓥)
 
   pres-carr'
     : f ∘ bwd ~ fst
-  pres-carr' = pres-carr ▸ bwd ∙h fst ◂ ε
+  pres-carr' = pres-carr ▸h bwd ∙h fst ◂h ε
 }
 }

--- a/src/Foundations/SubtypeEquiv.lagda.tree
+++ b/src/Foundations/SubtypeEquiv.lagda.tree
@@ -62,6 +62,6 @@ module FromFibreSubtype {𝓤 𝓥 𝓦} {A : Type 𝓤} (S : Subtype A 𝓥)
 
   pres-carr'
     : f ∘ bwd ~ fst
-  pres-carr' = pres-carr ▸h bwd ∙h fst ◃h ε
+  pres-carr' = pres-carr ▹h bwd ∙h fst ◃h ε
 }
 }

--- a/src/Foundations/Towers.lagda.tree
+++ b/src/Foundations/Towers.lagda.tree
@@ -87,7 +87,7 @@ comp-tower-map
 comp-tower-map F G .Tower-map.map
   = Tower-map.map F ∘ Tower-map.map G
 comp-tower-map F G .Tower-map.comm
-  = Tower-map.comm F ▸h Tower-map.map G
+  = Tower-map.comm F ▹h Tower-map.map G
   ∙h Tower-map.map F ◃h Tower-map.comm G
 
 id-tower-map
@@ -114,7 +114,7 @@ tower-map~
       (F G : Tower-map S S')
     → Type (𝓤 ⊔ 𝓥)
 tower-map~ F G = Σ[ α ∶ (∀ {n} → map F {n} ~ map G)]
-                  (∀ {n} → comm F ∙h α ▸h A.decr G
+                  (∀ {n} → comm F ∙h α ▹h A.decr G
                        ~ (B.decr F ◃h α) ∙h comm G {n})
   where open Tower-map
 }
@@ -146,8 +146,8 @@ tower-map-inv←equiv {A = A} {B} {F} Feq = imap where
   module F {n} = is-equiv (Feq n)
   imap : Tower-map B A
   imap .map = F.bwd
-  imap .comm = (F.η h⁻¹) ▸h Tower.decr A ▸h F.bwd
-             ∙h F.bwd ◃h (  (comm F h⁻¹) ▸h F.bwd
+  imap .comm = (F.η h⁻¹) ▹h Tower.decr A ▹h F.bwd
+             ∙h F.bwd ◃h (  (comm F h⁻¹) ▹h F.bwd
                         ∙h Tower.decr B ◃h F.ε)
 }
 }

--- a/src/Foundations/Towers.lagda.tree
+++ b/src/Foundations/Towers.lagda.tree
@@ -88,7 +88,7 @@ comp-tower-map F G .Tower-map.map
   = Tower-map.map F ∘ Tower-map.map G
 comp-tower-map F G .Tower-map.comm
   = Tower-map.comm F ▸h Tower-map.map G
-  ∙h Tower-map.map F ◂h Tower-map.comm G
+  ∙h Tower-map.map F ◃h Tower-map.comm G
 
 id-tower-map
   : ∀ {𝓤} {A : Tower 𝓤}
@@ -115,7 +115,7 @@ tower-map~
     → Type (𝓤 ⊔ 𝓥)
 tower-map~ F G = Σ[ α ∶ (∀ {n} → map F {n} ~ map G)]
                   (∀ {n} → comm F ∙h α ▸h A.decr G
-                       ~ (B.decr F ◂h α) ∙h comm G {n})
+                       ~ (B.decr F ◃h α) ∙h comm G {n})
   where open Tower-map
 }
 }
@@ -147,8 +147,8 @@ tower-map-inv←equiv {A = A} {B} {F} Feq = imap where
   imap : Tower-map B A
   imap .map = F.bwd
   imap .comm = (F.η h⁻¹) ▸h Tower.decr A ▸h F.bwd
-             ∙h F.bwd ◂h (  (comm F h⁻¹) ▸h F.bwd
-                        ∙h Tower.decr B ◂h F.ε)
+             ∙h F.bwd ◃h (  (comm F h⁻¹) ▸h F.bwd
+                        ∙h Tower.decr B ◃h F.ε)
 }
 }
 

--- a/src/Foundations/Towers.lagda.tree
+++ b/src/Foundations/Towers.lagda.tree
@@ -87,8 +87,8 @@ comp-tower-map
 comp-tower-map F G .Tower-map.map
   = Tower-map.map F ∘ Tower-map.map G
 comp-tower-map F G .Tower-map.comm
-  = Tower-map.comm F ▸ Tower-map.map G
-  ∙h Tower-map.map F ◂ Tower-map.comm G
+  = Tower-map.comm F ▸h Tower-map.map G
+  ∙h Tower-map.map F ◂h Tower-map.comm G
 
 id-tower-map
   : ∀ {𝓤} {A : Tower 𝓤}
@@ -114,8 +114,8 @@ tower-map~
       (F G : Tower-map S S')
     → Type (𝓤 ⊔ 𝓥)
 tower-map~ F G = Σ[ α ∶ (∀ {n} → map F {n} ~ map G)]
-                  (∀ {n} → comm F ∙h α ▸ A.decr G
-                       ~ (B.decr F ◂ α) ∙h comm G {n})
+                  (∀ {n} → comm F ∙h α ▸h A.decr G
+                       ~ (B.decr F ◂h α) ∙h comm G {n})
   where open Tower-map
 }
 }
@@ -146,9 +146,9 @@ tower-map-inv←equiv {A = A} {B} {F} Feq = imap where
   module F {n} = is-equiv (Feq n)
   imap : Tower-map B A
   imap .map = F.bwd
-  imap .comm = (F.η h⁻¹) ▸ Tower.decr A ▸ F.bwd
-             ∙h F.bwd ◂ (  (comm F h⁻¹) ▸ F.bwd
-                        ∙h Tower.decr B ◂ F.ε)
+  imap .comm = (F.η h⁻¹) ▸h Tower.decr A ▸h F.bwd
+             ∙h F.bwd ◂h (  (comm F h⁻¹) ▸h F.bwd
+                        ∙h Tower.decr B ◂h F.ε)
 }
 }
 

--- a/src/Foundations/WithFunExt.lagda.tree
+++ b/src/Foundations/WithFunExt.lagda.tree
@@ -90,8 +90,8 @@ Cocone-path→
     → (c c' : Cocone S X)
     → (p : c .Cocone.p ＝ c' .Cocone.p)
     → (q : c .Cocone.q ＝ c' .Cocone.q)
-    → (c .Cocone.filler ∙h happly q ▸h S .Span.right
-         ~ happly p ▸h S .Span.left ∙h c' .Cocone.filler)
+    → (c .Cocone.filler ∙h happly q ▹h S .Span.right
+         ~ happly p ▹h S .Span.left ∙h c' .Cocone.filler)
     → c ＝ c'
 Cocone-path→ = Foundations.Spans.Cocone-path→ global-funext
 }

--- a/src/Foundations/WithFunExt.lagda.tree
+++ b/src/Foundations/WithFunExt.lagda.tree
@@ -90,8 +90,8 @@ Cocone-path→
     → (c c' : Cocone S X)
     → (p : c .Cocone.p ＝ c' .Cocone.p)
     → (q : c .Cocone.q ＝ c' .Cocone.q)
-    → (c .Cocone.filler ∙h happly q ▸ S .Span.right
-         ~ happly p ▸ S .Span.left ∙h c' .Cocone.filler)
+    → (c .Cocone.filler ∙h happly q ▸h S .Span.right
+         ~ happly p ▸h S .Span.left ∙h c' .Cocone.filler)
     → c ＝ c'
 Cocone-path→ = Foundations.Spans.Cocone-path→ global-funext
 }

--- a/src/Modalities/GlobalReflectiveSubuniverses.lagda.tree
+++ b/src/Modalities/GlobalReflectiveSubuniverses.lagda.tree
@@ -227,7 +227,7 @@ module gReflectiveClosure {α} (RS : gRSubU α) where
   ∈S←retract {X = X} {Y = Y} (s , r , rs) Y-loc
     = in-SubU←η-retraction (reflector X) (r ∘ ○-rec Y-loc s , ret) where
       ret : (r ∘ ○-rec Y-loc s) ∘ η {A = X} ~ id
-      ret = r ◂h ○-rec-β Y-loc s ∙h rs
+      ret = r ◃h ○-rec-β Y-loc s ∙h rs
 
   Π∈S
     : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : A → Type 𝓥}
@@ -822,7 +822,7 @@ module gRSubUInduction {α}
       f' = ○-rec (SΣ ○∈S ps) f''
 
       secη : fst ∘ f' ∘ η ~ η
-      secη = fst ◂h ○-rec-β _ _
+      secη = fst ◃h ○-rec-β _ _
 
     ind-β
       : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : ○ A → Type 𝓥}

--- a/src/Modalities/GlobalReflectiveSubuniverses.lagda.tree
+++ b/src/Modalities/GlobalReflectiveSubuniverses.lagda.tree
@@ -227,7 +227,7 @@ module gReflectiveClosure {α} (RS : gRSubU α) where
   ∈S←retract {X = X} {Y = Y} (s , r , rs) Y-loc
     = in-SubU←η-retraction (reflector X) (r ∘ ○-rec Y-loc s , ret) where
       ret : (r ∘ ○-rec Y-loc s) ∘ η {A = X} ~ id
-      ret = r ◂ ○-rec-β Y-loc s ∙h rs
+      ret = r ◂h ○-rec-β Y-loc s ∙h rs
 
   Π∈S
     : ∀ {𝓤 𝓥} {A : Type 𝓤} {B : A → Type 𝓥}
@@ -822,7 +822,7 @@ module gRSubUInduction {α}
       f' = ○-rec (SΣ ○∈S ps) f''
 
       secη : fst ∘ f' ∘ η ~ η
-      secη = fst ◂ ○-rec-β _ _
+      secη = fst ◂h ○-rec-β _ _
 
     ind-β
       : ∀ {𝓤 𝓥} {A : Type 𝓤} {P : ○ A → Type 𝓥}

--- a/src/Modalities/Instances/Localisation.lagda.tree
+++ b/src/Modalities/Instances/Localisation.lagda.tree
@@ -333,7 +333,7 @@ h(x)}, which we do again by induction on #{x} with the motive #{x
 
      \p{For the map in question, we take:
        ##{(K : gf' \sim hf') \mapsto
-         (- ▸h f_f)^{-1}(g(\rm{is-ext}_{f'}) \cdot K \cdot h(\rm{is-ext}_{f'})^{-1})}
+         (- ▹h f_f)^{-1}(g(\rm{is-ext}_{f'}) \cdot K \cdot h(\rm{is-ext}_{f'})^{-1})}
       }
 
       \p{Unfolding #{f''(K)f_i =_{x \mapsto g(x) = h(x)}^{\rm{is-ext}_{f'}} K},

--- a/src/Modalities/Instances/Localisation.lagda.tree
+++ b/src/Modalities/Instances/Localisation.lagda.tree
@@ -383,9 +383,9 @@ h(x)}, which we do again by induction on #{x} with the motive #{x
      (q : g ∘ g' ~ h ∘ g') →
      precomp Y (f i) (g ∘ FreeInj.ext g') ~
      precomp Y (f i) (h ∘ FreeInj.ext g')
-  lem g h i g' K =      g ◂h (FreeInj.is-ext g')
+  lem g h i g' K =      g ◃h (FreeInj.is-ext g')
                      ∙h K
-                     ∙h ((h ◂h FreeInj.is-ext g') h⁻¹)
+                     ∙h ((h ◃h FreeInj.is-ext g') h⁻¹)
 
   opaque
     secAp
@@ -537,7 +537,7 @@ module _
 
     qiso : quasi-inv (precomp A f)
     qiso .fst = precomp A s
-    qiso .snd .fst α = funext→ (α ◂h sec)
+    qiso .snd .fst α = funext→ (α ◃h sec)
     qiso .snd .snd h = funext→ λ x →
       h (s (f x))
         ＝⟨ sym (ap h (H0 x)) ⟩

--- a/src/Modalities/Instances/Localisation.lagda.tree
+++ b/src/Modalities/Instances/Localisation.lagda.tree
@@ -333,7 +333,7 @@ h(x)}, which we do again by induction on #{x} with the motive #{x
 
      \p{For the map in question, we take:
        ##{(K : gf' \sim hf') \mapsto
-         (- ▸ f_f)^{-1}(g(\rm{is-ext}_{f'}) \cdot K \cdot h(\rm{is-ext}_{f'})^{-1})}
+         (- ▸h f_f)^{-1}(g(\rm{is-ext}_{f'}) \cdot K \cdot h(\rm{is-ext}_{f'})^{-1})}
       }
 
       \p{Unfolding #{f''(K)f_i =_{x \mapsto g(x) = h(x)}^{\rm{is-ext}_{f'}} K},
@@ -383,9 +383,9 @@ h(x)}, which we do again by induction on #{x} with the motive #{x
      (q : g ∘ g' ~ h ∘ g') →
      precomp Y (f i) (g ∘ FreeInj.ext g') ~
      precomp Y (f i) (h ∘ FreeInj.ext g')
-  lem g h i g' K =      g ◂ (FreeInj.is-ext g')
+  lem g h i g' K =      g ◂h (FreeInj.is-ext g')
                      ∙h K
-                     ∙h ((h ◂ FreeInj.is-ext g') h⁻¹)
+                     ∙h ((h ◂h FreeInj.is-ext g') h⁻¹)
 
   opaque
     secAp
@@ -537,7 +537,7 @@ module _
 
     qiso : quasi-inv (precomp A f)
     qiso .fst = precomp A s
-    qiso .snd .fst α = funext→ (α ◂ sec)
+    qiso .snd .fst α = funext→ (α ◂h sec)
     qiso .snd .snd h = funext→ λ x →
       h (s (f x))
         ＝⟨ sym (ap h (H0 x)) ⟩

--- a/src/Modalities/Subuniverses.lagda.tree
+++ b/src/Modalities/Subuniverses.lagda.tree
@@ -112,7 +112,7 @@ subuniverses we have a theorem: a type is modal iff #{\eta} is an equivalence.}
   qinv : quasi-inv η
   qinv .fst      = ○-elim as id
   qinv .snd .fst = ○-elim-β as id
-  qinv .snd .snd = ∈S▸η.bwd ○∈S (η ◂h ○-elim-β as id)
+  qinv .snd .snd = ∈S▸η.bwd ○∈S (η ◃h ○-elim-β as id)
 
 in-SubU←η-is-equiv
   : ∀ {𝓤 𝓥} {S : SubU 𝓤 𝓥}
@@ -149,7 +149,7 @@ in-SubU←η-is-equiv {S = S} RA eq
   = is-equiv←qinv
       ( f
       , ret
-      , ∈S▸η.bwd ○∈S (η ◂h ret)) where open Reflector RA
+      , ∈S▸η.bwd ○∈S (η ◃h ret)) where open Reflector RA
 
 in-SubU←η-retraction
   : ∀ {𝓤 𝓥} {S : SubU 𝓤 𝓥}
@@ -300,7 +300,7 @@ module ModalInduction {𝓤 𝓥} {S : SubU 𝓤 𝓥}
     f' = ○-elim (SΣ ○∈S ps) f''
 
     secη : fst ∘ f' ∘ η ~ η
-    secη = fst ◂h ○-elim-β _ _
+    secη = fst ◃h ○-elim-β _ _
 
   ind-β
     : ∀ {A : Type 𝓤} {P : ○ A → Type 𝓤} (P∈S : ∀ a → P a ∈ S)

--- a/src/Modalities/Subuniverses.lagda.tree
+++ b/src/Modalities/Subuniverses.lagda.tree
@@ -112,7 +112,7 @@ subuniverses we have a theorem: a type is modal iff #{\eta} is an equivalence.}
   qinv : quasi-inv η
   qinv .fst      = ○-elim as id
   qinv .snd .fst = ○-elim-β as id
-  qinv .snd .snd = ∈S▸η.bwd ○∈S (η ◂ ○-elim-β as id)
+  qinv .snd .snd = ∈S▸η.bwd ○∈S (η ◂h ○-elim-β as id)
 
 in-SubU←η-is-equiv
   : ∀ {𝓤 𝓥} {S : SubU 𝓤 𝓥}
@@ -149,7 +149,7 @@ in-SubU←η-is-equiv {S = S} RA eq
   = is-equiv←qinv
       ( f
       , ret
-      , ∈S▸η.bwd ○∈S (η ◂ ret)) where open Reflector RA
+      , ∈S▸η.bwd ○∈S (η ◂h ret)) where open Reflector RA
 
 in-SubU←η-retraction
   : ∀ {𝓤 𝓥} {S : SubU 𝓤 𝓥}
@@ -300,7 +300,7 @@ module ModalInduction {𝓤 𝓥} {S : SubU 𝓤 𝓥}
     f' = ○-elim (SΣ ○∈S ps) f''
 
     secη : fst ∘ f' ∘ η ~ η
-    secη = fst ◂ ○-elim-β _ _
+    secη = fst ◂h ○-elim-β _ _
 
   ind-β
     : ∀ {A : Type 𝓤} {P : ○ A → Type 𝓤} (P∈S : ∀ a → P a ∈ S)

--- a/src/Synthetic/Categories/Groupoids.lagda.tree
+++ b/src/Synthetic/Categories/Groupoids.lagda.tree
@@ -335,7 +335,7 @@ is-left-local = is-local (λ (_ _ : 𝟙) → i0)
 
 is-Δ¹-discrete←is-left : ∀ {𝓤} {A : Type 𝓤} → is-left-local A → is-Δ¹-discrete A
 is-Δ¹-discrete←is-left {_} {A} il x
-  = is-equiv-∘~ (il x ◂e⁻¹ (ε ▸h point)) (is-equiv⁻¹ (il x)) point-is-equiv where
+  = is-equiv-∘~ (il x ◂e⁻¹ (ε ▹h point)) (is-equiv⁻¹ (il x)) point-is-equiv where
   open is-equiv (il x)
 
 is-left←is-Δ¹-discrete : ∀ {𝓤} {A : Type 𝓤} → is-Δ¹-discrete A → is-left-local A

--- a/src/Synthetic/Categories/Groupoids.lagda.tree
+++ b/src/Synthetic/Categories/Groupoids.lagda.tree
@@ -334,12 +334,12 @@ is-left-local = is-local (λ (_ _ : 𝟙) → i0)
 
 is-Δ¹-discrete←is-left : ∀ {𝓤} {A : Type 𝓤} → is-left-local A → is-Δ¹-discrete A
 is-Δ¹-discrete←is-left {_} {A} il x
-  = is-equiv-∘~ (il x ◂e⁻¹ (ε ▸ point)) (is-equiv⁻¹ (il x)) point-is-equiv where
+  = is-equiv-∘~ (il x ◂e⁻¹ (ε ▸h point)) (is-equiv⁻¹ (il x)) point-is-equiv where
   open is-equiv (il x)
 
 is-left←is-Δ¹-discrete : ∀ {𝓤} {A : Type 𝓤} → is-Δ¹-discrete A → is-left-local A
 is-left←is-Δ¹-discrete {_} {A} gp x
-  = is-equiv-∘~ ((point ◂ η) ▸e⁻¹ (gp x)) point-is-equiv (is-equiv⁻¹ (gp x)) where
+  = is-equiv-∘~ ((point ◂h η) ▸e⁻¹ (gp x)) point-is-equiv (is-equiv⁻¹ (gp x)) where
   open is-equiv (gp x)
 
 is-left←is-groupoid : ∀ {𝓤} {A : Type 𝓤} → is-groupoid A → is-left-local A

--- a/src/Synthetic/Categories/Groupoids.lagda.tree
+++ b/src/Synthetic/Categories/Groupoids.lagda.tree
@@ -340,7 +340,7 @@ is-Δ¹-discrete←is-left {_} {A} il x
 
 is-left←is-Δ¹-discrete : ∀ {𝓤} {A : Type 𝓤} → is-Δ¹-discrete A → is-left-local A
 is-left←is-Δ¹-discrete {_} {A} gp x
-  = is-equiv-∘~ ((point ◂h η) ▸e⁻¹ (gp x)) point-is-equiv (is-equiv⁻¹ (gp x)) where
+  = is-equiv-∘~ ((point ◃h η) ▸e⁻¹ (gp x)) point-is-equiv (is-equiv⁻¹ (gp x)) where
   open is-equiv (gp x)
 
 is-left←is-groupoid : ∀ {𝓤} {A : Type 𝓤} → is-groupoid A → is-left-local A

--- a/src/Synthetic/Categories/Precategories.lagda.tree
+++ b/src/Synthetic/Categories/Precategories.lagda.tree
@@ -461,7 +461,7 @@ ext-mk-horn-compute-diagonal
   : ∀ {𝓤} {A : Type 𝓤} {x y z} (f : Hom A y z) (g : Hom A x y)
     → Homᵈ.hom ∘ is-equiv.bwd (ext-mk-horn-is-equiv f g) ~ precomp A ι₂ ∘ fst
 ext-mk-horn-compute-diagonal f g
-  = (Homᵈ.hom ◂h is-equiv.η (ext-mk-horn-is-equiv f g))
+  = (Homᵈ.hom ◃h is-equiv.η (ext-mk-horn-is-equiv f g))
     ▸e⁻¹ (ext-mk-horn-is-equiv f g)
 
 opaque

--- a/src/Synthetic/Categories/Precategories.lagda.tree
+++ b/src/Synthetic/Categories/Precategories.lagda.tree
@@ -461,7 +461,7 @@ ext-mk-horn-compute-diagonal
   : ∀ {𝓤} {A : Type 𝓤} {x y z} (f : Hom A y z) (g : Hom A x y)
     → Homᵈ.hom ∘ is-equiv.bwd (ext-mk-horn-is-equiv f g) ~ precomp A ι₂ ∘ fst
 ext-mk-horn-compute-diagonal f g
-  = (Homᵈ.hom ◂ is-equiv.η (ext-mk-horn-is-equiv f g))
+  = (Homᵈ.hom ◂h is-equiv.η (ext-mk-horn-is-equiv f g))
     ▸e⁻¹ (ext-mk-horn-is-equiv f g)
 
 opaque

--- a/src/Synthetic/Categories/PushoutJoins.lagda.tree
+++ b/src/Synthetic/Categories/PushoutJoins.lagda.tree
@@ -131,7 +131,7 @@ extend-slice-map
   : ∀ {𝓤 𝓥 𝓦 𝓧} {P : Type 𝓤} {Q : Type 𝓥} {A : Type 𝓦} {B : Type 𝓧}
       (p : P → A) (q : Q → A) (f : A → B)
     → Slice-map p q → Slice-map (f ∘ p) (f ∘ q)
-extend-slice-map p q f = total-map (λ _ → f ◂_)
+extend-slice-map p q f = total-map (λ _ → f ◂h_)
 
 slice-square
   : ∀ {𝓤 𝓥 𝓜 𝓝} {A : Type 𝓤} {B : Type 𝓥} (f : A → B)

--- a/src/Synthetic/Categories/PushoutJoins.lagda.tree
+++ b/src/Synthetic/Categories/PushoutJoins.lagda.tree
@@ -131,7 +131,7 @@ extend-slice-map
   : ∀ {𝓤 𝓥 𝓦 𝓧} {P : Type 𝓤} {Q : Type 𝓥} {A : Type 𝓦} {B : Type 𝓧}
       (p : P → A) (q : Q → A) (f : A → B)
     → Slice-map p q → Slice-map (f ∘ p) (f ∘ q)
-extend-slice-map p q f = total-map (λ _ → f ◂h_)
+extend-slice-map p q f = total-map (λ _ → f ◃h_)
 
 slice-square
   : ∀ {𝓤 𝓥 𝓜 𝓝} {A : Type 𝓤} {B : Type 𝓥} (f : A → B)

--- a/src/Synthetic/Horns.lagda.tree
+++ b/src/Synthetic/Horns.lagda.tree
@@ -430,7 +430,7 @@ retract of arrows of the pushout product #{\point(0) \pushprod \point(1)}.
 
 Δ¹-endo←Λ[2,1]-ret : retraction-arrow-map Δ¹-endo←Λ[2,1]-section
 Δ¹-endo←Λ[2,1]-ret .fst
-  = mk-amap id (Δ²←Δ¹-endo) (Δ²-retract-Δ¹-endo .snd .snd ▸ Λ[2,1]-incl)
+  = mk-amap id (Δ²←Δ¹-endo) (Δ²-retract-Δ¹-endo .snd .snd ▸h Λ[2,1]-incl)
 Δ¹-endo←Λ[2,1]-ret .snd .fst = ~refl
 Δ¹-endo←Λ[2,1]-ret .snd .snd .fst = Δ²-retract-Δ¹-endo .snd .snd
 Δ¹-endo←Λ[2,1]-ret .snd .snd .snd _ = ∙-reflr _

--- a/src/Synthetic/Horns.lagda.tree
+++ b/src/Synthetic/Horns.lagda.tree
@@ -403,7 +403,7 @@ retract of arrows of the pushout product #{\point(0) \pushprod \point(1)}.
 
 Δ¹-endo←Λ[2,1]-ret : retraction-arrow-map Δ¹-endo←Λ[2,1]-section
 Δ¹-endo←Λ[2,1]-ret .fst
-  = mk-amap id (Δ²←Δ¹-endo) (Δ²-retract-of-Δ¹-endo .snd .snd ▸h Λ[2,1]-incl)
+  = mk-amap id (Δ²←Δ¹-endo) (Δ²-retract-of-Δ¹-endo .snd .snd ▹h Λ[2,1]-incl)
 Δ¹-endo←Λ[2,1]-ret .snd .fst = ~refl
 Δ¹-endo←Λ[2,1]-ret .snd .snd .fst = Δ²-retract-of-Δ¹-endo .snd .snd
 Δ¹-endo←Λ[2,1]-ret .snd .snd .snd _ = ∙-reflr _


### PR DESCRIPTION
Disambiguated these operations by appending an `h`-suffix. this is so we can use the non-suffixed versions for whiskering and horizontal concatenation of identifications.