### PR TITLE
No need to confirm if no changes — `assign-tree-ids`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,13 @@ assign-tree-ids-no-commit: check-duplicate-tree-ids check-sync-main
 
 
 assign-tree-ids: assign-tree-ids-no-commit
-	@if ! git diff --quiet || ! git diff --cached --quiet || [ -n "$$(git ls-files --others --exclude-standard)" ]; then \
+	# Commit if there are
+	# - unstaged changes to tracked files
+	# - staged changes, or
+	# - untracked files, excluding gitignored files
+	@if ! git diff --quiet || \
+	   ! git diff --cached --quiet || \
+	   [ -n "$$(git ls-files --others --exclude-standard)" ]; then \
 	   git add . && git commit -m "Re-ID trees"; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -149,14 +149,14 @@ list-trees:
 	 ./scripts/list-trees $(DUP_DIR)
 
 check-sync-main:
+	@if [ -n "$$(git status --porcelain)" ]; then \
+	  echo "Repository is currently in a dirty state."; \
+	  exit 1; \
+	fi
 	@git fetch
 	@if !(git rev-list --left-right --count $(UPSTREAM)/main...HEAD | head -c 1 | grep -q "^0$$") then \
-	    echo "You are out of sync with main, please merge upstream/main into your branch "; \
+	    echo "You are out of sync with main, please merge upstream/main into your branch."; \
 	    exit 1; \
-	fi
-	@if [ -n "$(git status --porcelain)" ]; then \
-	  echo "Repository is currently in a dirty state"; \
-	  exit 1; \
 	fi
 
 assign-tree-ids-dry:
@@ -165,19 +165,24 @@ assign-tree-ids-dry:
 	   exit 1; \
 	else \
 	   echo "Dry running the renamer:"; \
-	   python3 scripts/assign_tree_ids.py -n $(PREFIX) src/ trees/  ; \
+	   python3 scripts/assign_tree_ids.py -n $(ASSIGN_TREE_IDS_FLAGS) $(PREFIX) src/ trees/  ; \
 	fi
 
 confirm-assign-tree-ids:
-	@echo -n "Confirm changes? [y/N] " && read answer && [ $${answer:-N} = y ]
+	@$(MAKE) --no-print-directory assign-tree-ids-dry ASSIGN_TREE_IDS_FLAGS=--confirm
 
-assign-tree-ids-no-commit: check-duplicate-tree-ids check-sync-main assign-tree-ids-dry confirm-assign-tree-ids
-	python3 scripts/assign_tree_ids.py $(PREFIX) src/ trees/
+assign-tree-ids-no-commit: check-duplicate-tree-ids check-sync-main
+	@if [ -z "$(PREFIX)" ]; then \
+	   echo "Requires PREFIX=..."; \
+	   exit 1; \
+	fi
+	@python3 scripts/assign_tree_ids.py --confirm $(PREFIX) src/ trees/
 
 
 assign-tree-ids: assign-tree-ids-no-commit
-	git add .
-	git commit -m "Re-ID trees"
+	@if ! git diff --quiet || ! git diff --cached --quiet || [ -n "$$(git ls-files --others --exclude-standard)" ]; then \
+	   git add . && git commit -m "Re-ID trees"; \
+	fi
 
 check-forest-no-typecheck: sync-forest-src
 	@mkdir -p "$(HTML_DIR)"

--- a/scripts/assign_tree_ids.py
+++ b/scripts/assign_tree_ids.py
@@ -72,14 +72,14 @@ if not prefix_trees:
 
 prefix_trees.sort(key=lambda x: int(x, 36))
 
-print("\nBuilding a remapping: \n")
+print("\nBuilding a remapping:")
 
 for tid in prefix_trees:
     new_num = int_to_base36(next_val)
     old_key = f"{PREFIX}-{tid}"
     new_key = f"{CANON}-{new_num}"
     rename_map[old_key] = new_key
-    print(f"{old_key} → {new_key}")
+    print(f" {old_key} → {new_key}")
     next_val += 1
 
 # ----------------------------
@@ -101,7 +101,6 @@ prefix_files.sort(key=lambda x: int(x[1], 36))
 # Update references in files
 # ----------------------------
 
-print("\nUpdating references in files:\n")
 
 # subtree_re = re.compile(rf"(\\subtree\[)({PREFIX}-\w{{4}})(\])", re.IGNORECASE)
 link_re = re.compile(rf"({PREFIX}-\w{{4}})", re.IGNORECASE)
@@ -111,21 +110,31 @@ for tree in tree_files:
     text = tree.read_text(encoding="utf-8")
     updated = link_re.sub(lambda m: rename_map.get(m.group(1)), text)
     if updated != text:
-        print(f"Updating references in {tree}")
         reference_updates.append((tree, updated))
 
+if reference_updates:
+  print("\nUpdating references in files:")
+  for (tree , update) in reference_updates:
+      print(f" {tree}")
+else:
+  print("\nNo references in files to update.")
 
 # ----------------------------
 # Rename files
 # ----------------------------
 
-print("\nRenaming files:\n")
+if prefix_files:
+  print("\nRenaming files:")
 
-file_renames = []
-for path, num in prefix_files:
-    new_path = path.with_name(f"{rename_map[f'{PREFIX}-{num}']}{EXT}")
-    print(f"Renaming {path} → {new_path}")
-    file_renames.append((path, new_path))
+  file_renames = []
+  for path, num in prefix_files:
+      new_path = path.with_name(f"{rename_map[f'{PREFIX}-{num}']}{EXT}")
+      print(f" {path} → {new_path}")
+      file_renames.append((path, new_path))
+else:
+  print("\nNo files to rename.")
+
+print()
 
 if not DRY_RUN:
 

--- a/scripts/assign_tree_ids.py
+++ b/scripts/assign_tree_ids.py
@@ -127,10 +127,10 @@ else:
 # Rename files
 # ----------------------------
 
+file_renames = []
 if prefix_files:
     print("\nRenaming files:")
 
-    file_renames = []
     for path, num in prefix_files:
         new_path = path.with_name(f"{rename_map[f'{PREFIX}-{num}']}{EXT}")
         print(f" {path} → {new_path}")

--- a/scripts/assign_tree_ids.py
+++ b/scripts/assign_tree_ids.py
@@ -27,7 +27,7 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    "dirs", nargs="+", help="Directories to scan recursively for .tree files"
+    "dirs", nargs="+", help=f"Directories to scan recursively for {EXT} files"
 )
 parser.add_argument(
     "-n",
@@ -87,9 +87,9 @@ for tid in prefix_trees:
 # ----------------------------
 tree_files = []
 for d in DIRS:
-    tree_files.extend(d.rglob("*.tree"))
+    tree_files.extend(d.rglob(f"*{EXT}"))
 
-prefix_file_re = re.compile(rf"{PREFIX}-(\w{{4}})\.tree$")
+prefix_file_re = re.compile(rf"{PREFIX}-(\w{{4}})\{EXT}$")
 prefix_files = [
     (p, m.group(1)) for p in tree_files if (m := prefix_file_re.search(p.name))
 ]
@@ -123,7 +123,7 @@ print("\nRenaming files:\n")
 
 file_renames = []
 for path, num in prefix_files:
-    new_path = path.with_name(f"{rename_map[f'{PREFIX}-{num}']}.tree")
+    new_path = path.with_name(f"{rename_map[f'{PREFIX}-{num}']}{EXT}")
     print(f"Renaming {path} → {new_path}")
     file_renames.append((path, new_path))
 

--- a/scripts/assign_tree_ids.py
+++ b/scripts/assign_tree_ids.py
@@ -36,6 +36,9 @@ parser.add_argument(
     help="Show what would change, but do not modify anything",
 )
 parser.add_argument("--gap", type=int, default=50, help="Number of new tree IDs needed")
+parser.add_argument(
+    "--confirm", action="store_true", help="Ask for confirmation after previewing changes"
+)
 
 args = parser.parse_args()
 
@@ -62,6 +65,10 @@ prefix_re = re.compile(rf"{PREFIX}-(\w{{4}})$", re.IGNORECASE)
 prefix_trees = [
     prefix_re.search(tree).group(1) for tree in all_trees if prefix_re.search(tree)
 ]
+
+if not prefix_trees:
+    print(f"There are no trees with the prefix '{PREFIX}'.")
+    sys.exit(0)
 
 prefix_trees.sort(key=lambda x: int(x, 36))
 
@@ -99,13 +106,13 @@ print("\nUpdating references in files:\n")
 # subtree_re = re.compile(rf"(\\subtree\[)({PREFIX}-\w{{4}})(\])", re.IGNORECASE)
 link_re = re.compile(rf"({PREFIX}-\w{{4}})", re.IGNORECASE)
 
+reference_updates = []
 for tree in tree_files:
     text = tree.read_text(encoding="utf-8")
     updated = link_re.sub(lambda m: rename_map.get(m.group(1)), text)
     if updated != text:
         print(f"Updating references in {tree}")
-        if not DRY_RUN:
-            tree.write_text(updated, encoding="utf-8")
+        reference_updates.append((tree, updated))
 
 
 # ----------------------------
@@ -114,8 +121,22 @@ for tree in tree_files:
 
 print("\nRenaming files:\n")
 
+file_renames = []
 for path, num in prefix_files:
     new_path = path.with_name(f"{rename_map[f'{PREFIX}-{num}']}.tree")
     print(f"Renaming {path} → {new_path}")
-    if not DRY_RUN:
+    file_renames.append((path, new_path))
+
+if args.confirm:
+    try:
+        answer = input("Confirm changes? [y/N] ")
+    except EOFError:
+        sys.exit(1)
+    if answer != "y":
+        sys.exit(1)
+
+if not DRY_RUN:
+    for tree, updated in reference_updates:
+        tree.write_text(updated, encoding="utf-8")
+    for path, new_path in file_renames:
         path.rename(new_path)

--- a/scripts/assign_tree_ids.py
+++ b/scripts/assign_tree_ids.py
@@ -87,7 +87,9 @@ for tid in prefix_trees:
 # ----------------------------
 tree_files = []
 for d in DIRS:
-    tree_files.extend(d.rglob(f"*{EXT}"))
+    tree_files.extend(
+        p for p in d.rglob(f"*{EXT}") if "autogen" not in p.absolute().parts
+    )
 
 prefix_file_re = re.compile(rf"{PREFIX}-(\w{{4}})\{EXT}$")
 prefix_files = [

--- a/scripts/assign_tree_ids.py
+++ b/scripts/assign_tree_ids.py
@@ -127,16 +127,17 @@ for path, num in prefix_files:
     print(f"Renaming {path} → {new_path}")
     file_renames.append((path, new_path))
 
-if args.confirm:
-    try:
-        answer = input("Confirm changes? [y/N] ")
-    except EOFError:
-        sys.exit(1)
-    if answer != "y":
-        sys.exit(1)
-
 if not DRY_RUN:
-    for tree, updated in reference_updates:
-        tree.write_text(updated, encoding="utf-8")
-    for path, new_path in file_renames:
-        path.rename(new_path)
+
+  if args.confirm:
+      try:
+          answer = input("Confirm changes? [y/N] ")
+      except EOFError:
+          sys.exit(1)
+      if answer != "y":
+          sys.exit(1)
+
+  for tree, updated in reference_updates:
+      tree.write_text(updated, encoding="utf-8")
+  for path, new_path in file_renames:
+      path.rename(new_path)

--- a/scripts/assign_tree_ids.py
+++ b/scripts/assign_tree_ids.py
@@ -37,7 +37,9 @@ parser.add_argument(
 )
 parser.add_argument("--gap", type=int, default=50, help="Number of new tree IDs needed")
 parser.add_argument(
-    "--confirm", action="store_true", help="Ask for confirmation after previewing changes"
+    "--confirm",
+    action="store_true",
+    help="Ask for confirmation after previewing changes",
 )
 
 args = parser.parse_args()
@@ -115,40 +117,39 @@ for tree in tree_files:
         reference_updates.append((tree, updated))
 
 if reference_updates:
-  print("\nUpdating references in files:")
-  for (tree , update) in reference_updates:
-      print(f" {tree}")
+    print("\nUpdating references in files:")
+    for tree, update in reference_updates:
+        print(f" {tree}")
 else:
-  print("\nNo references in files to update.")
+    print("\nNo references in files to update.")
 
 # ----------------------------
 # Rename files
 # ----------------------------
 
 if prefix_files:
-  print("\nRenaming files:")
+    print("\nRenaming files:")
 
-  file_renames = []
-  for path, num in prefix_files:
-      new_path = path.with_name(f"{rename_map[f'{PREFIX}-{num}']}{EXT}")
-      print(f" {path} → {new_path}")
-      file_renames.append((path, new_path))
+    file_renames = []
+    for path, num in prefix_files:
+        new_path = path.with_name(f"{rename_map[f'{PREFIX}-{num}']}{EXT}")
+        print(f" {path} → {new_path}")
+        file_renames.append((path, new_path))
 else:
-  print("\nNo files to rename.")
+    print("\nNo files to rename.")
 
 print()
 
 if not DRY_RUN:
+    if args.confirm:
+        try:
+            answer = input("Confirm changes? [y/N] ")
+        except EOFError:
+            sys.exit(1)
+        if answer != "y":
+            sys.exit(1)
 
-  if args.confirm:
-      try:
-          answer = input("Confirm changes? [y/N] ")
-      except EOFError:
-          sys.exit(1)
-      if answer != "y":
-          sys.exit(1)
-
-  for tree, updated in reference_updates:
-      tree.write_text(updated, encoding="utf-8")
-  for path, new_path in file_renames:
-      path.rename(new_path)
+    for tree, updated in reference_updates:
+        tree.write_text(updated, encoding="utf-8")
+    for path, new_path in file_renames:
+        path.rename(new_path)

--- a/scripts/list-trees
+++ b/scripts/list-trees
@@ -2,7 +2,7 @@
 
 {
   rg -n --no-heading --no-ignore-vcs -o --glob '*.tree' --glob '!**/autogen/*' 'subtree\[[0-9A-Za-z\-]*\]' "$1" src/
-  find "$1" -name '*.tree'
+  find "$1" -type d -name autogen -prune -o -name '*.tree' -print
 } | awk '
 /subtree\[[a-zA-Z]{3}-/ {
 	split($0, a, ":")


### PR DESCRIPTION
Makes it so there is no ask for confirmation if assigning tree ids does nothing. Also, it will no longer run if the working branch is dirty. Also, ignores `autogen` files now. Also, some formatting improvements to the output. Also, uses the predefined `EXT` variable now.