### PR TITLE
change terminology "author" to "prefix" for ID assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ help:
 	@echo "  make python-server [PORT=<port>]        # Alias for make serve"
 	@echo "  make check-duplicate-tree-ids [DIR=<dir>]  # Find duplicate subtree references (default: trees)"
 	@echo "  make list-trees                         # List all of the trees in the forest"
-	@echo "  make assign-tree-ids-no-commit [AUTHOR=<author>] [UPSTREAM=<upstream>] # Assign tree ids to non-canonically-ID'd trees (AUTHOR=... required) (UPSTREAM, default: upstream)"
-	@echo "  make assign-tree-ids           [AUTHOR=<author>] [UPSTREAM=<upstream>] # Run assign-tree-ids-no-commit and then commit the results"
+	@echo "  make assign-tree-ids-no-commit [PREFIX=<prefix>] [UPSTREAM=<upstream>] # Assign tree ids to non-canonically-ID'd trees (PREFIX=... required) (UPSTREAM, default: upstream)"
+	@echo "  make assign-tree-ids           [PREFIX=<prefixr>] [UPSTREAM=<upstream>] # Run assign-tree-ids-no-commit and then commit the results"
 	@echo "  make clean-agda                         # Remove generated agda artefacts"
 	@echo "  make clean-forester                     # Remove generated forester artefacts"
 	@echo "  make clean                              # Remove all generated build artefacts"
@@ -160,19 +160,19 @@ check-sync-main:
 	fi
 
 assign-tree-ids-dry:
-	@if [ -z "$(AUTHOR)" ]; then \
-	   echo "Requires AUTHOR=..."; \
+	@if [ -z "$(PREFIX)" ]; then \
+	   echo "Requires PREFIX=..."; \
 	   exit 1; \
 	else \
 	   echo "Dry running the renamer:"; \
-	   python3 scripts/assign_tree_ids.py -n $(AUTHOR) src/ trees/  ; \
+	   python3 scripts/assign_tree_ids.py -n $(PREFIX) src/ trees/  ; \
 	fi
 
 confirm-assign-tree-ids:
 	@echo -n "Confirm changes? [y/N] " && read answer && [ $${answer:-N} = y ]
 
 assign-tree-ids-no-commit: check-duplicate-tree-ids check-sync-main assign-tree-ids-dry confirm-assign-tree-ids
-	python3 scripts/assign_tree_ids.py $(AUTHOR) src/ trees/
+	python3 scripts/assign_tree_ids.py $(PREFIX) src/ trees/
 
 
 assign-tree-ids: assign-tree-ids-no-commit

--- a/scripts/assign_tree_ids.py
+++ b/scripts/assign_tree_ids.py
@@ -16,14 +16,14 @@ EXT = ".tree"
 # ----------------------------
 
 parser = argparse.ArgumentParser(
-    description="Rename author-prefixed tree files to stt-XXXX using forester JSON."
+    description="Rename prefixed tree files to stt-XXXX using forester JSON."
 )
-parser.add_argument("author", help="Author prefix to replace (e.g. smi)")
+parser.add_argument("prefix", help="Prefix to replace (e.g. smi)")
 parser.add_argument(
     "-c",
     "--canonical",
     default="stt",
-    help="The canonical URL to insert onto, default=stt",
+    help="The canonical prefix to insert onto, default=stt",
 )
 
 parser.add_argument(
@@ -39,7 +39,7 @@ parser.add_argument("--gap", type=int, default=50, help="Number of new tree IDs 
 
 args = parser.parse_args()
 
-AUTHOR = args.author
+PREFIX = args.prefix
 DIRS = [Path(d) for d in args.dirs]
 DRY_RUN = args.dry_run
 GAP = args.gap
@@ -57,19 +57,19 @@ print(f"Starting STT value: {int_to_base36(next_val)}")
 # ----------------------------
 rename_map = {}
 
-auth_re = re.compile(rf"{AUTHOR}-(\w{{4}})$", re.IGNORECASE)
+prefix_re = re.compile(rf"{PREFIX}-(\w{{4}})$", re.IGNORECASE)
 
-author_trees = [
-    auth_re.search(tree).group(1) for tree in all_trees if auth_re.search(tree)
+prefix_trees = [
+    prefix_re.search(tree).group(1) for tree in all_trees if prefix_re.search(tree)
 ]
 
-author_trees.sort(key=lambda x: int(x, 36))
+prefix_trees.sort(key=lambda x: int(x, 36))
 
 print("\nBuilding a remapping: \n")
 
-for tid in author_trees:
+for tid in prefix_trees:
     new_num = int_to_base36(next_val)
-    old_key = f"{AUTHOR}-{tid}"
+    old_key = f"{PREFIX}-{tid}"
     new_key = f"{CANON}-{new_num}"
     rename_map[old_key] = new_key
     print(f"{old_key} → {new_key}")
@@ -82,10 +82,10 @@ tree_files = []
 for d in DIRS:
     tree_files.extend(d.rglob("*.tree"))
 
-auth_re = re.compile(rf"{AUTHOR}-(\w{{4}})\.tree$")
-author_files = [(p, m.group(1)) for p in tree_files if (m := auth_re.search(p.name))]
+prefix_file_re = re.compile(rf"{PREFIX}-(\w{{4}})\.tree$")
+prefix_files = [(p, m.group(1)) for p in tree_files if (m := prefix_file_re.search(p.name))]
 
-author_files.sort(key=lambda x: int(x[1], 36))
+prefix_files.sort(key=lambda x: int(x[1], 36))
 
 
 # ----------------------------
@@ -94,8 +94,8 @@ author_files.sort(key=lambda x: int(x[1], 36))
 
 print("\nUpdating references in files:\n")
 
-# subtree_re = re.compile(rf"(\\subtree\[)({AUTHOR}-\w{{4}})(\])", re.IGNORECASE)
-link_re = re.compile(rf"({AUTHOR}-\w{{4}})", re.IGNORECASE)
+# subtree_re = re.compile(rf"(\\subtree\[)({PREFIX}-\w{{4}})(\])", re.IGNORECASE)
+link_re = re.compile(rf"({PREFIX}-\w{{4}})", re.IGNORECASE)
 
 for tree in tree_files:
     text = tree.read_text(encoding="utf-8")
@@ -112,8 +112,8 @@ for tree in tree_files:
 
 print("\nRenaming files:\n")
 
-for path, num in author_files:
-    new_path = path.with_name(f"{rename_map[f'{AUTHOR}-{num}']}.tree")
+for path, num in prefix_files:
+    new_path = path.with_name(f"{rename_map[f'{PREFIX}-{num}']}.tree")
     print(f"Renaming {path} → {new_path}")
     if not DRY_RUN:
         path.rename(new_path)

--- a/scripts/assign_tree_ids.py
+++ b/scripts/assign_tree_ids.py
@@ -83,7 +83,9 @@ for d in DIRS:
     tree_files.extend(d.rglob("*.tree"))
 
 prefix_file_re = re.compile(rf"{PREFIX}-(\w{{4}})\.tree$")
-prefix_files = [(p, m.group(1)) for p in tree_files if (m := prefix_file_re.search(p.name))]
+prefix_files = [
+    (p, m.group(1)) for p in tree_files if (m := prefix_file_re.search(p.name))
+]
 
 prefix_files.sort(key=lambda x: int(x[1], 36))
 

--- a/trees/stt/stt-00S3.tree
+++ b/trees/stt/stt-00S3.tree
@@ -18,7 +18,7 @@ it is also checked as part of the CI.
 
 \p{Only once you've been notified by a reviewer should you assign canonical IDs
 to your trees. This can be achieved by running \code{make assign-tree-ids
-AUTHOR=abc}. The repository should be in a clean state and synchronised with
+PREFIX=abc}. The repository should be in a clean state and synchronised with
 the upstream main branch. If either of these criteria are not met, this script
 will return an error. Note that it is important that this process only happens
 when the pull request is ready to be merged as notified by a maintainer, as


### PR DESCRIPTION
It should be documented that contributors can use an abbreviation of e.g. their last names, but the underlying mechanism is just a prefix, so I believe this makes the make target more intuitive.

OK'ed by @samtoth in private communication.